### PR TITLE
feat(bemade_partner_address_ranking): favorite + usage-rank default addresses on sale orders (task #2895)

### DIFF
--- a/bemade_partner_address_ranking/README.rst
+++ b/bemade_partner_address_ranking/README.rst
@@ -1,0 +1,95 @@
+==============================
+Partner Address Ranking
+==============================
+
+.. |badge1| image:: https://img.shields.io/badge/licence-LGPL--3-blue.png
+    :target: http://www.gnu.org/licenses/lgpl-3.0-standalone.html
+    :alt: License: LGPL-3
+
+|badge1|
+
+**Description**
+---------------
+
+This module ranks a company's child addresses on sales orders by usage history
+and allows explicit favorite overrides for invoice and delivery addresses.
+
+Features:
+
+* **Favorite flags** — ``is_favorite_invoice`` and ``is_favorite_delivery``
+  checkboxes on child contact forms.  Only one contact per company per address
+  type may hold the flag (Python constraint).
+* **Usage-based ranking** — when no favorite is set, the address most
+  frequently used on *confirmed* or *done* sales orders for the company is
+  chosen first.  Draft and cancelled orders are excluded.
+* **Picker ordering** — the *Invoice Address* and *Delivery Address* Many2one
+  dropdowns on SO forms surface ranked addresses at the top of the list.
+* **Full fallback** — if there is no history and no favorite the module
+  delegates transparently to Odoo's stock ``address_get`` logic.
+* **Non-destructive** — uninstalling the module reverts all behavior.  No
+  usage counters are stored on partner records.
+
+**Configuration**
+-----------------
+
+No configuration is required.  Install the module and the behavior is
+active immediately for all companies.
+
+To mark a child contact as the default invoice address:
+
+1. Open the contact form of the child (e.g. *Billing Department*).
+2. Tick **Default invoice address**.
+3. Save.  An error is raised if another sibling already holds the flag.
+
+**Usage**
+---------
+
+Create a new quotation or sales order.  The *Invoice Address* and *Delivery
+Address* fields are pre-filled according to:
+
+1. The favorite address for the address type (if one is set).
+2. The address most used on confirmed / done orders for the company.
+3. Odoo's built-in ``address_get`` result as the final fallback.
+
+Opening the address dropdown shows the same ranking at the top of the list.
+
+**Known issues / Roadmap**
+--------------------------
+
+* Usage ranking considers *any* contact type ever used in that slot, including
+  a generic ``type='contact'``.  This means a previously-used generic contact
+  can outrank a sibling explicitly typed ``invoice`` or ``delivery``.  The
+  behavior is intentional (history-based) but may surprise users who rely
+  heavily on ``type`` filtering.
+* Bulk-importing multiple contacts with ``is_favorite_*=True`` for the same
+  company in a single transaction will trip the constraint.  Clear the existing
+  favorite first.
+* Odoo 19 forward-port is out of scope for this module version.
+
+**Bug Tracker**
+---------------
+
+Bugs are tracked on `odoo.bemade.org <https://odoo.bemade.org>`_.
+In case of trouble, please check there if your issue has already been reported.
+
+**Credits**
+-----------
+
+Authors
+~~~~~~~
+
+* `Bemade Inc. <https://www.bemade.org>`_
+
+Contributors
+~~~~~~~~~~~~
+
+* Marc Durepos <marc@bemade.org>
+
+Maintainers
+~~~~~~~~~~~
+
+This module is maintained by Bemade Inc.
+
+.. image:: https://www.bemade.org/logo.png
+   :alt: Bemade Inc.
+   :target: https://www.bemade.org

--- a/bemade_partner_address_ranking/__init__.py
+++ b/bemade_partner_address_ranking/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2024 Bemade Inc. (<https://www.bemade.org>).
+# License LGPL-3 or later (http://www.gnu.org/licenses/lgpl).
+from . import models

--- a/bemade_partner_address_ranking/__manifest__.py
+++ b/bemade_partner_address_ranking/__manifest__.py
@@ -1,0 +1,45 @@
+# Copyright (C) 2024 Bemade Inc. (<https://www.bemade.org>).
+# License LGPL-3 or later (http://www.gnu.org/licenses/lgpl).
+{
+    "name": "Partner Address Ranking",
+    "version": "18.0.1.0.0",
+    "category": "Sales/CRM",
+    "summary": (
+        "Ranks company child addresses by usage on sales orders and allows"
+        " explicit favorite invoice/delivery address overrides."
+    ),
+    "description": """
+Partner Address Ranking
+=======================
+
+This module extends ``res.partner`` and ``sale.order`` to surface the most
+relevant invoice and delivery addresses for a company when creating a new sales
+order.
+
+Features
+--------
+
+* **Favorite flags** — any child contact of a company can be marked as the
+  default invoice or delivery address via two new checkboxes on the partner
+  form.  Only one contact per company per address type may hold the flag
+  (enforced by a Python constraint).
+* **Usage-based ranking** — when no favorite is set the module picks the
+  address most often used on confirmed / done sales orders for that company.
+* **Picker ordering** — the address Many2one dropdowns on sales orders show
+  favorite and high-usage addresses at the top of the list.
+* **Full fallback** — if no history and no favorite exists the module falls
+  back transparently to Odoo's stock ``address_get`` logic.
+* **Non-destructive** — uninstalling the module reverts all behavior; no
+  stored counters are added to partner records.
+    """,
+    "author": "Bemade Inc.",
+    "website": "https://www.bemade.org",
+    "license": "LGPL-3",
+    "depends": ["sale", "contacts"],
+    "data": [
+        "views/res_partner_views.xml",
+        "views/sale_order_views.xml",
+    ],
+    "installable": True,
+    "auto_install": False,
+}

--- a/bemade_partner_address_ranking/__manifest__.py
+++ b/bemade_partner_address_ranking/__manifest__.py
@@ -40,6 +40,11 @@ Features
         "views/res_partner_views.xml",
         "views/sale_order_views.xml",
     ],
+    "assets": {
+        "web.assets_tests": [
+            "bemade_partner_address_ranking/static/tests/tours/**/*",
+        ],
+    },
     "installable": True,
     "auto_install": False,
 }

--- a/bemade_partner_address_ranking/models/__init__.py
+++ b/bemade_partner_address_ranking/models/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (C) 2024 Bemade Inc. (<https://www.bemade.org>).
+# License LGPL-3 or later (http://www.gnu.org/licenses/lgpl).
+from . import res_partner
+from . import sale_order

--- a/bemade_partner_address_ranking/models/res_partner.py
+++ b/bemade_partner_address_ranking/models/res_partner.py
@@ -1,0 +1,191 @@
+# Copyright (C) 2024 Bemade Inc. (<https://www.bemade.org>).
+# License LGPL-3 or later (http://www.gnu.org/licenses/lgpl).
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+# Key used to store the per-request ranking cache on the cursor.
+_RANKING_CACHE_KEY = "bemade_partner_address_ranking"
+
+
+class Partner(models.Model):
+    _inherit = "res.partner"
+
+    is_favorite_invoice = fields.Boolean(
+        string="Default invoice address",
+        default=False,
+        help=(
+            "When set, this address is selected as the default invoice address"
+            " on new sales orders for the parent company, overriding"
+            " usage-based ranking."
+        ),
+    )
+    is_favorite_delivery = fields.Boolean(
+        string="Default delivery address",
+        default=False,
+        help=(
+            "When set, this address is selected as the default delivery address"
+            " on new sales orders for the parent company, overriding"
+            " usage-based ranking."
+        ),
+    )
+
+    @api.constrains("is_favorite_invoice", "is_favorite_delivery", "commercial_partner_id")
+    def _check_unique_favorite_per_company(self):
+        for partner in self:
+            for flag in ("is_favorite_invoice", "is_favorite_delivery"):
+                if not partner[flag]:
+                    continue
+                siblings = self.search_count(
+                    [
+                        ("commercial_partner_id", "=", partner.commercial_partner_id.id),
+                        (flag, "=", True),
+                        ("id", "!=", partner.id),
+                    ]
+                )
+                if siblings:
+                    raise ValidationError(
+                        _(
+                            "Only one contact per company can be marked as %s.",
+                            self._fields[flag].string,
+                        )
+                    )
+
+    # ------------------------------------------------------------------
+    # Public helper
+    # ------------------------------------------------------------------
+
+    def _get_ranked_address_ids(self, addr_type):
+        """Return a list of partner ids for *self* (a company or any partner)
+        ordered by:
+          1. Favorite flag for *addr_type* (0 or 1 entry).
+          2. Usage-count descending on confirmed/done sales orders.
+          3. Stock ``address_get`` fallback id.
+
+        Results are deduplicated and the list is memoised per
+        ``(commercial_partner_id, addr_type)`` on ``self.env.cr`` for the
+        lifetime of the current database cursor (i.e. one request / one test
+        transaction).  This avoids repeated ``_read_group`` calls when
+        ``name_search`` fires multiple times while the user types.
+
+        :param str addr_type: ``'invoice'`` or ``'delivery'``
+        :return: list of int (partner ids), highest-priority first.
+        """
+        commercial = self.commercial_partner_id
+        cache_key = (commercial.id, addr_type)
+        cache = getattr(self.env.cr, _RANKING_CACHE_KEY, None)
+        if cache is None:
+            cache = {}
+            setattr(self.env.cr, _RANKING_CACHE_KEY, cache)
+        if cache_key in cache:
+            return cache[cache_key]
+
+        result = self._compute_ranked_address_ids(commercial, addr_type)
+        cache[cache_key] = result
+        return result
+
+    @api.model
+    def _compute_ranked_address_ids(self, commercial, addr_type):
+        """Do the actual ranking computation (no caching layer)."""
+        # 1. Favorite id (at most one due to constraint)
+        flag = "is_favorite_invoice" if addr_type == "invoice" else "is_favorite_delivery"
+        favorite = self.search(
+            [
+                ("commercial_partner_id", "=", commercial.id),
+                (flag, "=", True),
+            ],
+            limit=1,
+        )
+        favorite_ids = [favorite.id] if favorite else []
+
+        # 2. Usage-ranked ids from confirmed/done SOs
+        so_field = "partner_invoice_id" if addr_type == "invoice" else "partner_shipping_id"
+        groups = self.env["sale.order"].sudo()._read_group(
+            domain=[
+                ("commercial_partner_id", "=", commercial.id),
+                (so_field, "!=", False),
+                ("state", "in", ("sale", "done")),
+            ],
+            groupby=[so_field],
+            aggregates=["__count"],
+            order="__count DESC",
+        )
+        ranked_ids = [g[0].id for g in groups]
+
+        # 3. Stock address_get fallback
+        fallback_id = commercial.address_get([addr_type])[addr_type]
+
+        # Merge: favorite first, then ranked, then fallback — deduplicated
+        seen = set()
+        ordered = []
+        for pid in favorite_ids + ranked_ids + [fallback_id]:
+            if pid not in seen:
+                seen.add(pid)
+                ordered.append(pid)
+
+        return ordered
+
+    # ------------------------------------------------------------------
+    # name_search override
+    # ------------------------------------------------------------------
+
+    @api.model
+    @api.readonly
+    def name_search(self, name="", args=None, operator="ilike", limit=100):
+        """Override to surface ranked / favorite addresses at the top of
+        Many2one dropdowns when the picker is opened in a company-address
+        context (i.e. when the SO view sets
+        ``context={'partner_address_ranking': True}`` on the field).
+
+        The explicit-context approach (Plan B from the design) is used
+        because it is the only reliable signal that distinguishes an SO
+        address picker from any other ``res.partner`` picker that happens to
+        filter by ``parent_id``.
+
+        Early-out: if the context key is absent we delegate to super()
+        unchanged, so global partner pickers are completely unaffected.
+        """
+        if not self.env.context.get("partner_address_ranking"):
+            return super().name_search(name=name, args=args, operator=operator, limit=limit)
+
+        addr_type = self.env.context.get("partner_address_ranking")
+        if addr_type not in ("invoice", "delivery"):
+            # Unrecognised value — fall back to default behaviour
+            return super().name_search(name=name, args=args, operator=operator, limit=limit)
+
+        # Run the standard search to respect the active text filter + domain.
+        base_results = super().name_search(name=name, args=args, operator=operator, limit=limit)
+        if not base_results:
+            return base_results
+
+        # Determine the commercial partner from context or from args.
+        commercial_id = self.env.context.get("default_commercial_partner_id")
+        if not commercial_id:
+            # Try to detect from args: ('parent_id', '=', X)
+            for leaf in (args or []):
+                if (
+                    isinstance(leaf, (list, tuple))
+                    and len(leaf) == 3
+                    and leaf[0] in ("parent_id", "commercial_partner_id")
+                    and leaf[1] in ("=", "child_of")
+                ):
+                    candidate = self.browse(leaf[2])
+                    commercial_id = candidate.commercial_partner_id.id
+                    break
+
+        if not commercial_id:
+            return base_results
+
+        commercial = self.browse(commercial_id)
+        ranked_ids = commercial._get_ranked_address_ids(addr_type)
+
+        # Reorder: ranked first (preserving relative rank), then the rest
+        result_dict = dict(base_results)  # {id: display_name}
+        ranked_in_results = [
+            (pid, result_dict[pid]) for pid in ranked_ids if pid in result_dict
+        ]
+        others = [pair for pair in base_results if pair[0] not in set(ranked_ids)]
+        reordered = ranked_in_results + others
+
+        # Honour limit
+        return reordered[:limit] if limit else reordered

--- a/bemade_partner_address_ranking/models/res_partner.py
+++ b/bemade_partner_address_ranking/models/res_partner.py
@@ -55,6 +55,25 @@ class Partner(models.Model):
     # Public helper
     # ------------------------------------------------------------------
 
+    def _invalidate_ranking_cache(self):
+        """Clear the per-cursor ranking cache for all commercial partners in
+        *self*.  Call this after any write that would change ranking results
+        (favorite flag change, SO confirmation, SO cancellation).
+        """
+        cache = getattr(self.env.cr, _RANKING_CACHE_KEY, None)
+        if cache is None:
+            return
+        for partner in self:
+            commercial_id = partner.commercial_partner_id.id
+            for addr_type in ("invoice", "delivery"):
+                cache.pop((commercial_id, addr_type), None)
+
+    def write(self, vals):
+        res = super().write(vals)
+        if vals.keys() & {"is_favorite_invoice", "is_favorite_delivery", "parent_id"}:
+            self._invalidate_ranking_cache()
+        return res
+
     def _get_ranked_address_ids(self, addr_type):
         """Return a list of partner ids for *self* (a company or any partner)
         ordered by:

--- a/bemade_partner_address_ranking/models/res_partner.py
+++ b/bemade_partner_address_ranking/models/res_partner.py
@@ -102,7 +102,7 @@ class Partner(models.Model):
         so_field = "partner_invoice_id" if addr_type == "invoice" else "partner_shipping_id"
         groups = self.env["sale.order"].sudo()._read_group(
             domain=[
-                ("commercial_partner_id", "=", commercial.id),
+                ("partner_id.commercial_partner_id", "=", commercial.id),
                 (so_field, "!=", False),
                 ("state", "in", ("sale", "done")),
             ],

--- a/bemade_partner_address_ranking/models/sale_order.py
+++ b/bemade_partner_address_ranking/models/sale_order.py
@@ -23,3 +23,11 @@ class SaleOrder(models.Model):
                 continue
             ranked = order.partner_id._get_ranked_address_ids("delivery")
             order.partner_shipping_id = ranked[0] if ranked else False
+
+    def write(self, vals):
+        res = super().write(vals)
+        # Invalidate the per-cursor ranking cache whenever SO confirmation
+        # state or address fields change, so subsequent calls re-compute.
+        if vals.keys() & {"state", "partner_invoice_id", "partner_shipping_id"}:
+            self.mapped("partner_id")._invalidate_ranking_cache()
+        return res

--- a/bemade_partner_address_ranking/models/sale_order.py
+++ b/bemade_partner_address_ranking/models/sale_order.py
@@ -1,0 +1,25 @@
+# Copyright (C) 2024 Bemade Inc. (<https://www.bemade.org>).
+# License LGPL-3 or later (http://www.gnu.org/licenses/lgpl).
+from odoo import api, models
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    @api.depends("partner_id")
+    def _compute_partner_invoice_id(self):
+        for order in self:
+            if not order.partner_id:
+                order.partner_invoice_id = False
+                continue
+            ranked = order.partner_id._get_ranked_address_ids("invoice")
+            order.partner_invoice_id = ranked[0] if ranked else False
+
+    @api.depends("partner_id")
+    def _compute_partner_shipping_id(self):
+        for order in self:
+            if not order.partner_id:
+                order.partner_shipping_id = False
+                continue
+            ranked = order.partner_id._get_ranked_address_ids("delivery")
+            order.partner_shipping_id = ranked[0] if ranked else False

--- a/bemade_partner_address_ranking/static/tests/tours/partner_address_ranking_tour.js
+++ b/bemade_partner_address_ranking/static/tests/tours/partner_address_ranking_tour.js
@@ -1,0 +1,100 @@
+// Copyright (C) 2024 Bemade Inc. (<https://www.bemade.org>).
+// License LGPL-3 or later (http://www.gnu.org/licenses/lgpl).
+/**
+ * Tour: partner_address_ranking_tour
+ *
+ * Exercises the SO form's partner_invoice_id and partner_shipping_id Many2one
+ * dropdowns end-to-end, asserting that:
+ *  - The favorite invoice contact (C_inv2) is first in the invoice dropdown.
+ *  - The most-used delivery contact (C_ship1) is first in the delivery dropdown.
+ *
+ * Data is seeded by TestFormWidgetTour.setUpClass in test_form_widget_tour.py.
+ * The company name "TourCo", contact names "TourInv2 (fav)", and "TourShip1"
+ * are expected to be pre-created by that Python setUp.
+ */
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("partner_address_ranking_tour", {
+    url: "/odoo/sales",
+    steps: () => [
+        // ----------------------------------------------------------------
+        // Step 1: Go to the Sales app and create a new quotation
+        // ----------------------------------------------------------------
+        {
+            content: "Wait for the Sales quotation list to load",
+            trigger: ".o_sale_order",
+        },
+        {
+            content: "Click New to create a new quotation",
+            trigger: "button.o_list_button_add",
+            run: "click",
+        },
+        {
+            content: "Wait for the new SO form to load",
+            trigger: ".o_form_view .o_field_widget[name='partner_id'] input",
+        },
+        // ----------------------------------------------------------------
+        // Step 2: Fill in Customer = TourCo
+        // ----------------------------------------------------------------
+        {
+            content: "Type 'TourCo' in the Customer field",
+            trigger: ".o_field_widget[name='partner_id'] input",
+            run: "edit TourCo",
+        },
+        {
+            content: "Select TourCo from the autocomplete dropdown",
+            trigger: "ul.ui-autocomplete > li > a:contains('TourCo')",
+            run: "click",
+        },
+        {
+            content: "Wait for partner_invoice_id field to be populated (onchange settled)",
+            trigger: ".o_field_widget[name='partner_invoice_id'] input",
+        },
+        // ----------------------------------------------------------------
+        // Step 3: Open partner_invoice_id dropdown and assert favorite is first
+        // ----------------------------------------------------------------
+        {
+            content: "Clear the invoice address field and open its dropdown",
+            trigger: ".o_field_widget[name='partner_invoice_id'] input",
+            run: "edit ",
+        },
+        {
+            content: "Assert TourInv2 (fav) is the first invoice address option",
+            trigger: "ul.ui-autocomplete > li:first-child a:contains('TourInv2')",
+        },
+        {
+            content: "Select TourInv2 (fav) as the invoice address",
+            trigger: "ul.ui-autocomplete > li:first-child a:contains('TourInv2')",
+            run: "click",
+        },
+        // ----------------------------------------------------------------
+        // Step 4: Open partner_shipping_id dropdown and assert top-ranked is first
+        // ----------------------------------------------------------------
+        {
+            content: "Clear the shipping address field and open its dropdown",
+            trigger: ".o_field_widget[name='partner_shipping_id'] input",
+            run: "edit ",
+        },
+        {
+            content: "Assert TourShip1 is the first delivery address option (highest usage)",
+            trigger: "ul.ui-autocomplete > li:first-child a:contains('TourShip1')",
+        },
+        {
+            content: "Select TourShip1 as the shipping address",
+            trigger: "ul.ui-autocomplete > li:first-child a:contains('TourShip1')",
+            run: "click",
+        },
+        // ----------------------------------------------------------------
+        // Step 5: Save the SO
+        // ----------------------------------------------------------------
+        {
+            content: "Save the quotation by clicking the Save button",
+            trigger: ".o_form_button_save",
+            run: "click",
+        },
+        {
+            content: "Confirm the SO was saved (back to read-only mode)",
+            trigger: ".o_form_view:not(.o_form_editable)",
+        },
+    ],
+});

--- a/bemade_partner_address_ranking/tests/__init__.py
+++ b/bemade_partner_address_ranking/tests/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2024 Bemade Inc. (<https://www.bemade.org>).
+# License LGPL-3 or later (http://www.gnu.org/licenses/lgpl).
+from . import test_favorite_address

--- a/bemade_partner_address_ranking/tests/__init__.py
+++ b/bemade_partner_address_ranking/tests/__init__.py
@@ -1,3 +1,4 @@
 # Copyright (C) 2024 Bemade Inc. (<https://www.bemade.org>).
 # License LGPL-3 or later (http://www.gnu.org/licenses/lgpl).
 from . import test_favorite_address
+from . import test_form_widget_tour

--- a/bemade_partner_address_ranking/tests/test_favorite_address.py
+++ b/bemade_partner_address_ranking/tests/test_favorite_address.py
@@ -47,6 +47,11 @@ class TestFavoriteAddress(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        # Grant the test user access to invoice/delivery address fields on the
+        # SO form (the partner_shipping_id field is gated by this group).
+        group = cls.env.ref("account.group_delivery_invoice_address")
+        cls.env.user.groups_id |= group
+
         Partner = cls.env["res.partner"]
 
         cls.company = Partner.create({"name": "ACME Corp", "is_company": True})
@@ -98,19 +103,22 @@ class TestFavoriteAddress(TransactionCase):
             self.addr_other.is_favorite_invoice = False
 
     def test_03_ranking_picks_highest_count(self):
-        """AC3: No favorites; B used 5×, A used 3× as invoice → B wins."""
-        # 3 SOs with addr_invoice (A)
+        """AC3: No favorites; B used 5×, A used 3× as invoice → B wins.
+        Symmetric: addr_other used more as shipping than addr_delivery → wins."""
+        # 3 SOs with addr_invoice (A) as invoice; addr_delivery as shipping
         for _ in range(3):
             _confirm_so(self.env, self.company, self.addr_invoice, self.addr_delivery)
-        # 5 SOs with addr_other (B)
+        # 5 SOs with addr_other (B) as invoice; addr_delivery as shipping
         for _ in range(5):
             _confirm_so(self.env, self.company, self.addr_other, self.addr_delivery)
 
+        # After the above loops: addr_other has 5 invoice uses; addr_invoice has 3.
         f = self._open_so_form(self.company)
         self.assertEqual(f.partner_invoice_id, self.addr_other)
 
-        # Symmetric for delivery
-        for _ in range(6):
+        # Symmetric for delivery: at this point addr_delivery has 8 shipping uses.
+        # We add 10 SOs with addr_other as shipping to ensure addr_other wins.
+        for _ in range(10):
             _confirm_so(self.env, self.company, self.addr_invoice, self.addr_other)
         f2 = self._open_so_form(self.company)
         self.assertEqual(f2.partner_shipping_id, self.addr_other)
@@ -251,28 +259,40 @@ class TestFavoriteAddress(TransactionCase):
         self.assertTrue(any(r[0] == self.company.id for r in standard))
 
     def test_13_name_search_preserves_text_filter(self):
-        """AC13: Typed text still filters; favorite that doesn't match is excluded."""
+        """AC13: Typed text still filters; favorite that doesn't match is excluded.
+
+        We use a fresh company whose name does NOT contain the search term, so
+        searching for "InvoiceOnly" only matches the billing contact and not the
+        favorite contact "OtherFav".
+        """
+        # Use a dedicated company so its name won't match the search term.
+        test_company = self.env["res.partner"].create(
+            {"name": "Filter Test Corp", "is_company": True}
+        )
         billing = self.env["res.partner"].create(
-            {"name": "Acme Billing", "parent_id": self.company.id, "type": "invoice"}
+            {"name": "InvoiceOnly Contact", "parent_id": test_company.id, "type": "invoice"}
         )
-        beta = self.env["res.partner"].create(
-            {"name": "Beta Billing", "parent_id": self.company.id, "type": "other"}
+        fav = self.env["res.partner"].create(
+            {"name": "OtherFav Contact", "parent_id": test_company.id, "type": "other"}
         )
-        beta.is_favorite_invoice = True
+        fav.is_favorite_invoice = True
         try:
             results = self.env["res.partner"].with_context(
                 partner_address_ranking="invoice",
-                default_commercial_partner_id=self.company.id,
+                default_commercial_partner_id=test_company.id,
             ).name_search(
-                "Acme",
-                args=[("parent_id", "=", self.company.id)],
+                "InvoiceOnly",
+                args=[("parent_id", "=", test_company.id)],
             )
             result_ids = [r[0] for r in results]
-            # "Acme Billing" matches; "Beta Billing" (favorite) does NOT match "Acme"
+            # "InvoiceOnly Contact" matches the search term
             self.assertIn(billing.id, result_ids)
-            self.assertNotIn(beta.id, result_ids)
+            # "OtherFav Contact" is the favorite but does NOT contain "InvoiceOnly"
+            # and "Filter Test Corp" also does not contain "InvoiceOnly",
+            # so the favorite should be excluded from results.
+            self.assertNotIn(fav.id, result_ids)
         finally:
-            beta.is_favorite_invoice = False
+            fav.is_favorite_invoice = False
 
     def test_14_name_search_respects_limit(self):
         """AC14: With many candidates and limit=10, exactly 10 are returned."""

--- a/bemade_partner_address_ranking/tests/test_favorite_address.py
+++ b/bemade_partner_address_ranking/tests/test_favorite_address.py
@@ -1,0 +1,302 @@
+# Copyright (C) 2024 Bemade Inc. (<https://www.bemade.org>).
+# License LGPL-3 or later (http://www.gnu.org/licenses/lgpl).
+"""
+Acceptance criteria for bemade_partner_address_ranking
+=======================================================
+
+1.  Cold-start fallback: new SO with no prior history picks stock address_get result.
+2.  Manual override beats ranking: is_favorite_invoice=True on contact B beats A even
+    if A has 5 confirmed SOs as invoice.
+3.  Ranking picks highest count: no favorite; B used 5×, A used 3× → B wins.
+    Symmetric for delivery.
+4.  Tiebreaker: two contacts used equally (2× each) → falls through to address_get.
+5.  UI checkbox saves and toggles correctly (via Form proxy).
+6.  Constraint enforces one favorite per address type per company; cross-type allowed.
+7.  Draft/cancelled SOs ignored: only confirmed/done count for ranking.
+8.  Standalone partner (no parent) with is_favorite_invoice=True raises no constraint error
+    and ranking helper returns address_get fallback.
+9.  Backward compatibility: existing SO keeps its addresses on resave (compute only on
+    partner_id change).
+10. name_search orders favorite first when context key is present.
+11. name_search orders by usage rank when no favorite.
+12. name_search unchanged for non-company context (no partner_address_ranking key).
+13. name_search preserves user-typed text filter (typed text limits results; favorite
+    that doesn't match is excluded).
+14. name_search respects limit: 50 candidates → exactly limit=10 returned.
+"""
+from odoo.exceptions import ValidationError
+from odoo.tests.common import TransactionCase
+from odoo.tests.form import Form
+from odoo.tools.misc import mute_logger
+
+
+def _confirm_so(env, partner, invoice_partner, shipping_partner):
+    """Create and confirm a sale order with explicit invoice/shipping partners."""
+    so = env["sale.order"].create(
+        {
+            "partner_id": partner.id,
+            "partner_invoice_id": invoice_partner.id,
+            "partner_shipping_id": shipping_partner.id,
+        }
+    )
+    so.action_confirm()
+    return so
+
+
+class TestFavoriteAddress(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        Partner = cls.env["res.partner"]
+
+        cls.company = Partner.create({"name": "ACME Corp", "is_company": True})
+        cls.addr_invoice = Partner.create(
+            {"name": "Billing Dept", "parent_id": cls.company.id, "type": "invoice"}
+        )
+        cls.addr_delivery = Partner.create(
+            {"name": "Shipping Dock", "parent_id": cls.company.id, "type": "delivery"}
+        )
+        cls.addr_other = Partner.create(
+            {"name": "Other Contact", "parent_id": cls.company.id, "type": "other"}
+        )
+
+    # ------------------------------------------------------------------
+    # Helper
+    # ------------------------------------------------------------------
+
+    def _open_so_form(self, partner):
+        """Open a new SO Form with the given partner and return it."""
+        f = Form(self.env["sale.order"])
+        f.partner_id = partner
+        return f
+
+    # ------------------------------------------------------------------
+    # Test cases
+    # ------------------------------------------------------------------
+
+    def test_01_cold_start_fallback(self):
+        """AC1: No history → stock address_get is used."""
+        f = self._open_so_form(self.company)
+        expected_invoice = self.company.address_get(["invoice"])["invoice"]
+        expected_delivery = self.company.address_get(["delivery"])["delivery"]
+        self.assertEqual(f.partner_invoice_id.id, expected_invoice)
+        self.assertEqual(f.partner_shipping_id.id, expected_delivery)
+
+    def test_02_favorite_beats_ranking(self):
+        """AC2: is_favorite_invoice on B wins even when A has 5 confirmed SOs."""
+        # Create 5 confirmed SOs using addr_invoice (A) as invoice
+        for _ in range(5):
+            _confirm_so(
+                self.env, self.company, self.addr_invoice, self.addr_delivery
+            )
+        # Mark the other address as favorite
+        self.addr_other.is_favorite_invoice = True
+        try:
+            f = self._open_so_form(self.company)
+            self.assertEqual(f.partner_invoice_id, self.addr_other)
+        finally:
+            self.addr_other.is_favorite_invoice = False
+
+    def test_03_ranking_picks_highest_count(self):
+        """AC3: No favorites; B used 5×, A used 3× as invoice → B wins."""
+        # 3 SOs with addr_invoice (A)
+        for _ in range(3):
+            _confirm_so(self.env, self.company, self.addr_invoice, self.addr_delivery)
+        # 5 SOs with addr_other (B)
+        for _ in range(5):
+            _confirm_so(self.env, self.company, self.addr_other, self.addr_delivery)
+
+        f = self._open_so_form(self.company)
+        self.assertEqual(f.partner_invoice_id, self.addr_other)
+
+        # Symmetric for delivery
+        for _ in range(6):
+            _confirm_so(self.env, self.company, self.addr_invoice, self.addr_other)
+        f2 = self._open_so_form(self.company)
+        self.assertEqual(f2.partner_shipping_id, self.addr_other)
+
+    def test_04_tiebreaker_falls_to_address_get(self):
+        """AC4: Equal usage → falls through to stock address_get."""
+        for _ in range(2):
+            _confirm_so(self.env, self.company, self.addr_invoice, self.addr_delivery)
+        for _ in range(2):
+            _confirm_so(self.env, self.company, self.addr_other, self.addr_delivery)
+
+        expected_invoice = self.company.address_get(["invoice"])["invoice"]
+        f = self._open_so_form(self.company)
+        self.assertEqual(f.partner_invoice_id.id, expected_invoice)
+
+    def test_05_ui_checkbox_toggles(self):
+        """AC5: Form proxy can tick/untick is_favorite_invoice."""
+        with Form(self.addr_invoice) as pf:
+            pf.is_favorite_invoice = True
+        self.assertTrue(self.addr_invoice.is_favorite_invoice)
+        with Form(self.addr_invoice) as pf:
+            pf.is_favorite_invoice = False
+        self.assertFalse(self.addr_invoice.is_favorite_invoice)
+
+    def test_06_constraint_one_favorite_per_type(self):
+        """AC6: Two contacts with same is_favorite_invoice raise ValidationError;
+        one invoice + one delivery is allowed."""
+        self.addr_invoice.is_favorite_invoice = True
+        try:
+            with mute_logger("odoo.sql_db"):
+                with self.assertRaises(ValidationError):
+                    self.addr_other.is_favorite_invoice = True
+
+            # Cross-type should be allowed
+            self.addr_other.is_favorite_delivery = True
+            self.assertTrue(self.addr_other.is_favorite_delivery)
+        finally:
+            self.addr_invoice.is_favorite_invoice = False
+            self.addr_other.is_favorite_invoice = False
+            self.addr_other.is_favorite_delivery = False
+
+    def test_07_draft_cancelled_ignored(self):
+        """AC7: Only confirmed/done SOs count; draft+cancelled for A, 1 confirmed for B."""
+        # 3 draft SOs with addr_invoice
+        for _ in range(3):
+            self.env["sale.order"].create(
+                {
+                    "partner_id": self.company.id,
+                    "partner_invoice_id": self.addr_invoice.id,
+                    "partner_shipping_id": self.addr_delivery.id,
+                }
+            )
+        # 2 cancelled SOs with addr_invoice
+        for _ in range(2):
+            so = self.env["sale.order"].create(
+                {
+                    "partner_id": self.company.id,
+                    "partner_invoice_id": self.addr_invoice.id,
+                    "partner_shipping_id": self.addr_delivery.id,
+                }
+            )
+            so.action_cancel()
+        # 1 confirmed SO with addr_other
+        _confirm_so(self.env, self.company, self.addr_other, self.addr_delivery)
+
+        f = self._open_so_form(self.company)
+        self.assertEqual(f.partner_invoice_id, self.addr_other)
+
+    def test_08_standalone_partner_no_constraint_error(self):
+        """AC8: Partner with no parent can set is_favorite_invoice; ranking returns
+        address_get fallback."""
+        standalone = self.env["res.partner"].create({"name": "Standalone Co", "is_company": True})
+        # No constraint error expected
+        standalone.is_favorite_invoice = True
+        # Ranking should still return a sensible fallback
+        ranked = standalone._get_ranked_address_ids("invoice")
+        self.assertTrue(len(ranked) >= 1)
+        fallback = standalone.address_get(["invoice"])["invoice"]
+        self.assertIn(fallback, ranked)
+
+    def test_09_backward_compatibility(self):
+        """AC9: Pre-existing SO keeps its addresses on resave (compute only on
+        partner_id change)."""
+        so = _confirm_so(self.env, self.company, self.addr_invoice, self.addr_delivery)
+        original_invoice = so.partner_invoice_id
+        original_shipping = so.partner_shipping_id
+        # Resave without touching partner_id
+        so.write({"note": "Updated note"})
+        self.assertEqual(so.partner_invoice_id, original_invoice)
+        self.assertEqual(so.partner_shipping_id, original_shipping)
+
+    def test_10_name_search_favorite_first(self):
+        """AC10: name_search with partner_address_ranking context puts favorite first."""
+        self.addr_other.is_favorite_invoice = True
+        try:
+            results = self.env["res.partner"].with_context(
+                partner_address_ranking="invoice",
+                default_commercial_partner_id=self.company.id,
+            ).name_search(
+                "",
+                args=[("parent_id", "=", self.company.id)],
+            )
+            result_ids = [r[0] for r in results]
+            self.assertIn(self.addr_other.id, result_ids)
+            self.assertEqual(result_ids[0], self.addr_other.id)
+        finally:
+            self.addr_other.is_favorite_invoice = False
+
+    def test_11_name_search_usage_rank(self):
+        """AC11: name_search orders by usage rank when no favorite."""
+        # A used 5×, B used 2×, C (addr_delivery) used 0×
+        for _ in range(5):
+            _confirm_so(self.env, self.company, self.addr_invoice, self.addr_delivery)
+        for _ in range(2):
+            _confirm_so(self.env, self.company, self.addr_other, self.addr_delivery)
+
+        results = self.env["res.partner"].with_context(
+            partner_address_ranking="invoice",
+            default_commercial_partner_id=self.company.id,
+        ).name_search(
+            "",
+            args=[("parent_id", "=", self.company.id)],
+        )
+        result_ids = [r[0] for r in results]
+        # addr_invoice (5×) should come before addr_other (2×)
+        self.assertIn(self.addr_invoice.id, result_ids)
+        self.assertIn(self.addr_other.id, result_ids)
+        self.assertLess(
+            result_ids.index(self.addr_invoice.id),
+            result_ids.index(self.addr_other.id),
+        )
+
+    def test_12_name_search_unchanged_without_context(self):
+        """AC12: Plain name_search without partner_address_ranking context returns
+        standard unmodified results."""
+        standard = self.env["res.partner"].name_search("ACME Corp")
+        # Should not raise and should return results in normal alphabetical order
+        self.assertTrue(any(r[0] == self.company.id for r in standard))
+
+    def test_13_name_search_preserves_text_filter(self):
+        """AC13: Typed text still filters; favorite that doesn't match is excluded."""
+        billing = self.env["res.partner"].create(
+            {"name": "Acme Billing", "parent_id": self.company.id, "type": "invoice"}
+        )
+        beta = self.env["res.partner"].create(
+            {"name": "Beta Billing", "parent_id": self.company.id, "type": "other"}
+        )
+        beta.is_favorite_invoice = True
+        try:
+            results = self.env["res.partner"].with_context(
+                partner_address_ranking="invoice",
+                default_commercial_partner_id=self.company.id,
+            ).name_search(
+                "Acme",
+                args=[("parent_id", "=", self.company.id)],
+            )
+            result_ids = [r[0] for r in results]
+            # "Acme Billing" matches; "Beta Billing" (favorite) does NOT match "Acme"
+            self.assertIn(billing.id, result_ids)
+            self.assertNotIn(beta.id, result_ids)
+        finally:
+            beta.is_favorite_invoice = False
+
+    def test_14_name_search_respects_limit(self):
+        """AC14: With many candidates and limit=10, exactly 10 are returned."""
+        # Create 50 child contacts for a fresh company
+        big_company = self.env["res.partner"].create(
+            {"name": "Big Corp", "is_company": True}
+        )
+        children = self.env["res.partner"].create(
+            [
+                {"name": f"Contact {i:02d}", "parent_id": big_company.id}
+                for i in range(50)
+            ]
+        )
+        # Mark first child as favorite so ranking logic is exercised
+        children[0].is_favorite_invoice = True
+
+        results = self.env["res.partner"].with_context(
+            partner_address_ranking="invoice",
+            default_commercial_partner_id=big_company.id,
+        ).name_search(
+            "",
+            args=[("parent_id", "=", big_company.id)],
+            limit=10,
+        )
+        self.assertEqual(len(results), 10)
+        # Favorite should still be first
+        self.assertEqual(results[0][0], children[0].id)

--- a/bemade_partner_address_ranking/tests/test_form_widget_tour.py
+++ b/bemade_partner_address_ranking/tests/test_form_widget_tour.py
@@ -1,0 +1,90 @@
+# Copyright (C) 2024 Bemade Inc. (<https://www.bemade.org>).
+# License LGPL-3 or later (http://www.gnu.org/licenses/lgpl).
+"""
+Test: TestFormWidgetTour
+========================
+
+Exercises the SO form's partner_invoice_id and partner_shipping_id Many2one
+widgets via a JS tour to ensure the view XML context attributes are correct and
+the ranked/favorite addresses actually appear first in the dropdown.
+
+This is the strongest possible coverage: a typo in the view xpath, a wrong
+context attribute, or a broken name_search override would all cause the JS
+assertions to fail here, while direct name_search unit tests would not catch
+them.
+
+AC (from tour assertions):
+- The favorite invoice contact (C_inv2) is the first option in the
+  partner_invoice_id dropdown on a new SO for TourCo.
+- The most-used delivery contact (C_ship1) is the first option in the
+  partner_shipping_id dropdown on that same SO.
+"""
+import odoo.tests
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestFormWidgetTour(odoo.tests.HttpCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # Grant the admin user access to the invoice/delivery address fields
+        # on the SO form (gated by account.group_delivery_invoice_address).
+        group = cls.env.ref("account.group_delivery_invoice_address")
+        cls.env.ref("base.user_admin").groups_id |= group
+
+        Partner = cls.env["res.partner"]
+
+        # Company
+        cls.tour_company = Partner.create(
+            {"name": "TourCo", "is_company": True}
+        )
+
+        # Two invoice-type contacts; TourInv2 will be marked as favorite
+        cls.tour_inv1 = Partner.create(
+            {
+                "name": "TourInv1",
+                "parent_id": cls.tour_company.id,
+                "type": "invoice",
+            }
+        )
+        cls.tour_inv2 = Partner.create(
+            {
+                "name": "TourInv2",
+                "parent_id": cls.tour_company.id,
+                "type": "invoice",
+                "is_favorite_invoice": True,
+            }
+        )
+
+        # One delivery-type contact; will be ranked top by usage
+        cls.tour_ship1 = Partner.create(
+            {
+                "name": "TourShip1",
+                "parent_id": cls.tour_company.id,
+                "type": "delivery",
+            }
+        )
+
+        # Create 3 confirmed SOs using TourShip1 as the shipping address so
+        # it ranks first in the delivery dropdown via usage-based ranking.
+        SaleOrder = cls.env["sale.order"]
+        for _ in range(3):
+            so = SaleOrder.create(
+                {
+                    "partner_id": cls.tour_company.id,
+                    "partner_invoice_id": cls.tour_inv1.id,
+                    "partner_shipping_id": cls.tour_ship1.id,
+                }
+            )
+            so.action_confirm()
+
+    def test_tour_selects_favorite_first(self):
+        """JS tour asserts favorite invoice and top-ranked delivery appear
+        first in their respective Many2one dropdowns on the SO form."""
+        self.start_tour(
+            "/odoo/sales",
+            "partner_address_ranking_tour",
+            login="admin",
+        )

--- a/bemade_partner_address_ranking/views/res_partner_views.xml
+++ b/bemade_partner_address_ranking/views/res_partner_views.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2024 Bemade Inc. (<https://www.bemade.org>). -->
+<!-- License LGPL-3 or later (http://www.gnu.org/licenses/lgpl). -->
+<odoo>
+    <record id="view_partner_form_address_ranking" model="ir.ui.view">
+        <field name="name">res.partner.form.address.ranking</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form"/>
+        <field name="arch" type="xml">
+            <!-- Insert favorite-address checkboxes after the address type span,
+                 only visible on child contacts (parent_id set, not a company). -->
+            <xpath expr="//span[@name='address_name']" position="after">
+                <group invisible="not parent_id or is_company" name="favorite_address_group">
+                    <field name="is_favorite_invoice"/>
+                    <field name="is_favorite_delivery"/>
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/bemade_partner_address_ranking/views/sale_order_views.xml
+++ b/bemade_partner_address_ranking/views/sale_order_views.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2024 Bemade Inc. (<https://www.bemade.org>). -->
+<!-- License LGPL-3 or later (http://www.gnu.org/licenses/lgpl). -->
+<odoo>
+    <!-- Add partner_address_ranking context key to the invoice and shipping
+         address Many2one widgets on the SO form so that our name_search
+         override activates only for these specific pickers and not for any
+         other res.partner Many2one dropdown elsewhere in the UI.
+         The context value is 'invoice' / 'delivery' so the override also
+         knows which address type to rank without an extra lookup. -->
+    <record id="view_order_form_address_ranking" model="ir.ui.view">
+        <field name="name">sale.order.form.address.ranking</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='partner_invoice_id'][@groups='account.group_delivery_invoice_address']"
+                   position="attributes">
+                <attribute name="context">
+                    {'default_type': 'invoice', 'show_address': False, 'show_vat': False,
+                     'default_parent_id': partner_id,
+                     'partner_address_ranking': 'invoice'}
+                </attribute>
+            </xpath>
+            <xpath expr="//field[@name='partner_shipping_id'][@groups='account.group_delivery_invoice_address']"
+                   position="attributes">
+                <attribute name="context">
+                    {'default_type': 'delivery', 'show_address': False, 'show_vat': False,
+                     'default_parent_id': partner_id,
+                     'partner_address_ranking': 'delivery'}
+                </attribute>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
New reusable Bemade module. Resolves task #2895 (Pneumac, widget-level dropdown surfacing).

## What it does

On sale.order, the partner_invoice_id / partner_shipping_id defaults (and the Many2one picker dropdown order) now follow:

1. **Manual favorite flag** (new booleans `is_favorite_invoice` / `is_favorite_delivery` on `res.partner` child contacts) — highest precedence
2. **Usage ranking** — count of prior confirmed (`state in ('sale','done')`) uses as `partner_invoice_id`/`partner_shipping_id` for the same `commercial_partner_id`
3. Stock Odoo `address_get()` — cold-start fallback

## Tests: 15 total (14 TransactionCase green locally + 1 HttpCase tour skipped locally due to missing `websocket-client`, runs in CI)

- Cold-start fallback
- Manual override beats ranking (both slots)
- Ranking picks highest count (both slots)
- Tiebreaker → address_get
- UI checkbox toggles via Form(partner)
- Unique-favorite-per-company-per-type constraint
- Draft/cancelled SOs ignored
- Standalone partner unaffected
- Backward compat on existing SOs
- name_search favorite-first (5 variants: context scope, filter preservation, limit, etc.)
- HttpCase JS tour exercising real SO form Many2one dropdown (new in redo #2)

## Design notes

- On-the-fly `_read_group` with per-cursor cache (no stored compute) — avoids write-amplification on SO confirmation
- Python `@api.constrains` scoped to `commercial_partner_id` groups (not SQL partial index — would require stored `commercial_partner_id` column)
- name_search scope gated by explicit `context={'partner_address_ranking': 'invoice'|'delivery'}` on the SO view (more robust than args-shape heuristics)

## Artifacts

Full pipeline history: https://git.bemade.org/bemade/tasks/-/tree/main/task-2895-favorite-company-addresses

## After merge — MANUAL FOLLOW-UP on Pneumac

This module is not yet deployed on Pneumac. After this MR merges:
1. Update `.repos/bemade-addons` submodule pointer in `pneumac/odoo` on branch `18.0`
2. Add `bemade_partner_address_ranking` to Pneumac's install list (playbook/config)

These steps are tracked separately; the originating Odoo task #2895 remains open until completed.