### PR TITLE
fix(product_supplierinfo_tracking): correct XML ID for supplierinfo list view

### DIFF
--- a/product_supplierinfo_tracking/views/product_view.xml
+++ b/product_supplierinfo_tracking/views/product_view.xml
@@ -4,7 +4,7 @@
     <record id="product_supplierinfo_list_view_discounted" model="ir.ui.view">
         <field name="name">product.supplierinfo.list.view.discounted</field>
         <field name="model">product.supplierinfo</field>
-        <field name="inherit_id" ref="product.product_supplierinfo_list_view" />
+        <field name="inherit_id" ref="product.product_supplierinfo_tree_view" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='discount']" position="after">
                 <field name="price_discounted" string="Discounted Price" optional="show"/>


### PR DESCRIPTION
## Summary
- Fixes `ValueError: External ID not found in the system: product.product_supplierinfo_list_view` on Odoo 19
- The correct XML ID is `product.product_supplierinfo_tree_view` (unchanged from Odoo 18)
- Broke RWI CI pipeline #2820 after task #3336 merge

## Test plan
- [ ] CI passes on RWI after submodule update