### PR TITLE
[19.0][FEAT] odoo_herd: allow selecting probes

### DIFF
--- a/odoo_herd/models/k8s_odoo_instance.py
+++ b/odoo_herd/models/k8s_odoo_instance.py
@@ -117,6 +117,15 @@ class K8sOdooInstance(models.Model):
     current_rolling_update_max_surge = fields.Char(
         string="Current Max Surge", compute="_compute_current_values"
     )
+    current_probe_startup_path = fields.Char(
+        string="Current Startup Probe Path", compute="_compute_current_values"
+    )
+    current_probe_liveness_path = fields.Char(
+        string="Current Liveness Probe Path", compute="_compute_current_values"
+    )
+    current_probe_readiness_path = fields.Char(
+        string="Current Readiness Probe Path", compute="_compute_current_values"
+    )
 
     # Editable spec fields (will sync back to cluster)
     # Note: image, replicas, cpu_*, memory_*, filestore_size, etc. inherited from mixin
@@ -168,6 +177,9 @@ class K8sOdooInstance(models.Model):
             instance.current_deployment_strategy = "Recreate"
             instance.current_rolling_update_max_unavailable = ""
             instance.current_rolling_update_max_surge = ""
+            instance.current_probe_startup_path = "/web/health"
+            instance.current_probe_liveness_path = "/web/health"
+            instance.current_probe_readiness_path = "/web/health"
 
             if not instance.cluster_id or not instance.cluster_id.active:
                 continue
@@ -236,6 +248,18 @@ class K8sOdooInstance(models.Model):
                 )
                 instance.current_rolling_update_max_surge = rolling_update.get(
                     "maxSurge", ""
+                )
+
+                # Extract probe paths
+                probes = spec.get("probes", {})
+                instance.current_probe_startup_path = probes.get(
+                    "startupPath", "/web/health"
+                )
+                instance.current_probe_liveness_path = probes.get(
+                    "livenessPath", "/web/health"
+                )
+                instance.current_probe_readiness_path = probes.get(
+                    "readinessPath", "/web/health"
                 )
 
             except Exception as e:
@@ -505,6 +529,9 @@ class K8sOdooInstance(models.Model):
                 "deployment_strategy_type": self.current_deployment_strategy,
                 "rolling_update_max_unavailable": self.current_rolling_update_max_unavailable,
                 "rolling_update_max_surge": self.current_rolling_update_max_surge,
+                "probe_startup_path": self.current_probe_startup_path,
+                "probe_liveness_path": self.current_probe_liveness_path,
+                "probe_readiness_path": self.current_probe_readiness_path,
             }
         )
         return {
@@ -679,6 +706,18 @@ class K8sOdooInstance(models.Model):
             # Explicitly set rollingUpdate to None to clear any existing values
             strategy["rollingUpdate"] = None
         patch["spec"]["strategy"] = strategy
+
+        # Health Probes - always include if any probe field is set
+        default_path = "/web/health"
+        probes = {}
+        if self.probe_startup_path:
+            probes["startupPath"] = self.probe_startup_path
+        if self.probe_liveness_path:
+            probes["livenessPath"] = self.probe_liveness_path
+        if self.probe_readiness_path:
+            probes["readinessPath"] = self.probe_readiness_path
+        if probes:
+            patch["spec"]["probes"] = probes
 
         # Return None if no actual changes
         return patch if patch["spec"] else None

--- a/odoo_herd/models/k8s_odoo_instance_config_mixin.py
+++ b/odoo_herd/models/k8s_odoo_instance_config_mixin.py
@@ -111,3 +111,23 @@ class K8sOdooInstanceConfigMixin(models.AbstractModel):
         string="Max Surge",
         help="Maximum surge pods during rolling update (e.g., '25%', '1')",
     )
+
+    # Health Probe Configuration
+    probe_startup_path = fields.Char(
+        string="Startup Probe Path",
+        default="/web/health",
+        help="HTTP path for startup probe. Used during container initialization.",
+    )
+
+    probe_liveness_path = fields.Char(
+        string="Liveness Probe Path",
+        default="/web/health",
+        help="HTTP path for liveness probe. Checks if the process is alive.",
+    )
+
+    probe_readiness_path = fields.Char(
+        string="Readiness Probe Path",
+        default="/web/health",
+        help="HTTP path for readiness probe. Use /health/ready if health_check_k8s "
+        "module is installed for deep checks (DB + filestore).",
+    )

--- a/odoo_herd/tests/__init__.py
+++ b/odoo_herd/tests/__init__.py
@@ -2,3 +2,4 @@
 from . import test_create_instance_wizard
 from . import test_create_instance_wizard_view
 from . import test_deployment_strategy
+from . import test_probe_configuration

--- a/odoo_herd/tests/test_probe_configuration.py
+++ b/odoo_herd/tests/test_probe_configuration.py
@@ -1,0 +1,172 @@
+"""
+Test probe configuration functionality in odoo_herd.
+
+Use Case: Allow users to configure Kubernetes health probe paths per OdooInstance.
+This enables using the health_check_k8s module's /health/ready endpoint for
+deep health checks (DB + filestore) instead of the default /web/health.
+
+Acceptance Criteria:
+- Probe paths can be configured on k8s.odoo.instance (startup, liveness, readiness)
+- Default paths are /web/health for backwards compatibility
+- Patch data includes probes section when syncing to cluster
+- Create wizard can specify probe paths for new instances
+- Only include probes in spec when at least one differs from default
+"""
+import json
+from typing import Any, cast
+
+from odoo.tests.common import TransactionCase
+
+
+class TestInstanceProbeConfiguration(TransactionCase):
+    """Test probe configuration on k8s.odoo.instance model"""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        env: Any = cls.env
+        cls.cluster = cast(
+            Any,
+            env["k8s.cluster"].create(
+                {
+                    "name": "test-cluster",
+                    "api_endpoint": "https://k8s.example.com",
+                    "kubeconfig": "{}",
+                    "default_namespace": "default",
+                    "webhook_base_url": "http://odoo.example.com",
+                }
+            ),
+        )
+
+        cls.instance = cast(
+            Any,
+            env["k8s.odoo.instance"].create(
+                {
+                    "name": "test-instance",
+                    "cluster_id": cls.cluster.id,
+                    "namespace": "default",
+                    "spec": json.dumps(
+                        {
+                            "image": "odoo:18.0",
+                            "replicas": 1,
+                        }
+                    ),
+                    "status": json.dumps({"phase": "Running"}),
+                }
+            ),
+        )
+
+    def test_instance_build_patch_data_no_probes_when_default(self):
+        """Patch data should not include probes section when all paths are default"""
+        # Set all probe paths to default
+        self.instance.probe_startup_path = "/web/health"
+        self.instance.probe_liveness_path = "/web/health"
+        self.instance.probe_readiness_path = "/web/health"
+
+        patch_data = self.instance._build_patch_data()
+
+        # Probes section should not be included when all are default
+        self.assertNotIn("probes", patch_data.get("spec", {}))
+
+    def test_instance_build_patch_data_custom_readiness(self):
+        """Patch data should include probes section with custom readiness path"""
+        self.instance.probe_startup_path = "/web/health"
+        self.instance.probe_liveness_path = "/web/health"
+        self.instance.probe_readiness_path = "/health/ready"
+
+        patch_data = self.instance._build_patch_data()
+
+        self.assertIn("probes", patch_data["spec"])
+        probes = patch_data["spec"]["probes"]
+        # Only readiness should be included since others are default
+        self.assertEqual(probes.get("readinessPath"), "/health/ready")
+
+    def test_instance_build_patch_data_all_custom_probes(self):
+        """Patch data should include all custom probe paths"""
+        self.instance.probe_startup_path = "/custom/startup"
+        self.instance.probe_liveness_path = "/custom/liveness"
+        self.instance.probe_readiness_path = "/custom/readiness"
+
+        patch_data = self.instance._build_patch_data()
+
+        self.assertIn("probes", patch_data["spec"])
+        probes = patch_data["spec"]["probes"]
+        self.assertEqual(probes["startupPath"], "/custom/startup")
+        self.assertEqual(probes["livenessPath"], "/custom/liveness")
+        self.assertEqual(probes["readinessPath"], "/custom/readiness")
+
+
+class TestCreateInstanceWizardProbeConfiguration(TransactionCase):
+    """Test probe configuration in the create instance wizard"""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        env: Any = cls.env
+        cls.cluster = cast(
+            Any,
+            env["k8s.cluster"].create(
+                {
+                    "name": "test-cluster",
+                    "api_endpoint": "https://k8s.example.com",
+                    "kubeconfig": "{}",
+                    "default_namespace": "default",
+                    "webhook_base_url": "http://odoo.example.com",
+                }
+            ),
+        )
+
+    def _make_wizard(self, **kwargs):
+        vals = {
+            "cluster_id": self.cluster.id,
+            "name": "demo",
+            "namespace": "odoo",
+            "image": "odoo:18.0",
+            "replicas": 1,
+            "admin_password": "admin",
+            "ingress_hosts": "odoo.example.com",
+            "filestore_size": "10Gi",
+            "filestore_storage_class": "standard",
+            "cluster_issuer": "lets-encrypt",
+        }
+        vals.update(kwargs)
+        env: Any = self.env
+        wiz = (
+            env["k8s.create.instance.wizard"]
+            .with_context(default_cluster_id=self.cluster.id)
+            .create(vals)
+        )
+        return cast(Any, wiz)
+
+    def test_wizard_build_instance_spec_no_probes_when_default(self):
+        """Wizard should not include probes section when all paths are default"""
+        wiz = self._make_wizard()
+        hosts = wiz._parse_ingress_hosts()
+        spec = wiz._build_instance_spec(hosts)
+
+        # Probes section should not be included when all are default
+        self.assertNotIn("probes", spec)
+
+    def test_wizard_build_instance_spec_custom_readiness(self):
+        """Wizard should include probes section with custom readiness path"""
+        wiz = self._make_wizard(probe_readiness_path="/health/ready")
+        hosts = wiz._parse_ingress_hosts()
+        spec = wiz._build_instance_spec(hosts)
+
+        self.assertIn("probes", spec)
+        self.assertEqual(spec["probes"].get("readinessPath"), "/health/ready")
+
+    def test_wizard_build_instance_spec_all_custom_probes(self):
+        """Wizard should include all custom probe paths"""
+        wiz = self._make_wizard(
+            probe_startup_path="/custom/startup",
+            probe_liveness_path="/custom/liveness",
+            probe_readiness_path="/custom/readiness",
+        )
+        hosts = wiz._parse_ingress_hosts()
+        spec = wiz._build_instance_spec(hosts)
+
+        self.assertIn("probes", spec)
+        self.assertEqual(spec["probes"]["startupPath"], "/custom/startup")
+        self.assertEqual(spec["probes"]["livenessPath"], "/custom/liveness")
+        self.assertEqual(spec["probes"]["readinessPath"], "/custom/readiness")

--- a/odoo_herd/views/k8s_odoo_instance_views.xml
+++ b/odoo_herd/views/k8s_odoo_instance_views.xml
@@ -324,6 +324,66 @@
                             </group>
                         </page>
                         
+                        <page string="Health Probes" name="health_probes">
+                            <group>
+                                <group string="Probe Paths">
+                                    <label for="probe_startup_path" string="Startup Probe"/>
+                                    <div>
+                                        <field name="probe_startup_path" placeholder="/web/health"/>
+                                        <div class="mt-1">
+                                            <span class="text-muted small">Cluster: </span>
+                                            <field name="current_probe_startup_path" 
+                                                readonly="1" 
+                                                nolabel="1" 
+                                                class="oe_inline text-primary fw-bold small" 
+                                                decoration-warning="current_probe_startup_path != probe_startup_path"
+                                                decoration-info="current_probe_startup_path == probe_startup_path"
+                                                />
+                                        </div>
+                                        <div class="text-muted small mt-1">
+                                            <i class="fa fa-info-circle"/> Used during container initialization.
+                                        </div>
+                                    </div>
+                                    
+                                    <label for="probe_liveness_path" string="Liveness Probe"/>
+                                    <div>
+                                        <field name="probe_liveness_path" placeholder="/web/health"/>
+                                        <div class="mt-1">
+                                            <span class="text-muted small">Cluster: </span>
+                                            <field name="current_probe_liveness_path" 
+                                                readonly="1" 
+                                                nolabel="1" 
+                                                class="oe_inline text-primary fw-bold small" 
+                                                decoration-warning="current_probe_liveness_path != probe_liveness_path"
+                                                decoration-info="current_probe_liveness_path == probe_liveness_path"
+                                                />
+                                        </div>
+                                        <div class="text-muted small mt-1">
+                                            <i class="fa fa-info-circle"/> Checks if the process is alive.
+                                        </div>
+                                    </div>
+                                    
+                                    <label for="probe_readiness_path" string="Readiness Probe"/>
+                                    <div>
+                                        <field name="probe_readiness_path" placeholder="/web/health"/>
+                                        <div class="mt-1">
+                                            <span class="text-muted small">Cluster: </span>
+                                            <field name="current_probe_readiness_path" 
+                                                readonly="1" 
+                                                nolabel="1" 
+                                                class="oe_inline text-primary fw-bold small" 
+                                                decoration-warning="current_probe_readiness_path != probe_readiness_path"
+                                                decoration-info="current_probe_readiness_path == probe_readiness_path"
+                                                />
+                                        </div>
+                                        <div class="text-muted small mt-1">
+                                            <i class="fa fa-info-circle"/> Use <b>/health/ready</b> if health_check_k8s module is installed for deep checks (DB + filestore).
+                                        </div>
+                                    </div>
+                                </group>
+                            </group>
+                        </page>
+                        
                         <page string="Raw Data">
                             <group>
                                 <group string="Specification">

--- a/odoo_herd/wizards/k8s_create_instance_wizard.py
+++ b/odoo_herd/wizards/k8s_create_instance_wizard.py
@@ -282,6 +282,18 @@ class K8sCreateInstanceWizard(models.TransientModel):
                 strategy["rollingUpdate"] = rolling_update
         instance_spec["strategy"] = strategy
 
+        # Health Probes - only include if at least one differs from default
+        default_path = "/web/health"
+        probes = {}
+        if self.probe_startup_path and self.probe_startup_path != default_path:
+            probes["startupPath"] = self.probe_startup_path
+        if self.probe_liveness_path and self.probe_liveness_path != default_path:
+            probes["livenessPath"] = self.probe_liveness_path
+        if self.probe_readiness_path and self.probe_readiness_path != default_path:
+            probes["readinessPath"] = self.probe_readiness_path
+        if probes:
+            instance_spec["probes"] = probes
+
         return instance_spec
 
     def _validate_initialization_mode(self):

--- a/odoo_herd/wizards/k8s_create_instance_wizard_views.xml
+++ b/odoo_herd/wizards/k8s_create_instance_wizard_views.xml
@@ -144,6 +144,19 @@
                                 <field name="config_options" widget="ace" options="{'mode': 'json'}" nolabel="1"/>
                             </group>
                         </page>
+                        
+                        <page string="Health Probes" name="health_probes">
+                            <group>
+                                <group string="Probe Paths">
+                                    <field name="probe_startup_path" placeholder="/web/health"/>
+                                    <field name="probe_liveness_path" placeholder="/web/health"/>
+                                    <field name="probe_readiness_path" placeholder="/web/health"/>
+                                </group>
+                            </group>
+                            <div class="text-muted small">
+                                <i class="fa fa-info-circle"/> Use <b>/health/ready</b> for readiness probe if health_check_k8s module is installed for deep checks (DB + filestore).
+                            </div>
+                        </page>
                     </notebook>
                 </sheet>
                 


### PR DESCRIPTION
Allow the user to select different probes for health, liveness and startup on OdooInstances.
