### PR TITLE
fix(product_pricelist_supplierinfo_chatter): add price_discounted to views

### DIFF
--- a/product_pricelist_supplierinfo_chatter/views/supplierinfo_pricelist.xml
+++ b/product_pricelist_supplierinfo_chatter/views/supplierinfo_pricelist.xml
@@ -10,6 +10,9 @@
                 <xpath expr="//list" position="attributes">
                     <attribute name="editable"></attribute>
                 </xpath>
+                <xpath expr="//field[@name='discount']" position="after">
+                    <field name="price_discounted" optional="show"/>
+                </xpath>
             </field>
         </record>
 
@@ -18,6 +21,9 @@
             <field name="model">product.supplierinfo</field>
             <field name="inherit_id" ref="product.product_supplierinfo_form_view" />
             <field name="arch" type="xml">
+                <xpath expr="//field[@name='discount']" position="after">
+                    <field name="price_discounted" readonly="1"/>
+                </xpath>
                 <xpath expr="//sheet" position="after">
                     <chatter />
                 </xpath>


### PR DESCRIPTION
## Summary
- Adds the `price_discounted` computed field to the supplier info tree view (with `optional="show"`) and form view (readonly), placed after the `discount` field in both.
- Resolves task #1731.

## Test plan
- [ ] Open a product form, go to the Purchase tab, confirm `price_discounted` column appears in the supplier pricelist list view after `discount`.
- [ ] Click "View" on a supplier pricelist line, confirm `price_discounted` appears in the form view after `discount`.
- [ ] Verify the computed value matches `price * (1 - discount/100)`.