### PR TITLE
feat(fsm_visit_confirmation): re-land client requirements for visit emails

### DIFF
--- a/fsm_visit_confirmation/__manifest__.py
+++ b/fsm_visit_confirmation/__manifest__.py
@@ -44,8 +44,11 @@
     "license": "LGPL-3",
     "depends": ["industry_fsm", "bemade_fsm", "rating", "http_routing"],
     "data": [
+        "security/ir.model.access.csv",
+        "security/security.xml",
         "data/mail_templates.xml",
         "views/project_task_views.xml",
+        "views/fsm_task_client_requirement_views.xml",
         "views/project_portal_project_task_templates.xml",
         "views/project_task_type_views.xml",
     ],

--- a/fsm_visit_confirmation/__manifest__.py
+++ b/fsm_visit_confirmation/__manifest__.py
@@ -45,6 +45,7 @@
     "depends": ["industry_fsm", "bemade_fsm", "rating", "http_routing"],
     "data": [
         "data/mail_templates.xml",
+        "views/project_task_views.xml",
         "views/project_portal_project_task_templates.xml",
         "views/project_task_type_views.xml",
     ],

--- a/fsm_visit_confirmation/data/mail_templates.xml
+++ b/fsm_visit_confirmation/data/mail_templates.xml
@@ -10,8 +10,7 @@
         <field name="body_html" type="html">
             <div>
                 <div style="margin-bottom: 16px;">
-                    Dear <t t-out="object.work_order_contacts and object.work_order_contacts[0].name or object.partner_id.name"/>
-,
+                    Dear <t t-out="object.work_order_contacts and object.work_order_contacts[0].name or object.partner_id.name"/>,
                 </div>
                 <div style="margin-bottom: 16px;">
                     We would like to confirm the details of your upcoming service visit:
@@ -30,8 +29,7 @@
                             <t t-set="partner_tz" t-value="user.tz or object.company_id.partner_id.tz or 'America/Toronto'"/>
                             <span t-field="object.planned_date_begin" t-options="{'widget': 'datetime', 'timezone': partner_tz}"/>
                             <div style="font-size: 12px; color: #666;">
-                                (Timezone: <t t-out="partner_tz"/>
-)
+                                (Timezone: <t t-out="partner_tz"/>)
                             </div>
                         </td>
                     </tr>
@@ -44,9 +42,7 @@
                                 <t t-out="object.partner_id.street2"/>
                                 <br/>
                             </t>
-                            <t t-out="object.partner_id.city"/>
-,                            <t t-out="object.partner_id.state_id.code"/>
-                            <t t-out="object.partner_id.zip"/>
+                            <t t-out="object.partner_id.city"/>, <t t-out="object.partner_id.state_id.code"/> <t t-out="object.partner_id.zip"/>
                         </td>
                     </tr>
                     <tr>
@@ -61,16 +57,24 @@
                         </td>
                     </tr>
                 </table>
-                <t t-if="object.water_shutdown_required">
+                <!-- Client Requirements Section -->
+                <t t-if="object.client_requirement_ids">
                     <div style="margin: 16px 0px; padding: 12px; background-color: #fff3cd; border: 1px solid #ffc107; border-radius: 4px;">
-                        <strong style="color: #856404;">⚠️ Water Shutdown Notice</strong>
-                        <p style="margin: 8px 0px 0px 0px; color: #856404;">
-                            You will not have water during this service visit.
-                            <t t-if="object.water_shutdown_notes">
-                                <br/><em><t t-out="object.water_shutdown_notes"/></em>
-                            </t>
-                        </p>
+                        <strong style="color: #856404;">⚠️ Important Requirements for Your Visit</strong>
+                        <t t-foreach="object.client_requirement_ids" t-as="req">
+                            <p style="margin: 8px 0px 0px 0px; color: #856404;">
+                                <strong><t t-out="req.name"/></strong>
+                                <t t-if="req.description">
+                                    <br/><em><t t-out="req.description"/></em>
+                                </t>
+                            </p>
+                        </t>
                     </div>
+                    <t t-if="object.client_requirements_notes">
+                        <p style="margin: 8px 0px; color: #666;">
+                            <strong>Additional notes:</strong> <em><t t-out="object.client_requirements_notes"/></em>
+                        </p>
+                    </t>
                 </t>
                 <div style="margin: 16px 0px 16px 0px;">
                     Please take a moment to confirm this visit by clicking one of the following options:
@@ -93,12 +97,18 @@
                 </table>
                 <div style="margin-top: 16px;">
                     <p>Best regards,</p>
-                    <p>The <t t-out="object.company_id.name"/>
- service management team</p>
+                    <p>The <t t-out="object.company_id.name"/> service management team</p>
                 </div>
             </div>
         </field>
         <field name="lang">{{ object.work_order_contacts and object.work_order_contacts[0].lang or object.partner_id.lang }}</field>
         <field name="auto_delete" eval="False"/>
+    </record>
+
+    <!-- Demo data: Create default "Water Shutdown Required" requirement -->
+    <record id="client_requirement_water_shutdown" model="fsm.task.client.requirement">
+        <field name="name">Water Shutdown Required</field>
+        <field name="description">You will not have water during this service visit.</field>
+        <field name="active" eval="True"/>
     </record>
 </odoo>

--- a/fsm_visit_confirmation/data/mail_templates.xml
+++ b/fsm_visit_confirmation/data/mail_templates.xml
@@ -61,6 +61,17 @@
                         </td>
                     </tr>
                 </table>
+                <t t-if="object.water_shutdown_required">
+                    <div style="margin: 16px 0px; padding: 12px; background-color: #fff3cd; border: 1px solid #ffc107; border-radius: 4px;">
+                        <strong style="color: #856404;">⚠️ Water Shutdown Notice</strong>
+                        <p style="margin: 8px 0px 0px 0px; color: #856404;">
+                            You will not have water during this service visit.
+                            <t t-if="object.water_shutdown_notes">
+                                <br/><em><t t-out="object.water_shutdown_notes"/></em>
+                            </t>
+                        </p>
+                    </div>
+                </t>
                 <div style="margin: 16px 0px 16px 0px;">
                     Please take a moment to confirm this visit by clicking one of the following options:
                 </div>

--- a/fsm_visit_confirmation/models/__init__.py
+++ b/fsm_visit_confirmation/models/__init__.py
@@ -1,2 +1,3 @@
 from . import project_task_type
 from . import project_task
+from . import fsm_task_client_requirement

--- a/fsm_visit_confirmation/models/fsm_task_client_requirement.py
+++ b/fsm_visit_confirmation/models/fsm_task_client_requirement.py
@@ -1,0 +1,34 @@
+from odoo import models, fields
+
+
+class FSMTaskClientRequirement(models.Model):
+    """Client-facing requirements that can be communicated in visit confirmation emails.
+
+    This model stores reusable requirement types (e.g., "Water Shutdown Required",
+    "Power Shutdown Required", etc.) that can be linked to tasks.
+
+    New requirements can be added via the UI without code changes.
+    """
+    _name = "fsm.task.client.requirement"
+    _description = "FSM Task Client Requirement"
+
+    name = fields.Char(
+        string="Requirement Name",
+        required=True,
+        translate=True,
+        help="The name displayed to the client (e.g., 'Water Shutdown Required').",
+    )
+    description = fields.Text(
+        string="Description",
+        help="Additional information shown to the client when this requirement applies.",
+    )
+    active = fields.Boolean(default=True)
+    color = fields.Integer(
+        string="Color Index",
+        default=0,
+        help="Color for kanban/tags display.",
+    )
+
+    _sql_constraints = [
+        ("name_unique", "UNIQUE(name)", "Requirement name must be unique."),
+    ]

--- a/fsm_visit_confirmation/models/project_task.py
+++ b/fsm_visit_confirmation/models/project_task.py
@@ -4,17 +4,21 @@ from odoo import models, fields
 class ProjectTask(models.Model):
     _inherit = "project.task"
 
-    # Visit notification fields - designed for extensibility
-    # Each checkbox informs the customer about conditions during the service visit
-    water_shutdown_required = fields.Boolean(
-        string="Water Shutdown Required",
-        default=False,
-        help="Check if the customer will not have water during this service visit.",
+    # Many2many relation to client requirements - extensible without code changes
+    client_requirement_ids = fields.Many2many(
+        "fsm.task.client.requirement",
+        "project_task_client_requirement_rel",
+        "task_id",
+        "requirement_id",
+        string="Client Requirements",
+        help="Select client-facing requirements for this visit. "
+        "These will be communicated in the confirmation email.",
     )
 
-    water_shutdown_notes = fields.Text(
-        string="Water Shutdown Notes",
-        help="Additional notes about the water shutdown (e.g., duration, timing).",
+    # Notes field for additional context about requirements
+    client_requirements_notes = fields.Text(
+        string="Requirements Notes",
+        help="Additional notes about requirements (e.g., duration, timing, specific instructions).",
     )
 
     def write(self, vals):

--- a/fsm_visit_confirmation/models/project_task.py
+++ b/fsm_visit_confirmation/models/project_task.py
@@ -1,8 +1,21 @@
-from odoo import models
+from odoo import models, fields
 
 
 class ProjectTask(models.Model):
     _inherit = "project.task"
+
+    # Visit notification fields - designed for extensibility
+    # Each checkbox informs the customer about conditions during the service visit
+    water_shutdown_required = fields.Boolean(
+        string="Water Shutdown Required",
+        default=False,
+        help="Check if the customer will not have water during this service visit.",
+    )
+
+    water_shutdown_notes = fields.Text(
+        string="Water Shutdown Notes",
+        help="Additional notes about the water shutdown (e.g., duration, timing).",
+    )
 
     def write(self, vals):
         # Store old stage for comparison

--- a/fsm_visit_confirmation/security/ir.model.access.csv
+++ b/fsm_visit_confirmation/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+fsm_task_client_requirement_access_user,fsm.task.client.requirement.user,model_fsm_task_client_requirement,,1,0,0,0
+fsm_task_client_requirement_access_manager,fsm.task.client.requirement.manager,model_fsm_task_client_requirement,industry_fsm.group_fsm_manager,1,1,1,1

--- a/fsm_visit_confirmation/security/security.xml
+++ b/fsm_visit_confirmation/security/security.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+    <!-- Security rules for fsm.task.client.requirement -->
+    <record id="fsm_task_client_requirement_rule_user" model="ir.rule">
+        <field name="name">FSM Task Client Requirement: User</field>
+        <field name="model_id" ref="model_fsm_task_client_requirement"/>
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+    </record>
+    
+    <!-- FSM Managers can create/edit requirements -->
+    <record id="fsm_task_client_requirement_rule_manager" model="ir.rule">
+        <field name="name">FSM Task Client Requirement: Manager</field>
+        <field name="model_id" ref="model_fsm_task_client_requirement"/>
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4, ref('industry_fsm.group_fsm_manager'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="True"/>
+    </record>
+</odoo>

--- a/fsm_visit_confirmation/tests/test_fsm_visit_confirmation.py
+++ b/fsm_visit_confirmation/tests/test_fsm_visit_confirmation.py
@@ -205,39 +205,7 @@ class TestFSMVisitConfirmation(HttpCase):
             messages, "A message with feedback should be posted on the task"
         )
 
-    def test_04_client_requirement_model_exists(self):
-        """Test that fsm.task.client.requirement model exists and can be used"""
-        requirement_model = self.env["fsm.task.client.requirement"]
-        
-        # Create a requirement
-        requirement = requirement_model.create({
-            "name": "Test Requirement",
-            "description": "This is a test requirement description",
-        })
-        
-        self.assertTrue(requirement.id, "Requirement should be created successfully")
-        self.assertEqual(requirement.name, "Test Requirement", "Name should match")
-        self.assertEqual(requirement.description, "This is a test requirement description", "Description should match")
-        self.assertTrue(requirement.active, "Should be active by default")
-
-    def test_05_task_client_requirements_field(self):
-        """Test that client_requirement_ids field exists on project.task"""
-        # Create requirements
-        requirement_model = self.env["fsm.task.client.requirement"]
-        req1 = requirement_model.create({"name": "Water Shutdown Required"})
-        req2 = requirement_model.create({"name": "Power Shutdown Required"})
-        
-        # Assign requirements to task
-        self.task.write({
-            "client_requirement_ids": [(6, 0, [req1.id, req2.id])],
-            "client_requirements_notes": "Water off for 2 hours",
-        })
-        
-        self.assertIn(req1, self.task.client_requirement_ids, "Req1 should be in task requirements")
-        self.assertIn(req2, self.task.client_requirement_ids, "Req2 should be in task requirements")
-        self.assertEqual(self.task.client_requirements_notes, "Water off for 2 hours", "Notes should match")
-
-    def test_06_client_requirements_email_content(self):
+    def test_04_client_requirements_email_content(self):
         """Test that client requirements appear in confirmation email"""
         # Create a requirement
         requirement_model = self.env["fsm.task.client.requirement"]
@@ -270,7 +238,7 @@ class TestFSMVisitConfirmation(HttpCase):
         self.assertIn("You will not have water", new_mail.body_html, "Email should contain requirement description")
         self.assertIn("Approximately 1 hour", new_mail.body_html, "Email should contain notes")
 
-    def test_07_no_requirements_no_email_section(self):
+    def test_05_no_requirements_no_email_section(self):
         """Test that requirements section does NOT appear when no requirements set"""
         # Ensure no requirements on the task
         self.task.write({
@@ -292,7 +260,7 @@ class TestFSMVisitConfirmation(HttpCase):
         # Verify requirements section does NOT appear in email body
         self.assertNotIn("Important Requirements for Your Visit", new_mail.body_html, "Email should NOT contain requirements section when no requirements")
 
-    def test_08_multiple_requirements_display(self):
+    def test_06_multiple_requirements_display(self):
         """Test that multiple requirements display correctly in email"""
         # Create multiple requirements
         requirement_model = self.env["fsm.task.client.requirement"]

--- a/fsm_visit_confirmation/tests/test_fsm_visit_confirmation.py
+++ b/fsm_visit_confirmation/tests/test_fsm_visit_confirmation.py
@@ -247,3 +247,68 @@ class TestFSMVisitConfirmation(HttpCase):
         self.assertTrue(
             messages, "A message with feedback should be posted on the task"
         )
+
+    def test_04_water_shutdown_field_exists(self):
+        """Test that water_shutdown_required and water_shutdown_notes fields exist"""
+        self.assertFalse(self.task.water_shutdown_required, "Default should be False")
+        self.assertFalse(self.task.water_shutdown_notes, "Default notes should be empty")
+
+    def test_05_water_shutdown_field_write(self):
+        """Test that water_shutdown fields can be written"""
+        self.task.write({
+            "water_shutdown_required": True,
+            "water_shutdown_notes": "Water will be off for approximately 2 hours",
+        })
+        self.assertTrue(self.task.water_shutdown_required, "Should be True after write")
+        self.assertEqual(
+            self.task.water_shutdown_notes,
+            "Water will be off for approximately 2 hours",
+            "Notes should match",
+        )
+
+    def test_06_water_shutdown_email_content(self):
+        """Test that water shutdown info appears in confirmation email"""
+        # Set water shutdown on the task
+        self.task.write({
+            "water_shutdown_required": True,
+            "water_shutdown_notes": "Approximately 1 hour",
+        })
+
+        # Set the approval template on the approved stage
+        template = self.env.ref(
+            "fsm_visit_confirmation.fsm_visit_confirmation_email_template"
+        )
+        self.stage_approved.approval_template_id = template
+
+        # Move task to approved stage (triggers email)
+        self.task.write({"stage_id": self.stage_approved.id})
+
+        # Find the generated mail
+        new_mail = self.env["mail.mail"].search([], order="id desc", limit=1)
+        
+        # Verify water shutdown notice appears in email body
+        self.assertIn("Water Shutdown Notice", new_mail.body_html, "Email should contain water shutdown notice")
+        self.assertIn("You will not have water", new_mail.body_html, "Email should contain water shutdown message")
+        self.assertIn("Approximately 1 hour", new_mail.body_html, "Email should contain water shutdown notes")
+
+    def test_07_water_shutdown_no_email_when_false(self):
+        """Test that water shutdown notice does NOT appear when not required"""
+        # Ensure water_shutdown_required is False
+        self.task.write({
+            "water_shutdown_required": False,
+        })
+
+        # Set the approval template on the approved stage
+        template = self.env.ref(
+            "fsm_visit_confirmation.fsm_visit_confirmation_email_template"
+        )
+        self.stage_approved.approval_template_id = template
+
+        # Move task to approved stage (triggers email)
+        self.task.write({"stage_id": self.stage_approved.id})
+
+        # Find the generated mail
+        new_mail = self.env["mail.mail"].search([], order="id desc", limit=1)
+        
+        # Verify water shutdown notice does NOT appear in email body
+        self.assertNotIn("Water Shutdown Notice", new_mail.body_html, "Email should NOT contain water shutdown notice when not required")

--- a/fsm_visit_confirmation/tests/test_fsm_visit_confirmation.py
+++ b/fsm_visit_confirmation/tests/test_fsm_visit_confirmation.py
@@ -128,7 +128,7 @@ class TestFSMVisitConfirmation(HttpCase):
 
     def test_02_email_sent_on_stage_change(self):
         """Test that email is sent when task moves to approved stage"""
-        # Create email template
+        # Create email template with auto_delete=False so we can inspect the mail
         template_model = self.env["mail.template"]
         template = template_model.create(
             {
@@ -136,6 +136,7 @@ class TestFSMVisitConfirmation(HttpCase):
                 "model_id": self.env["ir.model"]._get("project.task").id,
                 "subject": "Test Subject",
                 "body_html": "<p>Test Body</p>",
+                "auto_delete": False,
             }
         )
         self.stage_approved.approval_template_id = template
@@ -188,7 +189,7 @@ class TestFSMVisitConfirmation(HttpCase):
         self.task.invalidate_recordset()
         self.assertEqual(
             self.task.state,
-            "05_changes_requested",
+            "02_changes_requested",
             "Task state should be updated to changes requested",
         )
 
@@ -207,12 +208,17 @@ class TestFSMVisitConfirmation(HttpCase):
 
     def test_04_client_requirements_email_content(self):
         """Test that client requirements appear in confirmation email"""
-        # Create a requirement
+        # Use existing requirement from demo data or create if missing
         requirement_model = self.env["fsm.task.client.requirement"]
-        req = requirement_model.create({
-            "name": "Water Shutdown Required",
-            "description": "You will not have water during this service visit.",
-        })
+        req = self.env.ref(
+            "fsm_visit_confirmation.client_requirement_water_shutdown",
+            raise_if_not_found=False,
+        )
+        if not req:
+            req = requirement_model.create({
+                "name": "Water Shutdown Required",
+                "description": "You will not have water during this service visit.",
+            })
         
         # Set requirements on the task
         self.task.write({
@@ -262,16 +268,25 @@ class TestFSMVisitConfirmation(HttpCase):
 
     def test_06_multiple_requirements_display(self):
         """Test that multiple requirements display correctly in email"""
-        # Create multiple requirements
+        # Use existing requirement from demo data or create if missing
         requirement_model = self.env["fsm.task.client.requirement"]
-        req1 = requirement_model.create({
-            "name": "Water Shutdown Required",
-            "description": "Water will be off for 2 hours.",
-        })
-        req2 = requirement_model.create({
-            "name": "Power Shutdown Required",
-            "description": "Power will be interrupted briefly.",
-        })
+        req1 = self.env.ref(
+            "fsm_visit_confirmation.client_requirement_water_shutdown",
+            raise_if_not_found=False,
+        )
+        if not req1:
+            req1 = requirement_model.create({
+                "name": "Water Shutdown Required",
+                "description": "Water will be off for 2 hours.",
+            })
+        else:
+            req1.description = "Water will be off for 2 hours."
+        req2 = requirement_model.search([("name", "=", "Power Shutdown Required")], limit=1)
+        if not req2:
+            req2 = requirement_model.create({
+                "name": "Power Shutdown Required",
+                "description": "Power will be interrupted briefly.",
+            })
         
         # Set requirements on the task
         self.task.write({

--- a/fsm_visit_confirmation/tests/test_fsm_visit_confirmation.py
+++ b/fsm_visit_confirmation/tests/test_fsm_visit_confirmation.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-
+import odoo.tests
 import logging
 from datetime import datetime, timedelta
 from odoo import http
@@ -37,108 +36,56 @@ class TestFSMVisitConfirmation(HttpCase):
 
     def setUp(self):
         super().setUp()
+        self.env = odoo.api.Environment(self.cr, self.uid, {})
 
-        # Configure test company
-        self.env.company.write(
+        # Find or create the default stage
+        stage_model = self.env["project.task.type"]
+        self.stage_new = stage_model.search([("name", "=", "New")], limit=1)
+        if not self.stage_new:
+            self.stage_new = stage_model.create(
+                {"name": "New", "sequence": 1}
+            )
+
+        self.stage_approved = stage_model.search(
+            [("name", "=", "Approved")], limit=1
+        )
+        if not self.stage_approved:
+            self.stage_approved = stage_model.create(
+                {"name": "Approved", "sequence": 10}
+            )
+
+        # Create a test project
+        project_model = self.env["project.project"]
+        self.project = project_model.create(
+            {"name": "Test FSM Project", "active": True}
+        )
+
+        # Create test customer partner
+        partner_model = self.env["res.partner"]
+        self.customer = partner_model.create(
             {
-                "email": "company@test.example.com",
-                "name": "Test Company",
+                "name": "Test Customer",
+                "email": "test@example.com",
+                "street": "123 Test St",
+                "city": "Test City",
+                "zip": "12345",
             }
         )
 
-        # Create test users and partners
-        self.fsm_user = self.env["res.users"].create(
-            {
-                "name": "FSM User",
-                "login": "fsm_user",
-                "email": "fsm@example.com",
-                "groups_id": [
-                    (
-                        6,
-                        0,
-                        [
-                            self.env.ref("industry_fsm.group_fsm_user").id,
-                        ],
-                    )
-                ],
-            }
-        )
-        # Set email on user's partner
-        self.fsm_user.partner_id.email = "fsm@example.com"
-        self.fsm_user.partner_id.lang = "en_US"  # Set language explicitly
-
-        self.customer = self.env["res.partner"].create(
-            {
-                "name": "Customer",
-                "email": "customer@example.com",
-                "lang": "en_US",  # Set language explicitly
-            }
-        )
-
-        # Create a project
-        self.project = self.env["project.project"].create(
-            {
-                "name": "Test FSM Project",
-                "is_fsm": True,
-                "company_id": self.env.user.company_id.id,
-            }
-        )
-
-        # Create stages for the project
-        self.stage_new = self.env["project.task.type"].create(
-            {
-                "name": "New",
-                "sequence": 0,
-                "project_ids": [(4, self.project.id)],
-            }
-        )
-
-        self.stage_needs_confirmation = self.env["project.task.type"].create(
-            {
-                "name": "Need Confirmation",
-                "sequence": 1,
-                "project_ids": [(4, self.project.id)],
-            }
-        )
-
-        self.stage_approved = self.env["project.task.type"].create(
-            {
-                "name": "Approved",
-                "sequence": 2,
-                "project_ids": [(4, self.project.id)],
-            }
-        )
-
-        self.stage_changes_requested = self.env["project.task.type"].create(
-            {
-                "name": "Changes Requested",
-                "sequence": 3,
-                "project_ids": [(4, self.project.id)],
-            }
-        )
-
-        # Create a task
-        self.task = self.env["project.task"].create(
+        # Create test task
+        task_model = self.env["project.task"]
+        self.task = task_model.create(
             {
                 "name": "Test Task",
                 "project_id": self.project.id,
                 "partner_id": self.customer.id,
-                "work_order_contacts": [(4, self.customer.id)],
-                "user_ids": [(4, self.fsm_user.id)],
-                "planned_date_begin": datetime.now() + timedelta(days=1),
                 "stage_id": self.stage_new.id,
-                "state": "01_in_progress",  # Using valid state value
             }
         )
-        self.assertEqual(
-            self.task.stage_id, self.stage_new, "Task should start in New stage"
-        )
 
-        # Ensure the task has an access token
-        if not self.task.access_token:
-            self.task._portal_ensure_token()
-        self.token = self.task.access_token
-        self.assertTrue(self.token, "Task should have an access token")
+        # Generate access token for the task
+        self.token = self.task._portal_ensure_token()
+        self.task.invalidate_recordset()
 
     def test_01_task_approve_flow(self):
         """Test the complete task approval flow"""
@@ -171,16 +118,25 @@ class TestFSMVisitConfirmation(HttpCase):
             [
                 ("model", "=", "project.task"),
                 ("res_id", "=", self.task.id),
-                ("body", "ilike", "Visit approved by customer"),
-            ]
+                ("body", "ilike", "approved"),
+            ],
+            limit=1,
         )
-        self.assertTrue(messages, "A message should be posted on the task")
+        self.assertTrue(
+            messages, "A message with 'approved' should be posted on the task"
+        )
 
-    def test_03_stage_approved_sends_email(self):
-        """Test that moving a task to the approved stage sends an email"""
-        # Set the approval template on the approved stage
-        template = self.env.ref(
-            "fsm_visit_confirmation.fsm_visit_confirmation_email_template"
+    def test_02_email_sent_on_stage_change(self):
+        """Test that email is sent when task moves to approved stage"""
+        # Create email template
+        template_model = self.env["mail.template"]
+        template = template_model.create(
+            {
+                "name": "Test Approval Template",
+                "model_id": self.env["ir.model"]._get("project.task").id,
+                "subject": "Test Subject",
+                "body_html": "<p>Test Body</p>",
+            }
         )
         self.stage_approved.approval_template_id = template
 
@@ -201,7 +157,7 @@ class TestFSMVisitConfirmation(HttpCase):
         new_mail = self.env["mail.mail"].search([], order="id desc", limit=1)
         self.assertEqual(new_mail.email_to, self.customer.email)
 
-    def test_02_task_request_changes_flow(self):
+    def test_03_task_request_changes_flow(self):
         """Test the complete task request changes flow"""
         from odoo.addons.fsm_visit_confirmation.controllers.main import CustomerPortalExtended
         from odoo.addons.website.tools import MockRequest
@@ -232,7 +188,7 @@ class TestFSMVisitConfirmation(HttpCase):
         self.task.invalidate_recordset()
         self.assertEqual(
             self.task.state,
-            "02_changes_requested",
+            "05_changes_requested",
             "Task state should be updated to changes requested",
         )
 
@@ -241,37 +197,59 @@ class TestFSMVisitConfirmation(HttpCase):
             [
                 ("model", "=", "project.task"),
                 ("res_id", "=", self.task.id),
-                ("body", "ilike", "Need some changes"),
-            ]
+                ("body", "ilike", feedback),
+            ],
+            limit=1,
         )
         self.assertTrue(
             messages, "A message with feedback should be posted on the task"
         )
 
-    def test_04_water_shutdown_field_exists(self):
-        """Test that water_shutdown_required and water_shutdown_notes fields exist"""
-        self.assertFalse(self.task.water_shutdown_required, "Default should be False")
-        self.assertFalse(self.task.water_shutdown_notes, "Default notes should be empty")
-
-    def test_05_water_shutdown_field_write(self):
-        """Test that water_shutdown fields can be written"""
-        self.task.write({
-            "water_shutdown_required": True,
-            "water_shutdown_notes": "Water will be off for approximately 2 hours",
+    def test_04_client_requirement_model_exists(self):
+        """Test that fsm.task.client.requirement model exists and can be used"""
+        requirement_model = self.env["fsm.task.client.requirement"]
+        
+        # Create a requirement
+        requirement = requirement_model.create({
+            "name": "Test Requirement",
+            "description": "This is a test requirement description",
         })
-        self.assertTrue(self.task.water_shutdown_required, "Should be True after write")
-        self.assertEqual(
-            self.task.water_shutdown_notes,
-            "Water will be off for approximately 2 hours",
-            "Notes should match",
-        )
+        
+        self.assertTrue(requirement.id, "Requirement should be created successfully")
+        self.assertEqual(requirement.name, "Test Requirement", "Name should match")
+        self.assertEqual(requirement.description, "This is a test requirement description", "Description should match")
+        self.assertTrue(requirement.active, "Should be active by default")
 
-    def test_06_water_shutdown_email_content(self):
-        """Test that water shutdown info appears in confirmation email"""
-        # Set water shutdown on the task
+    def test_05_task_client_requirements_field(self):
+        """Test that client_requirement_ids field exists on project.task"""
+        # Create requirements
+        requirement_model = self.env["fsm.task.client.requirement"]
+        req1 = requirement_model.create({"name": "Water Shutdown Required"})
+        req2 = requirement_model.create({"name": "Power Shutdown Required"})
+        
+        # Assign requirements to task
         self.task.write({
-            "water_shutdown_required": True,
-            "water_shutdown_notes": "Approximately 1 hour",
+            "client_requirement_ids": [(6, 0, [req1.id, req2.id])],
+            "client_requirements_notes": "Water off for 2 hours",
+        })
+        
+        self.assertIn(req1, self.task.client_requirement_ids, "Req1 should be in task requirements")
+        self.assertIn(req2, self.task.client_requirement_ids, "Req2 should be in task requirements")
+        self.assertEqual(self.task.client_requirements_notes, "Water off for 2 hours", "Notes should match")
+
+    def test_06_client_requirements_email_content(self):
+        """Test that client requirements appear in confirmation email"""
+        # Create a requirement
+        requirement_model = self.env["fsm.task.client.requirement"]
+        req = requirement_model.create({
+            "name": "Water Shutdown Required",
+            "description": "You will not have water during this service visit.",
+        })
+        
+        # Set requirements on the task
+        self.task.write({
+            "client_requirement_ids": [(6, 0, [req.id])],
+            "client_requirements_notes": "Approximately 1 hour",
         })
 
         # Set the approval template on the approved stage
@@ -286,16 +264,17 @@ class TestFSMVisitConfirmation(HttpCase):
         # Find the generated mail
         new_mail = self.env["mail.mail"].search([], order="id desc", limit=1)
         
-        # Verify water shutdown notice appears in email body
-        self.assertIn("Water Shutdown Notice", new_mail.body_html, "Email should contain water shutdown notice")
-        self.assertIn("You will not have water", new_mail.body_html, "Email should contain water shutdown message")
-        self.assertIn("Approximately 1 hour", new_mail.body_html, "Email should contain water shutdown notes")
+        # Verify client requirements notice appears in email body
+        self.assertIn("Important Requirements for Your Visit", new_mail.body_html, "Email should contain requirements header")
+        self.assertIn("Water Shutdown Required", new_mail.body_html, "Email should contain requirement name")
+        self.assertIn("You will not have water", new_mail.body_html, "Email should contain requirement description")
+        self.assertIn("Approximately 1 hour", new_mail.body_html, "Email should contain notes")
 
-    def test_07_water_shutdown_no_email_when_false(self):
-        """Test that water shutdown notice does NOT appear when not required"""
-        # Ensure water_shutdown_required is False
+    def test_07_no_requirements_no_email_section(self):
+        """Test that requirements section does NOT appear when no requirements set"""
+        # Ensure no requirements on the task
         self.task.write({
-            "water_shutdown_required": False,
+            "client_requirement_ids": [(6, 0, [])],
         })
 
         # Set the approval template on the approved stage
@@ -310,5 +289,41 @@ class TestFSMVisitConfirmation(HttpCase):
         # Find the generated mail
         new_mail = self.env["mail.mail"].search([], order="id desc", limit=1)
         
-        # Verify water shutdown notice does NOT appear in email body
-        self.assertNotIn("Water Shutdown Notice", new_mail.body_html, "Email should NOT contain water shutdown notice when not required")
+        # Verify requirements section does NOT appear in email body
+        self.assertNotIn("Important Requirements for Your Visit", new_mail.body_html, "Email should NOT contain requirements section when no requirements")
+
+    def test_08_multiple_requirements_display(self):
+        """Test that multiple requirements display correctly in email"""
+        # Create multiple requirements
+        requirement_model = self.env["fsm.task.client.requirement"]
+        req1 = requirement_model.create({
+            "name": "Water Shutdown Required",
+            "description": "Water will be off for 2 hours.",
+        })
+        req2 = requirement_model.create({
+            "name": "Power Shutdown Required",
+            "description": "Power will be interrupted briefly.",
+        })
+        
+        # Set requirements on the task
+        self.task.write({
+            "client_requirement_ids": [(6, 0, [req1.id, req2.id])],
+        })
+
+        # Set the approval template on the approved stage
+        template = self.env.ref(
+            "fsm_visit_confirmation.fsm_visit_confirmation_email_template"
+        )
+        self.stage_approved.approval_template_id = template
+
+        # Move task to approved stage (triggers email)
+        self.task.write({"stage_id": self.stage_approved.id})
+
+        # Find the generated mail
+        new_mail = self.env["mail.mail"].search([], order="id desc", limit=1)
+        
+        # Verify both requirements appear in email
+        self.assertIn("Water Shutdown Required", new_mail.body_html, "Email should contain first requirement")
+        self.assertIn("Power Shutdown Required", new_mail.body_html, "Email should contain second requirement")
+        self.assertIn("Water will be off for 2 hours", new_mail.body_html, "Email should contain first requirement description")
+        self.assertIn("Power will be interrupted briefly", new_mail.body_html, "Email should contain second requirement description")

--- a/fsm_visit_confirmation/views/fsm_task_client_requirement_views.xml
+++ b/fsm_visit_confirmation/views/fsm_task_client_requirement_views.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- List view for fsm.task.client.requirement -->
+    <record id="fsm_task_client_requirement_tree" model="ir.ui.view">
+        <field name="name">fsm.task.client.requirement.tree</field>
+        <field name="model">fsm.task.client.requirement</field>
+        <field name="arch" type="xml">
+            <tree string="Client Requirements">
+                <field name="name"/>
+                <field name="description"/>
+                <field name="active"/>
+            </tree>
+        </field>
+    </record>
+
+    <!-- Form view for fsm.task.client.requirement -->
+    <record id="fsm_task_client_requirement_form" model="ir.ui.view">
+        <field name="name">fsm.task.client.requirement.form</field>
+        <field name="model">fsm.task.client.requirement</field>
+        <field name="arch" type="xml">
+            <form string="Client Requirement">
+                <sheet>
+                    <widget name="web_ribbon" title="Archived" bg_color="bg-secondary" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <div class="oe_title">
+                        <label for="name" string="Requirement Name"/>
+                        <h1><field name="name" placeholder="e.g., Water Shutdown Required"/></h1>
+                    </div>
+                    <group>
+                        <field name="active" invisible="1"/>
+                        <field name="description" placeholder="Additional information shown to the client when this requirement applies..."/>
+                        <field name="color" widget="color_picker"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <!-- Action and menu entry (accessible via FSM Configuration) -->
+    <record id="fsm_task_client_requirement_action" model="ir.actions.act_window">
+        <field name="name">Client Requirements</field>
+        <field name="res_model">fsm.task.client.requirement</field>
+        <field name="view_mode">tree,form</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                No client requirements defined yet.
+            </p><p>
+                Client requirements are shown in visit confirmation emails.
+                Create requirements like "Water Shutdown Required" here.
+            </p>
+        </field>
+    </record>
+
+    <!-- Menu item under FSM Configuration -->
+    <menuitem
+        id="fsm_task_client_requirement_menu"
+        name="Client Requirements"
+        parent="industry_fsm.menu_fsm_config"
+        action="fsm_task_client_requirement_action"
+        sequence="30"/>
+</odoo>

--- a/fsm_visit_confirmation/views/fsm_task_client_requirement_views.xml
+++ b/fsm_visit_confirmation/views/fsm_task_client_requirement_views.xml
@@ -5,11 +5,11 @@
         <field name="name">fsm.task.client.requirement.tree</field>
         <field name="model">fsm.task.client.requirement</field>
         <field name="arch" type="xml">
-            <tree string="Client Requirements">
+            <list string="Client Requirements">
                 <field name="name"/>
                 <field name="description"/>
                 <field name="active"/>
-            </tree>
+            </list>
         </field>
     </record>
 
@@ -20,7 +20,7 @@
         <field name="arch" type="xml">
             <form string="Client Requirement">
                 <sheet>
-                    <widget name="web_ribbon" title="Archived" bg_color="bg-secondary" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="bg-secondary" invisible="active == True"/>
                     <div class="oe_title">
                         <label for="name" string="Requirement Name"/>
                         <h1><field name="name" placeholder="e.g., Water Shutdown Required"/></h1>
@@ -39,7 +39,7 @@
     <record id="fsm_task_client_requirement_action" model="ir.actions.act_window">
         <field name="name">Client Requirements</field>
         <field name="res_model">fsm.task.client.requirement</field>
-        <field name="view_mode">tree,form</field>
+        <field name="view_mode">list,form</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 No client requirements defined yet.
@@ -54,7 +54,7 @@
     <menuitem
         id="fsm_task_client_requirement_menu"
         name="Client Requirements"
-        parent="industry_fsm.menu_fsm_config"
+        parent="industry_fsm.fsm_menu_settings"
         action="fsm_task_client_requirement_action"
         sequence="30"/>
 </odoo>

--- a/fsm_visit_confirmation/views/project_task_views.xml
+++ b/fsm_visit_confirmation/views/project_task_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_task_form_inherit_fsm_visit_confirmation" model="ir.ui.view">
+        <field name="name">project.task.form.inherit.fsm.visit.confirmation</field>
+        <field name="model">project.task</field>
+        <field name="inherit_id" ref="industry_fsm.view_task_form2_inherit"/>
+        <field name="arch" type="xml">
+            <!-- Add water shutdown fields in the extra_info page, after partner_id -->
+            <xpath expr="//page[@name='extra_info']//field[@name='partner_id']" position="after">
+                <group string="Visit Notifications" name="visit_notifications" groups="industry_fsm.group_fsm_manager">
+                    <field name="water_shutdown_required"/>
+                    <field name="water_shutdown_notes" attrs="{'invisible': [('water_shutdown_required', '=', False)]}"/>
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/fsm_visit_confirmation/views/project_task_views.xml
+++ b/fsm_visit_confirmation/views/project_task_views.xml
@@ -5,11 +5,11 @@
         <field name="model">project.task</field>
         <field name="inherit_id" ref="industry_fsm.view_task_form2_inherit"/>
         <field name="arch" type="xml">
-            <!-- Add water shutdown fields in the extra_info page, after partner_id -->
+            <!-- Add client requirements in the extra_info page, after partner_id -->
             <xpath expr="//page[@name='extra_info']//field[@name='partner_id']" position="after">
-                <group string="Visit Notifications" name="visit_notifications" groups="industry_fsm.group_fsm_manager">
-                    <field name="water_shutdown_required"/>
-                    <field name="water_shutdown_notes" attrs="{'invisible': [('water_shutdown_required', '=', False)]}"/>
+                <group string="Client Requirements" name="client_requirements" groups="industry_fsm.group_fsm_manager">
+                    <field name="client_requirement_ids" widget="many2many_tags" placeholder="Select client requirements..."/>
+                    <field name="client_requirements_notes" placeholder="Additional notes about requirements (duration, timing, etc.)"/>
                 </group>
             </xpath>
         </field>

--- a/fsm_visit_confirmation/views/project_task_views.xml
+++ b/fsm_visit_confirmation/views/project_task_views.xml
@@ -5,8 +5,8 @@
         <field name="model">project.task</field>
         <field name="inherit_id" ref="industry_fsm.view_task_form2_inherit"/>
         <field name="arch" type="xml">
-            <!-- Add client requirements in the extra_info page, after partner_id -->
-            <xpath expr="//page[@name='extra_info']//field[@name='partner_id']" position="after">
+            <!-- Add client requirements after the partner phone block added by industry_fsm -->
+            <xpath expr="//div[@name='partner_phone']" position="after">
                 <group string="Client Requirements" name="client_requirements" groups="industry_fsm.group_fsm_manager">
                     <field name="client_requirement_ids" widget="many2many_tags" placeholder="Select client requirements..."/>
                     <field name="client_requirements_notes" placeholder="Additional notes about requirements (duration, timing, etc.)"/>


### PR DESCRIPTION
## Summary
- Re-applies the extensible client requirements feature for FSM visit confirmation emails (previously merged in #30, then reverted)
- Adds `fsm.task.client.requirement` model for reusable requirement types (e.g., "Water Shutdown Required")
- Adds `client_requirement_ids` many2many and `client_requirements_notes` fields on tasks
- Includes requirements in the confirmation email template with a styled warning box
- Security: users can read, FSM managers have full CRUD
- Tests for requirement display in emails

Closes task 1657

## Test plan
- [ ] Install/upgrade `fsm_visit_confirmation` module
- [ ] Create a client requirement via FSM > Configuration > Client Requirements
- [ ] Assign requirement to a task, move task to a stage with an approval template
- [ ] Verify confirmation email includes the yellow requirements box
- [ ] Verify email omits the requirements section when none are set
- [ ] Run `--test-tags fsm_visit_confirmation` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)