### PR TITLE
fix: bemade_fsm warning

### DIFF
--- a/bemade_fsm/__manifest__.py
+++ b/bemade_fsm/__manifest__.py
@@ -20,7 +20,7 @@
 ########################################################################################
 {
     "name": "Improved Field Service Management",
-    "version": "18.0.0.4.4",
+    "version": "18.0.0.4.5",
     "summary": (
         "Adds functionality necessary for managing field service operations at Durpro."
     ),

--- a/bemade_fsm/models/fsm_visit.py
+++ b/bemade_fsm/models/fsm_visit.py
@@ -49,6 +49,7 @@ class FSMVisit(models.Model):
         comodel_name="project.task",
         compute="_compute_task_id",
         string="Service Visit",
+        store=True
     )
 
     task_ids = fields.One2many(comodel_name="project.task", inverse_name="visit_id")


### PR DESCRIPTION
Fix a warning on bemade_fsm.visit.task_id by making it stored to enable
searching (needed for bemade_fsm.visit.visit_no calculation).
