### PR TITLE
fix: account_credit_hold followup report and email

### DIFF
--- a/account_credit_hold/models/res_partner.py
+++ b/account_credit_hold/models/res_partner.py
@@ -96,6 +96,7 @@ class Partner(models.Model):
         # Apply credit hold after successful followup execution
         if should_hold:
             self.action_credit_hold()
+            res = True
 
         return res
 

--- a/account_credit_hold/models/res_partner.py
+++ b/account_credit_hold/models/res_partner.py
@@ -80,12 +80,6 @@ class Partner(models.Model):
             else:
                 rec.hold_bg = prev_hold_bg
 
-    def _get_followup_report(self, options):
-        # Override to prevent hanging on PDF generation
-        # Just set minimal required options without generating the report
-        options.setdefault("attachment_ids", [])
-        options["report_attachment_id"] = False
-
     def _execute_followup_partner(self, options=None):
         # Check if we need to place on credit hold before expensive operations
         should_hold = self._should_hold()
@@ -105,8 +99,8 @@ class Partner(models.Model):
 
         return res
 
-    @api.depends('unreconciled_aml_ids', 'followup_next_action_date')
-    @api.depends_context('company', 'allowed_company_ids')
+    @api.depends("unreconciled_aml_ids", "followup_next_action_date")
+    @api.depends_context("company", "allowed_company_ids")
     def _compute_followup_status(self):
         super()._compute_followup_status()
         for rec in self:

--- a/account_credit_hold/tests/test_account_credit_hold.py
+++ b/account_credit_hold/tests/test_account_credit_hold.py
@@ -2,7 +2,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import date, timedelta
+from unittest.mock import patch
 from odoo.tests import common, tagged, Form
+from odoo.addons.mail.tests.common import MailCase
 from odoo.exceptions import UserError
 from odoo import Command, fields
 import freezegun
@@ -10,10 +12,24 @@ from typing import cast
 
 
 @tagged("post_install", "-at_install")
-class TestAccountCreditHold(common.TransactionCase):
+class TestAccountCreditHold(common.TransactionCase, MailCase):
 
     def setUp(self):
         super().setUp()
+
+        # Skip wkhtmltopdf (deadlocks in TransactionCase: the test cursor
+        # blocks the HTTP request wkhtmltopdf makes to fetch CSS assets).
+        # QWeb template rendering and get_options still run fully.
+        patcher = patch.object(
+            self.env.registry["ir.actions.report"],
+            "_run_wkhtmltopdf",
+            autospec=True,
+            side_effect=lambda self, bodies, **kw: b"".join(
+                b.encode() if isinstance(b, str) else b for b in bodies
+            ),
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
 
         # Create test partner
         self.partner = self.env["res.partner"].create(
@@ -401,3 +417,41 @@ class TestAccountCreditHold(common.TransactionCase):
             self.partner.invalidate_recordset()
             self.assertFalse(self.partner.hold_bg)
             self.assertFalse(self.partner.on_hold)
+
+    def test_followup_email_with_report_generates_cleanly(self):
+        """Followup execution with send_email generates the PDF report and
+        sends the email without errors (e.g. no None in attachment_ids)."""
+        # Enable email on the second followup line
+        self.followup_line_hold.send_email = True
+
+        with freezegun.freeze_time("2025-09-01"):
+            invoice = self.env["account.move"].create(
+                {
+                    "partner_id": self.partner.id,
+                    "move_type": "out_invoice",
+                    "invoice_date": "2025-08-01",
+                    "invoice_date_due": "2025-09-01",
+                    "invoice_line_ids": [
+                        Command.create(
+                            {
+                                "name": "Overdue Invoice",
+                                "quantity": 1.0,
+                                "price_unit": 500.0,
+                            }
+                        )
+                    ],
+                }
+            )
+            invoice.action_post()
+
+        with freezegun.freeze_time("2025-10-31"):
+            self.partner._compute_followup_status()
+            # First reminder (no hold, no email)
+            self.partner._execute_followup_partner()
+
+            self.partner._compute_followup_status()
+            # Second reminder triggers email with PDF report attachment
+            with self.mock_mail_gateway():
+                self.partner._execute_followup_partner(
+                    options={"snailmail": False}
+                )


### PR DESCRIPTION
## Summary
- Removes the `_get_followup_report` override that was silently disabling PDF report generation and returning `None`, causing `ValueError` in `message_post` when the followup cron sends emails (`[None, 362096, ...]` in attachment_ids)
- Adds test for the full followup-with-email flow to prevent regressions
- Mocks `_run_wkhtmltopdf` (not `export_to_pdf`) so QWeb template rendering and `get_options` still execute — only the subprocess is skipped (deadlocks in `TransactionCase`)
- Ensures `_execute_followup_partner` returns `True` when credit hold is applied

## Test plan
- [x] All existing `account_credit_hold` tests pass (13 tests, 0 failures)
- [x] New `test_followup_email_with_report_generates_cleanly` exercises the email path
- [ ] Verify followup cron runs without error on staging with a partner that has overdue invoices