### PR TITLE
[FIX] odoo_herd: sync instance phase values with odoo-operator

### DIFF
--- a/odoo_herd/controllers/dashboard.py
+++ b/odoo_herd/controllers/dashboard.py
@@ -38,19 +38,10 @@ class K8sDashboardController(http.Controller):
             )
 
             # Count instances by phase
-            phase_counts = {
-                "Running": 0,
-                "Upgrading": 0,
-                "Restoring": 0,
-                "Failed": 0,
-                "Unknown": 0,
-            }
+            phase_counts = {}
             for inst in instances:
-                phase = inst.phase or "Unknown"
-                if phase in phase_counts:
-                    phase_counts[phase] += 1
-                else:
-                    phase_counts["Unknown"] += 1
+                phase = inst.phase or "Unset"
+                phase_counts[phase] = phase_counts.get(phase, 0) + 1
 
             cluster_data.append(
                 {
@@ -82,8 +73,8 @@ class K8sDashboardController(http.Controller):
                 "image": inst.current_image,
                 "ready_replicas": inst.ready_replicas or 0,
                 "replicas": inst.current_replicas or 0,
-                "phase": inst.phase or "Unknown",
-                "deployment_state": inst.deployment_state or "Unknown",
+                "phase": inst.phase or "",
+                "deployment_state": inst.deployment_state or "",
             }
             for inst in all_instances
         ]
@@ -93,7 +84,7 @@ class K8sDashboardController(http.Controller):
 
         # Failed/non-running instances
         problem_instances = Instance.search(
-            [("phase", "not in", ["Running", "Unknown"])]
+            [("phase", "not in", ["Running", False])]
         )
         for inst in problem_instances:
             alerts.append(

--- a/odoo_herd/controllers/instance_webhook.py
+++ b/odoo_herd/controllers/instance_webhook.py
@@ -75,7 +75,7 @@ class K8sInstanceWebhook(http.Controller):
                 content_type="application/json",
             )
 
-        phase = payload.get("phase", "Unknown")
+        phase = payload.get("phase")
         message = payload.get("message", "")
 
         _logger.info(

--- a/odoo_herd/models/k8s_cluster.py
+++ b/odoo_herd/models/k8s_cluster.py
@@ -354,7 +354,7 @@ class K8sCluster(models.Model):
                     "namespace": namespace,
                     "spec": json.dumps(spec, indent=2),
                     "status": json.dumps(status, indent=2),
-                    "phase": status.get("phase", "Unknown"),
+                    "phase": status.get("phase"),
                     "url": status.get("url", ""),
                     "last_updated": fields.Datetime.now(),
                     "ready_replicas": ready_replicas,

--- a/odoo_herd/models/k8s_odoo_instance.py
+++ b/odoo_herd/models/k8s_odoo_instance.py
@@ -58,14 +58,11 @@ class K8sOdooInstance(models.Model):
             ("Degraded", "Degraded"),
             ("Stopped", "Stopped"),
             ("Upgrading", "Upgrading"),
-            ("UpgradeFailed", "Upgrade Failed"),
             ("Restoring", "Restoring"),
-            ("RestoreFailed", "Restore Failed"),
+            ("BackingUp", "Backing Up"),
             ("Error", "Error"),
-            ("Unknown", "Unknown"),
         ],
         string="Phase",
-        default="Unknown",
         readonly=True,
     )
 

--- a/odoo_herd/static/src/js/k8s_dashboard_component.js
+++ b/odoo_herd/static/src/js/k8s_dashboard_component.js
@@ -133,11 +133,18 @@ export class K8sDashboard extends Component {
 
     getPhaseClass(phase) {
         const phaseClasses = {
+            "Provisioning": "text-bg-info",
+            "Uninitialized": "text-bg-secondary",
+            "Initializing": "text-bg-info",
+            "InitFailed": "text-bg-danger",
+            "Starting": "text-bg-info",
             "Running": "text-bg-success",
+            "Degraded": "text-bg-warning",
+            "Stopped": "text-bg-secondary",
             "Upgrading": "text-bg-warning",
             "Restoring": "text-bg-info",
-            "Failed": "text-bg-danger",
-            "Unknown": "text-bg-secondary",
+            "BackingUp": "text-bg-info",
+            "Error": "text-bg-danger",
         };
         return phaseClasses[phase] || "text-bg-secondary";
     }
@@ -171,12 +178,18 @@ export class K8sDashboard extends Component {
 
     getPhaseLabel(phase) {
         const labels = {
+            "Provisioning": _t("Provisioning"),
+            "Uninitialized": _t("Uninitialized"),
+            "Initializing": _t("Initializing"),
+            "InitFailed": _t("Init Failed"),
+            "Starting": _t("Starting"),
             "Running": _t("Running"),
+            "Degraded": _t("Degraded"),
+            "Stopped": _t("Stopped"),
             "Upgrading": _t("Upgrading"),
             "Restoring": _t("Restoring"),
-            "Failed": _t("Failed"),
-            "Unknown": _t("Unknown"),
-            "Pending": _t("Pending"),
+            "BackingUp": _t("Backing Up"),
+            "Error": _t("Error"),
         };
         return labels[phase] || phase;
     }

--- a/odoo_herd/views/k8s_odoo_instance_views.xml
+++ b/odoo_herd/views/k8s_odoo_instance_views.xml
@@ -5,7 +5,7 @@
         <field name="name">k8s.odoo.instance.list</field>
         <field name="model">k8s.odoo.instance</field>
         <field name="arch" type="xml">
-            <list string="Odoo Instances" js_class="instance_list" decoration-muted="phase == 'Pending'" decoration-success="phase == 'Running'" decoration-danger="phase == 'Failed'">
+            <list string="Odoo Instances" js_class="instance_list" decoration-muted="phase in ('Stopped', 'Uninitialized')" decoration-success="phase == 'Running'" decoration-danger="phase in ('InitFailed', 'Error')" decoration-warning="phase == 'Degraded'">
                 <field name="name"/>
                 <field name="cluster_id"/>
                 <field name="namespace"/>


### PR DESCRIPTION
The phase selection field was missing BackingUp and included phases (UpgradeFailed, RestoreFailed, Unknown) not defined in the operator's OdooInstancePhase enum, causing webhook sync failures.