### PR TITLE
fix(mail_composer_from_selector): tree → list, add CI registry check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,3 +104,13 @@ jobs:
             --test-enable \
             --http-interface=127.0.0.1 \
             --stop-after-init 2>&1 | tee test-output.log
+      - name: Check for errors
+        if: always()
+        run: |
+          # Strip ANSI color codes before checking
+          sed 's/\x1b\[[0-9;]*m//g' test-output.log > test-output-clean.log
+          if grep -q "Failed to load registry" test-output-clean.log; then
+            echo "::error::Registry failed to load:"
+            grep "Failed to load registry" test-output-clean.log
+            exit 1
+          fi

--- a/mail_composer_from_selector/views/mail_from_address_views.xml
+++ b/mail_composer_from_selector/views/mail_from_address_views.xml
@@ -52,7 +52,7 @@
     <!-- Menu Item under Settings -->
     <menuitem id="mail_from_address_menu"
               name="From Addresses"
-              parent="base.menu_email_servers"
+              parent="base.menu_email"
               action="mail_from_address_action"
               groups="base.group_system"/>
 </odoo>

--- a/mail_composer_from_selector/views/mail_from_address_views.xml
+++ b/mail_composer_from_selector/views/mail_from_address_views.xml
@@ -7,12 +7,12 @@
         <field name="name">mail.from.address.view.tree</field>
         <field name="model">mail.from.address</field>
         <field name="arch" type="xml">
-            <tree string="Authorized From Addresses">
+            <list string="Authorized From Addresses">
                 <field name="sequence" widget="handle"/>
                 <field name="name"/>
                 <field name="email"/>
                 <field name="active" widget="boolean_toggle"/>
-            </tree>
+            </list>
         </field>
     </record>
 
@@ -46,7 +46,7 @@
     <record model="ir.actions.act_window" id="mail_from_address_action">
         <field name="name">Authorized From Addresses</field>
         <field name="res_model">mail.from.address</field>
-        <field name="view_mode">tree,form</field>
+        <field name="view_mode">list,form</field>
     </record>
 
     <!-- Menu Item under Settings -->


### PR DESCRIPTION
## Summary
- Replace `<tree>` with `<list>` in mail_from_address_views.xml (invalid since Odoo 18.0)
- Add CI step to detect registry load failures, which were silently swallowed because `odoo --stop-after-init` exits 0 even on CRITICAL errors

This is what caused the Durpro 18.0-staging pipeline to fail after merging PR #41.