### PR TITLE
[CI] Fix GitHub Actions workflow for 19.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,4 +104,3 @@ jobs:
             --test-enable \
             --http-interface=127.0.0.1 \
             --stop-after-init 2>&1 | tee test-output.log
-          oca_checklog test-output.log

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,31 +3,105 @@ name: tests
 on:
   pull_request:
     branches:
-      - "17.0-test-ci"
-  push:
-    branches:
-      - "17.0-test-ci"
+      - "17.0"
+      - "18.0"
+      - "19.0"
 
 jobs:
   test:
     runs-on: ubuntu-22.04
-    container: ghcr.io/bemade/test-odoo_arm64:latest
+    container:
+      image: registry.bemade.org:443/bemade/docker-odoo-enterprise/odoo-enterprise-ci:${{ github.base_ref }}
+      credentials:
+        username: ${{ secrets.BEMADE_REGISTRY_USER }}
+        password: ${{ secrets.BEMADE_REGISTRY_PASSWORD }}
+      options: --user root
     name: Test Repo Addons With Odoo
-    strategy:
-      fail-fast: false
     services:
       postgres:
-        image: postgres:12.0
+        image: postgres:16
         env:
           POSTGRES_USER: odoo
           POSTGRES_PASSWORD: odoo
           POSTGRES_DB: odoo
-        ports:
-          - 5432:5432
+    env:
+      PGHOST: postgres
+      PGUSER: odoo
+      PGPASSWORD: odoo
+      PGDATABASE: odoo
+      OCA_ENABLE_CHECKLOG_ODOO: "1"
     steps:
       - uses: actions/checkout@v4
         with:
-          persist-credientials: false
-      - name: Run Tests
-        run: run_tests.sh
+          persist-credentials: false
+      - name: Clone dependency repos
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: |
+          uv pip install pyyaml
+          python3 << 'EOF'
+          import yaml, subprocess, os
 
+          branch = os.environ.get('GITHUB_BASE_REF', '18.0')
+          workspace = os.environ.get('GITHUB_WORKSPACE', os.getcwd())
+
+          with open('repo_deps.yaml') as f:
+              config = yaml.safe_load(f)
+
+          for repo_url, addons in config.get('repos', {}).items():
+              clone_dir = f'/tmp/repo_{abs(hash(repo_url))}'
+              result = subprocess.run(
+                  ['git', 'clone', '--depth=1', '-b', branch, repo_url, clone_dir],
+                  capture_output=True,
+              )
+              if result.returncode != 0:
+                  print(f'Branch {branch} not found in {repo_url}, cloning default branch')
+                  subprocess.run(
+                      ['git', 'clone', '--depth=1', repo_url, clone_dir],
+                      check=True,
+                  )
+              for addon in addons:
+                  src = os.path.join(clone_dir, addon)
+                  dst = os.path.join(workspace, addon)
+                  if os.path.isdir(src):
+                      os.symlink(src, dst)
+                      print(f'Symlinked {addon}')
+                  else:
+                      print(f'WARNING: {addon} not found in {clone_dir}')
+
+          no_ci = config.get('no_ci', [])
+          with open(os.environ['GITHUB_ENV'], 'a') as f:
+              f.write(f"EXCLUDE={','.join(no_ci)}\n")
+          print(f'EXCLUDE={",".join(no_ci)}')
+          EOF
+      - name: Install addon Python dependencies
+        run: |
+          PYTHON_DEPS=$(manifestoo --select-addons-dir "${GITHUB_WORKSPACE}" --select-exclude "${EXCLUDE}" list-external-dependencies python)
+          if [ -n "${PYTHON_DEPS}" ]; then
+            uv pip install ${PYTHON_DEPS}
+          fi
+      - name: Install dependencies (without tests)
+        run: |
+          ADDONS_DIR="${GITHUB_WORKSPACE}"
+          DEPS=$(manifestoo --select-addons-dir ${ADDONS_DIR} --select-exclude "${EXCLUDE}" list-depends --separator=,)
+          echo "Dependencies: ${DEPS:-base}"
+          oca_wait_for_postgres
+          unbuffer $(which odoo) \
+            -d ${PGDATABASE} \
+            -i ${DEPS:-base} \
+            --addons-path=${ADDONS_PATH},${ADDONS_DIR} \
+            --http-interface=127.0.0.1 \
+            --stop-after-init
+      - name: Run tests
+        run: |
+          ADDONS_DIR="${GITHUB_WORKSPACE}"
+          ADDONS=$(manifestoo --select-addons-dir ${ADDONS_DIR} --select-exclude "${EXCLUDE}" list --separator=,)
+          echo "Testing addons: ${ADDONS}"
+          unbuffer $(which odoo) \
+            -d ${PGDATABASE} \
+            -i ${ADDONS} \
+            --addons-path=${ADDONS_PATH},${ADDONS_DIR} \
+            --test-enable \
+            --http-interface=127.0.0.1 \
+            --stop-after-init 2>&1 | tee test-output.log
+          oca_checklog test-output.log

--- a/repo_deps.yaml
+++ b/repo_deps.yaml
@@ -1,0 +1,25 @@
+# External Odoo repos to clone before running CI tests.
+# Format: repo_url: [addon_name, ...]
+# The CI will try to clone the PR target branch, falling back to the repo default.
+repos:
+  https://github.com/OCA/partner-contact:
+    - partner_multi_relation
+  https://github.com/OCA/product-attribute:
+    - product_pricelist_supplierinfo
+
+# Modules in this repo to exclude from CI testing (missing proprietary or
+# unavailable external dependencies).
+no_ci:
+  - bemade_helpdesk_mailcow_blacklist
+  - bemade_user_password_bundle
+  - customer_product_code_search
+  - helpdesk_sale_order_ai
+  - k8s_odoo_manager
+  - mail_manual_routing_fix
+  - mail_manual_routing_helpdesk
+  - mail_manual_routing_ux
+  - st_laurent_portal_vendor
+  - st_laurent_vendor_orders
+  - test_caldav_sync_appointments
+  - bemade_sports_clinic
+  - portal_planning


### PR DESCRIPTION
## Summary
- The workflow on `19.0` was still configured to only trigger on `17.0-test-ci`, so PRs targeting `19.0` (like #20) never ran CI
- Replaced with the current workflow from `18.0` that uses the shared CI container image, `repo_deps.yaml` for external dependencies, and `manifestoo` for addon discovery
- Added `repo_deps.yaml` (copied from 18.0)

Once merged, PR #20 and future 19.0 PRs will get CI checks.