### PR TITLE
feat(odoo_herd): add demo data option to instance creation

### DIFF
--- a/odoo_herd/models/k8s_odoo_instance_template.py
+++ b/odoo_herd/models/k8s_odoo_instance_template.py
@@ -33,6 +33,12 @@ class K8sOdooInstanceTemplate(models.Model):
     filestore_storage_class = fields.Char(required=True)
 
     # Database Initialization Defaults
+    default_install_demo_data = fields.Boolean(
+        string="Install Demo Data",
+        default=False,
+        help="Default setting for installing demo data on instances created from this template",
+    )
+
     default_initialization_mode = fields.Selection(
         [("fresh", "Fresh Database"), ("restore", "Restore from Backup")],
         string="Default Initialization Mode",
@@ -57,6 +63,7 @@ class K8sOdooInstanceTemplate(models.Model):
             "memory_limit": self.memory_limit,
             "database_cluster": self.database_cluster,
             "initialization_mode": self.default_initialization_mode,
+            "install_demo_data": self.default_install_demo_data,
         }
 
         # Keep config_options as formatted JSON string

--- a/odoo_herd/views/k8s_odoo_instance_template_views.xml
+++ b/odoo_herd/views/k8s_odoo_instance_template_views.xml
@@ -97,6 +97,7 @@
                             <group>
                                 <group>
                                     <field name="default_initialization_mode"/>
+                                    <field name="default_install_demo_data"/>
                                 </group>
                             </group>
                             <separator string="Additional Config Options (JSON)"/>

--- a/odoo_herd/wizards/k8s_create_instance_wizard.py
+++ b/odoo_herd/wizards/k8s_create_instance_wizard.py
@@ -64,6 +64,12 @@ class K8sCreateInstanceWizard(models.TransientModel):
         help="How to initialize the database",
     )
 
+    install_demo_data = fields.Boolean(
+        string="Install Demo Data",
+        default=False,
+        help="Install demo data during database initialization",
+    )
+
     # Restore from Odoo instance options (only shown when mode is restore)
     restore_url = fields.Char(
         string="Source Odoo URL",
@@ -290,7 +296,11 @@ class K8sCreateInstanceWizard(models.TransientModel):
         # Database initialization - the operator auto-creates an OdooInitJob
         # when init.enabled is true (default). Disable for restore modes.
         if self.initialization_mode == "fresh":
-            instance_spec["init"] = {"enabled": True, "modules": ["base"]}
+            instance_spec["init"] = {
+                "enabled": True,
+                "modules": ["base"],
+                "demo": self.install_demo_data,
+            }
         else:
             instance_spec["init"] = {"enabled": False}
 

--- a/odoo_herd/wizards/k8s_create_instance_wizard_views.xml
+++ b/odoo_herd/wizards/k8s_create_instance_wizard_views.xml
@@ -47,6 +47,12 @@
                         </group>
                     </group>
                     
+                    <group invisible="initialization_mode != 'fresh'">
+                        <group>
+                            <field name="install_demo_data"/>
+                        </group>
+                    </group>
+
                     <div class="alert alert-info" role="alert" invisible="initialization_mode != 'fresh'">
                         <p><strong>Fresh Database:</strong></p>
                         <ul>


### PR DESCRIPTION
Add install_demo_data checkbox to the create instance wizard (visible in Fresh Database mode) and a default_install_demo_data field on instance templates. The flag is passed as `demo` in the init spec for the operator to handle.