### PR TITLE
fix: replace removed demo data refs with self-contained test data

### DIFF
--- a/delivery_carrier_partner_account/__manifest__.py
+++ b/delivery_carrier_partner_account/__manifest__.py
@@ -28,6 +28,7 @@
     "depends": [
         "incrementing_sequence_mixin",
         "stock_delivery",
+        "delivery",
     ],
     "data": [
         "security/ir.model.access.csv",

--- a/delivery_carrier_partner_account/tests/test_carrier_account_common.py
+++ b/delivery_carrier_partner_account/tests/test_carrier_account_common.py
@@ -17,8 +17,34 @@ class TestCarrierAccountCommon(TransactionCase):
                 "name": "Third Party",
             }
         )
-        cls.delivery_carrier_1 = cls.env.ref("delivery.free_delivery_carrier")
-        cls.delivery_carrier_2 = cls.env.ref("delivery.delivery_local_delivery")
+        delivery_product_1 = cls.env["product.product"].create(
+            {
+                "name": "Test Delivery Product 1",
+                "type": "service",
+            }
+        )
+        delivery_product_2 = cls.env["product.product"].create(
+            {
+                "name": "Test Delivery Product 2",
+                "type": "service",
+            }
+        )
+        cls.delivery_carrier_1 = cls.env["delivery.carrier"].create(
+            {
+                "name": "Test Carrier 1",
+                "delivery_type": "fixed",
+                "product_id": delivery_product_1.id,
+                "fixed_price": 0.0,
+            }
+        )
+        cls.delivery_carrier_2 = cls.env["delivery.carrier"].create(
+            {
+                "name": "Test Carrier 2",
+                "delivery_type": "fixed",
+                "product_id": delivery_product_2.id,
+                "fixed_price": 10.0,
+            }
+        )
         cls.client_account_1 = cls.env["delivery.carrier.account"].create(
             {
                 "partner_id": cls.client_partner.id,
@@ -61,6 +87,19 @@ class TestCarrierAccountCommon(TransactionCase):
                 "account_number": "zzzzzzzzz",
             }
         )
+        cls.test_product = cls.env["product.product"].create(
+            {
+                "name": "Test Sale Product",
+                "list_price": 100.0,
+            }
+        )
+        cls.storable_product = cls.env["product.product"].create(
+            {
+                "name": "Test Storable Product",
+                "is_storable": True,
+                "list_price": 50.0,
+            }
+        )
 
     def _create_sale_order(self, billing_mode, carrier, account):
         vals = {
@@ -70,7 +109,7 @@ class TestCarrierAccountCommon(TransactionCase):
             "order_line": [
                 Command.create(
                     {
-                        "product_id": self.env.ref("product.product_product_4").id,
+                        "product_id": self.test_product.id,
                     }
                 )
             ],

--- a/delivery_carrier_partner_account/tests/test_res_partner.py
+++ b/delivery_carrier_partner_account/tests/test_res_partner.py
@@ -7,6 +7,34 @@ class TestResPartner(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        delivery_product_1 = cls.env["product.product"].create(
+            {
+                "name": "Test Delivery Product 1",
+                "type": "service",
+            }
+        )
+        delivery_product_2 = cls.env["product.product"].create(
+            {
+                "name": "Test Delivery Product 2",
+                "type": "service",
+            }
+        )
+        cls.carrier_1 = cls.env["delivery.carrier"].create(
+            {
+                "name": "Test Carrier 1",
+                "delivery_type": "fixed",
+                "product_id": delivery_product_1.id,
+                "fixed_price": 0.0,
+            }
+        )
+        cls.carrier_2 = cls.env["delivery.carrier"].create(
+            {
+                "name": "Test Carrier 2",
+                "delivery_type": "fixed",
+                "product_id": delivery_product_2.id,
+                "fixed_price": 10.0,
+            }
+        )
 
     def test_default_carrier_set_on_create(self):
         partner = self.env["res.partner"].create(
@@ -17,9 +45,7 @@ class TestResPartner(TransactionCase):
         account = self.env["delivery.carrier.account"].create(
             {
                 "partner_id": partner.id,
-                "delivery_carrier_id": self.env.ref(
-                    "delivery.free_delivery_carrier"
-                ).id,
+                "delivery_carrier_id": self.carrier_1.id,
                 "account_number": "1234567890",
             }
         )
@@ -39,9 +65,7 @@ class TestResPartner(TransactionCase):
                 "carrier_account_ids": [
                     Command.create(
                         {
-                            "delivery_carrier_id": self.env.ref(
-                                "delivery.free_delivery_carrier"
-                            ).id,
+                            "delivery_carrier_id": self.carrier_1.id,
                             "account_number": "1234567890",
                         }
                     )
@@ -59,9 +83,7 @@ class TestResPartner(TransactionCase):
                 "carrier_account_ids": [
                     Command.create(
                         {
-                            "delivery_carrier_id": self.env.ref(
-                                "delivery.free_delivery_carrier"
-                            ).id,
+                            "delivery_carrier_id": self.carrier_1.id,
                             "account_number": "1234567890",
                         }
                     )
@@ -71,9 +93,7 @@ class TestResPartner(TransactionCase):
         new_account = self.env["delivery.carrier.account"].create(
             {
                 "partner_id": partner.id,
-                "delivery_carrier_id": self.env.ref(
-                    "delivery.delivery_local_delivery"
-                ).id,
+                "delivery_carrier_id": self.carrier_2.id,
                 "account_number": "1234567890",
             }
         )
@@ -88,9 +108,7 @@ class TestResPartner(TransactionCase):
         new_account = self.env["delivery.carrier.account"].create(
             {
                 "partner_id": partner.id,
-                "delivery_carrier_id": self.env.ref(
-                    "delivery.free_delivery_carrier"
-                ).id,
+                "delivery_carrier_id": self.carrier_1.id,
                 "account_number": "1234567890",
             }
         )
@@ -106,9 +124,7 @@ class TestResPartner(TransactionCase):
         account = self.env["delivery.carrier.account"].create(
             {
                 "partner_id": partner.id,
-                "delivery_carrier_id": self.env.ref(
-                    "delivery.free_delivery_carrier"
-                ).id,
+                "delivery_carrier_id": self.carrier_1.id,
                 "account_number": "1234567890",
             }
         )
@@ -127,18 +143,14 @@ class TestResPartner(TransactionCase):
         account1 = self.env["delivery.carrier.account"].create(
             {
                 "partner_id": partner.id,
-                "delivery_carrier_id": self.env.ref(
-                    "delivery.free_delivery_carrier"
-                ).id,
+                "delivery_carrier_id": self.carrier_1.id,
                 "account_number": "1234567890",
             }
         )
         account2 = self.env["delivery.carrier.account"].create(
             {
                 "partner_id": partner.id,
-                "delivery_carrier_id": self.env.ref(
-                    "delivery.free_delivery_carrier"
-                ).id,
+                "delivery_carrier_id": self.carrier_1.id,
                 "account_number": "1234567891",
             }
         )

--- a/delivery_carrier_partner_account/tests/test_sale_order.py
+++ b/delivery_carrier_partner_account/tests/test_sale_order.py
@@ -54,7 +54,7 @@ class TestSalesOrder(TestCarrierAccountCommon):
                 "partner_shipping_id": self.random_partner.id,
                 "order_line": [
                     Command.create(
-                        {"product_id": self.env.ref("product.product_product_4").id}
+                        {"product_id": self.storable_product.id}
                     )
                 ],
             }
@@ -83,7 +83,7 @@ class TestSalesOrder(TestCarrierAccountCommon):
                 "partner_shipping_id": self.client_partner.id,
                 "order_line": [
                     Command.create(
-                        {"product_id": self.env.ref("product.product_delivery_01").id}
+                        {"product_id": self.storable_product.id}
                     )
                 ],
                 "carrier_id": self.delivery_carrier_1.id,

--- a/picking_policy_per_customer/models/sale_order.py
+++ b/picking_policy_per_customer/models/sale_order.py
@@ -9,7 +9,7 @@ class SaleOrder(models.Model):
         self.picking_policy = (
             self.partner_id
             and self.partner_id.picking_policy
-            or self.parnter_id.commercial_partner_id.picking_policy
+            or self.partner_id.commercial_partner_id.picking_policy
         ) or self.env["ir.config_parameter"].sudo().get_param(
             "sale.default_picking_policy", "direct"
         )

--- a/product_supplierinfo_tracking/tests/test_product_supplierinfo_tracking.py
+++ b/product_supplierinfo_tracking/tests/test_product_supplierinfo_tracking.py
@@ -55,7 +55,7 @@ class TestProductSupplierinfoTracking(TransactionCase):
             "partner_id",
             "product_name",
             "product_code",
-            "product_uom",
+            "product_uom_id",
             "min_qty",
             "currency_id",
             "date_start",

--- a/purchase_customer_requisition/tests/test_purchase_order.py
+++ b/purchase_customer_requisition/tests/test_purchase_order.py
@@ -11,10 +11,18 @@ class TestPurchaseOrder(TransactionCase):
         cls.mto_route = cls.env.ref("stock.route_warehouse0_mto")
         cls.buy_route = cls.env.ref("purchase_stock.route_warehouse0_buy")
         cls.mto_route.active = True
-        cls.supplier = cls.env.ref("base.res_partner_18")
-        cls.client_1 = cls.env.ref("base.res_partner_2")
-        cls.client_2 = cls.env.ref("base.res_partner_3")
-        cls.client_3 = cls.env.ref("base.res_partner_4")
+        cls.supplier = cls.env["res.partner"].create(
+            {"name": "Test Supplier", "is_company": True, "group_rfq": "all"}
+        )
+        cls.client_1 = cls.env["res.partner"].create(
+            {"name": "Test Client 1", "is_company": True}
+        )
+        cls.client_2 = cls.env["res.partner"].create(
+            {"name": "Test Client 2", "is_company": True}
+        )
+        cls.client_3 = cls.env["res.partner"].create(
+            {"name": "Test Client 3", "is_company": True}
+        )
         cls.product_1 = cls.env["product.product"].create(
             {
                 "name": "SuperProduct",

--- a/purchase_delivery_carrier/tests/test_purchase_delivery.py
+++ b/purchase_delivery_carrier/tests/test_purchase_delivery.py
@@ -7,8 +7,34 @@ class TestPurchaseDelivery(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.carrier_1 = cls.env.ref("delivery.delivery_local_delivery")
-        cls.carrier_2 = cls.env.ref("delivery.free_delivery_carrier")
+        delivery_product_1 = cls.env["product.product"].create(
+            {
+                "name": "Local Delivery Product",
+                "type": "service",
+            }
+        )
+        delivery_product_2 = cls.env["product.product"].create(
+            {
+                "name": "Free Delivery Product",
+                "type": "service",
+            }
+        )
+        cls.carrier_1 = cls.env["delivery.carrier"].create(
+            {
+                "name": "Test Local Delivery",
+                "delivery_type": "fixed",
+                "product_id": delivery_product_1.id,
+                "fixed_price": 10.0,
+            }
+        )
+        cls.carrier_2 = cls.env["delivery.carrier"].create(
+            {
+                "name": "Test Free Delivery",
+                "delivery_type": "fixed",
+                "product_id": delivery_product_2.id,
+                "fixed_price": 0.0,
+            }
+        )
 
         cls.partner_1 = cls.env["res.partner"].create(
             {


### PR DESCRIPTION
## Summary
- **picking_policy_per_customer**: fix typo `parnter_id` -> `partner_id` in onchange
- **product_supplierinfo_tracking**: fix field name `product_uom` -> `product_uom_id` in test
- **delivery_carrier_partner_account**: create own carriers/products in tests instead of referencing `delivery.delivery_local_delivery`, `delivery.free_delivery_carrier`, `product.product_product_4`, `product.product_delivery_01` (all removed in Odoo 19)
- **purchase_delivery_carrier**: create own carriers instead of xmlid refs
- **purchase_customer_requisition**: create own partners instead of `base.res_partner_2/3/4/18`, set `group_rfq=all` on supplier for robust PO grouping across module combinations
