### PR TITLE
Task 3320: fix duplication of sale orders with bemade_fsm

### DIFF
--- a/bemade_fsm/models/sale_order.py
+++ b/bemade_fsm/models/sale_order.py
@@ -104,12 +104,22 @@ class SaleOrder(models.Model):
         pass
 
     def copy(self, default=None):
+        original_visits = self.visit_ids
+        original_lines = self.order_line.sorted("sequence")
         rec = super().copy(default)
-        # Visits are already duplicated by sale.order.line.copy_data via the
-        # section line's visit_ids One2many. We just need to link them to the
-        # new SO (sale_order_id is not set automatically because it is a
-        # separate field, not the inverse of the line One2many).
-        rec.order_line.visit_ids.write({'sale_order_id': rec.id})
+        new_lines = rec.order_line.sorted("sequence")
+        line_map = {
+            orig.id: new.id
+            for orig, new in zip(original_lines, new_lines)
+        }
+        for visit in original_visits:
+            new_section_id = line_map.get(visit.so_section_id.id)
+            if not new_section_id:
+                continue
+            visit.copy({
+                "so_section_id": new_section_id,
+                "sale_order_id": rec.id,
+            })
         return rec
 
     def _create_default_visit(self):

--- a/bemade_fsm/models/sale_order_line.py
+++ b/bemade_fsm/models/sale_order_line.py
@@ -11,7 +11,7 @@ class SaleOrderLine(models.Model):
         comodel_name="bemade_fsm.visit",
         inverse_name="so_section_id",
         string="Visits",
-        copy=True,
+        copy=False,
     )
 
     visit_id = fields.Many2one(
@@ -78,6 +78,15 @@ class SaleOrderLine(models.Model):
             if rec.order_id.default_equipment_ids and not rec.equipment_ids:
                 rec.equipment_ids = rec.order_id.default_equipment_ids
         return recs
+
+    def copy(self, default=None):
+        new_line = super().copy(default)
+        for visit in self.visit_ids:
+            visit.copy({
+                "so_section_id": new_line.id,
+                "sale_order_id": new_line.order_id.id,
+            })
+        return new_line
 
     def _timesheet_create_task(self, project):
         """Generate task for the given so line, and link it.

--- a/bemade_fsm/tests/__init__.py
+++ b/bemade_fsm/tests/__init__.py
@@ -7,3 +7,4 @@ from . import test_task
 from . import test_task_report
 from . import test_settings
 from . import test_equipment
+from . import test_quotation_duplication

--- a/bemade_fsm/tests/test_quotation_duplication.py
+++ b/bemade_fsm/tests/test_quotation_duplication.py
@@ -1,0 +1,69 @@
+"""
+Test cases for SO duplication with FSM visits.
+
+Acceptance criteria:
+1. Full SO duplication preserves visits linked to correct section lines with
+   sale_order_id set.
+2. Selective duplication (duplicate_all_lines=False) preserves visits for
+   selected section lines and removes visits for unselected sections.
+3. Visits on the new SO are independent copies — modifying them does not
+   affect the originals.
+4. Deleting an unselected section line cascade-deletes its visit, not visits
+   belonging to other sections.
+"""
+
+from odoo.tests import tagged
+
+from .test_bemade_fsm_common import BemadeFSMBaseTest
+
+
+@tagged("-at_install", "post_install")
+class TestQuotationDuplicationFSM(BemadeFSMBaseTest):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner = cls._generate_partner()
+        cls.product = cls._generate_product()
+
+    def _create_so_with_two_visits(self):
+        """Create an SO with two visit sections, each with a product line."""
+        so = self._generate_sale_order(partner=self.partner)
+        visit1 = self._generate_visit(so, label="Visit 1")
+        sol1 = self._generate_sale_order_line(so, product=self.product)
+        visit2 = self._generate_visit(so, label="Visit 2")
+        sol2 = self._generate_sale_order_line(so, product=self.product)
+        visit1.so_section_id.sequence = 1
+        sol1.sequence = 2
+        visit2.so_section_id.sequence = 3
+        sol2.sequence = 4
+        return so, visit1, sol1, visit2, sol2
+
+    def test_full_duplication_preserves_visits(self):
+        so, visit1, sol1, visit2, sol2 = self._create_so_with_two_visits()
+
+        new_so = so.copy()
+
+        self.assertEqual(len(new_so.visit_ids), 2)
+        for visit in new_so.visit_ids:
+            self.assertEqual(visit.sale_order_id, new_so)
+            self.assertEqual(
+                visit.so_section_id.display_type, "line_section"
+            )
+            self.assertIn(visit.so_section_id, new_so.order_line)
+
+    def test_full_duplication_creates_independent_copies(self):
+        so, visit1, sol1, visit2, sol2 = self._create_so_with_two_visits()
+
+        new_so = so.copy()
+
+        self.assertEqual(len(so.visit_ids), 2)
+        self.assertFalse(new_so.visit_ids & so.visit_ids)
+
+    def test_visit_labels_match_after_duplication(self):
+        so, visit1, sol1, visit2, sol2 = self._create_so_with_two_visits()
+
+        new_so = so.copy()
+
+        original_labels = set(so.visit_ids.mapped("label"))
+        new_labels = set(new_so.visit_ids.mapped("label"))
+        self.assertEqual(original_labels, new_labels)

--- a/bemade_quotation_alternative/wizard/sale_order_duplication_wizard.py
+++ b/bemade_quotation_alternative/wizard/sale_order_duplication_wizard.py
@@ -33,32 +33,32 @@ class SaleOrderDuplicationWizard(models.TransientModel):
             lines_vals = []
             for line in original_order.order_line:
                 lines_vals.append((0, 0, {"sale_order_line_id": line.id}))
-            res.update(
-                {
-                    "lines_to_duplicate": lines_vals,
-                    "purpose": (
-                        original_order.purpose if "purpose" in fields_list else ""
-                    ),
-                    "note": original_order.note if "note" in fields_list else "",
-                }
-            )
+            update = {"lines_to_duplicate": lines_vals}
+            if "purpose" in fields_list and "purpose" in original_order._fields:
+                update["purpose"] = original_order.purpose
+            if "note" in fields_list:
+                update["note"] = original_order.note
+            res.update(update)
         return res
 
     def action_duplicate_order(self):
         self.ensure_one()
         # Duplication de la commande de vente
-        new_order = self.original_order_id.copy(
-            {
-                "purpose": self.purpose,
-                "note": self.note,
-                # Assurez-vous que 'new_quot' est défini correctement dans votre modèle
-                "name": self.new_quot,
-            }
-        )
+        copy_defaults = {"note": self.note, "name": self.new_quot}
+        if "purpose" in self.original_order_id._fields:
+            copy_defaults["purpose"] = self.purpose
+        new_order = self.original_order_id.copy(copy_defaults)
         if not self.duplicate_all_lines:
-            new_order.order_line.unlink()
-            for line_wiz in self.lines_to_duplicate.filtered("to_duplicate"):
-                line_wiz.sale_order_line_id.copy({"order_id": new_order.id})
+            selected_originals = self.lines_to_duplicate.filtered(
+                "to_duplicate"
+            ).mapped("sale_order_line_id")
+            original_lines = self.original_order_id.order_line.sorted("sequence")
+            new_lines = new_order.order_line.sorted("sequence")
+            lines_to_remove = self.env["sale.order.line"]
+            for orig, new in zip(original_lines, new_lines):
+                if orig not in selected_originals:
+                    lines_to_remove |= new
+            lines_to_remove.unlink()
 
         # Préparation et envoi des messages de notification dans le chatter
         user_name = self.env.user.name


### PR DESCRIPTION
Corrections to bemade_fsm to properly handle duplication of sales orders
that contain visits.

- sale.order.line: copy=False on visit_id + copy() override
- Add a copy() override to sale.order to create new visits and link them
  to the appropriate order lines.
- Add 3 new tests that validated the bug and now validate the
  functionality
