### PR TITLE
Add optional delivery billing mode setting

### DIFF
--- a/delivery_carrier_partner_account/__manifest__.py
+++ b/delivery_carrier_partner_account/__manifest__.py
@@ -19,7 +19,7 @@
 #
 {
     "name": "Carrier Accounts by Partner",
-    "version": "18.0.0.1.4",
+    "version": "18.0.0.1.5",
     "summary": "Add one or many carrier accounts per partner",
     "category": "Delivery",
     "author": "Bemade Inc.",
@@ -38,6 +38,7 @@
         "views/delivery_carrier_account_views.xml",
         "views/sale_order_views.xml",
         "views/stock_picking_views.xml",
+        "views/res_config_settings_views.xml",
         "wizard/choose_delivery_carrier_views.xml",
     ],
     "assets": {},

--- a/delivery_carrier_partner_account/models/__init__.py
+++ b/delivery_carrier_partner_account/models/__init__.py
@@ -1,5 +1,6 @@
 from . import carrier_account_mixin
 from . import delivery_carrier_account
+from . import res_config_settings
 from . import res_partner
 from . import sales_order
 from . import stock_picking

--- a/delivery_carrier_partner_account/models/res_config_settings.py
+++ b/delivery_carrier_partner_account/models/res_config_settings.py
@@ -1,0 +1,11 @@
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    require_delivery_billing_mode = fields.Boolean(
+        string="Require Delivery Billing Mode",
+        help="When enabled, a delivery billing mode must be set on sale orders before they can be confirmed.",
+        config_parameter="delivery_carrier_partner_account.require_delivery_billing_mode",
+    )

--- a/delivery_carrier_partner_account/views/res_config_settings_views.xml
+++ b/delivery_carrier_partner_account/views/res_config_settings_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.delivery.carrier.partner.account</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="stock.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//block[@name='shipping_setting_container']" position="inside">
+                <setting
+                    string="Require Delivery Billing Mode"
+                    help="Require a delivery billing mode on sale orders before confirmation.">
+                    <field name="require_delivery_billing_mode"/>
+                </setting>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Summary
- Adds a `require_delivery_billing_mode` boolean to `res.config.settings` (Inventory > Settings > Shipping), backed by `ir.config_parameter`
- Defaults to **off**, so downstream modules that confirm sale orders in tests don't hit a constraint requiring `delivery_billing_mode`
- When toggled on, downstream code (e.g. `pneumac_sale`) can enforce the requirement via the config parameter

## Test plan
- [ ] Install/upgrade `delivery_carrier_partner_account`
- [ ] Verify the setting appears under Inventory > Settings > Shipping
- [ ] Toggle on, confirm a sale order without billing mode → should be blocked by downstream constraint
- [ ] Toggle off, confirm a sale order without billing mode → should succeed