### PR TITLE
fix(mail_composer_from_selector): test isolation and company-aware lookup

### DIFF
--- a/mail_composer_from_selector/models/mail_from_address.py
+++ b/mail_composer_from_selector/models/mail_from_address.py
@@ -59,6 +59,7 @@ class MailFromAddress(models.Model):
         # Get addresses either with no user restriction or with the user in the list
         domain = [
             ("active", "=", True),
+            ("company_id", "in", [False, self.env.company.id]),
             "|",
             ("user_ids", "=", False),
             ("user_ids", "in", [user.id]),

--- a/mail_composer_from_selector/tests/test_mail_compose_message.py
+++ b/mail_composer_from_selector/tests/test_mail_compose_message.py
@@ -16,6 +16,8 @@ class TestMailComposeMessage(common.TransactionCase):
             'name': 'Test Partner',
             'email': 'partner@test.com',
         })
+        # Archive all pre-existing From addresses for test isolation
+        self.MailFromAddress.search([]).write({'active': False})
         # Create test From addresses
         self.from_addr_1 = self.MailFromAddress.create({
             'name': 'Support',

--- a/mail_composer_from_selector/wizards/mail_compose_message.py
+++ b/mail_composer_from_selector/wizards/mail_compose_message.py
@@ -1,7 +1,7 @@
 # Copyright 2025 Bemade Inc.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class MailComposeMessage(models.TransientModel):
@@ -16,6 +16,7 @@ class MailComposeMessage(models.TransientModel):
         store=True,
     )
 
+    @api.depends("composition_mode")
     def _compute_from_address_id(self):
         """Set default From address if the user has exactly one allowed address."""
         for composer in self:


### PR DESCRIPTION
## Summary
- Archive all pre-existing `mail.from.address` records in test setUp so other modules' data doesn't interfere with auto-selection count
- Add `company_id` filter to `_get_allowed_addresses()` domain — addresses should be scoped to the current company
- Add missing `@api.depends("composition_mode")` decorator on `_compute_from_address_id` so the compute triggers correctly on create

Fixes 3 consecutive CI failures on durpro 18.0-staging (pipelines #2815, #2819, #2821).

## Test plan
- [ ] CI passes on bemade-addons 18.0
- [ ] After merge + submodule update, durpro 18.0-staging CI passes