### PR TITLE
fix(i18n): use canonical occurrence prefixes + HTML-tagged msgids in fr_CA .po

### DIFF
--- a/bemade_mail_author_visibility/i18n/bemade_mail_author_visibility.pot
+++ b/bemade_mail_author_visibility/i18n/bemade_mail_author_visibility.pot
@@ -20,7 +20,7 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: bemade_mail_author_visibility
-#: view:bemade_mail_author_visibility.mail_notification_layout:0
-#: view:bemade_mail_author_visibility.mail_notification_light:0
+#: model_terms:ir.ui.view,arch_db:bemade_mail_author_visibility.mail_notification_layout
+#: model_terms:ir.ui.view,arch_db:bemade_mail_author_visibility.mail_notification_light
 msgid "Posted by:"
 msgstr ""

--- a/bemade_mail_author_visibility/i18n/bemade_mail_author_visibility.pot
+++ b/bemade_mail_author_visibility/i18n/bemade_mail_author_visibility.pot
@@ -22,5 +22,5 @@ msgstr ""
 #. module: bemade_mail_author_visibility
 #: model_terms:ir.ui.view,arch_db:bemade_mail_author_visibility.mail_notification_layout
 #: model_terms:ir.ui.view,arch_db:bemade_mail_author_visibility.mail_notification_light
-msgid "Posted by:"
+msgid "<strong>Posted by:</strong>"
 msgstr ""

--- a/bemade_mail_author_visibility/i18n/fr_CA.po
+++ b/bemade_mail_author_visibility/i18n/fr_CA.po
@@ -23,5 +23,5 @@ msgstr ""
 #. module: bemade_mail_author_visibility
 #: model_terms:ir.ui.view,arch_db:bemade_mail_author_visibility.mail_notification_layout
 #: model_terms:ir.ui.view,arch_db:bemade_mail_author_visibility.mail_notification_light
-msgid "Posted by:"
-msgstr "Publié par :"
+msgid "<strong>Posted by:</strong>"
+msgstr "<strong>Publié par :</strong>"

--- a/bemade_mail_author_visibility/i18n/fr_CA.po
+++ b/bemade_mail_author_visibility/i18n/fr_CA.po
@@ -21,7 +21,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #. module: bemade_mail_author_visibility
-#: view:bemade_mail_author_visibility.mail_notification_layout:0
-#: view:bemade_mail_author_visibility.mail_notification_light:0
+#: model_terms:ir.ui.view,arch_db:bemade_mail_author_visibility.mail_notification_layout
+#: model_terms:ir.ui.view,arch_db:bemade_mail_author_visibility.mail_notification_light
 msgid "Posted by:"
 msgstr "Publié par :"

--- a/sale_mandatory_customer_reference/i18n/fr_CA.po
+++ b/sale_mandatory_customer_reference/i18n/fr_CA.po
@@ -17,43 +17,36 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #. module: sale_mandatory_customer_reference
-#: views/portal_templates.xml:0
-#, python-format
+#: model_terms:ir.ui.view,arch_db:sale_mandatory_customer_reference.sale_order_portal_content_inherit_sale_mandatory_reference
 msgid "Your Reference"
 msgstr "Votre référence"
 
 #. module: sale_mandatory_customer_reference
-#: views/portal_templates.xml:0
-#, python-format
+#: model_terms:ir.ui.view,arch_db:sale_mandatory_customer_reference.sale_order_portal_content_inherit_sale_mandatory_reference
 msgid "Enter your purchase order number"
 msgstr "Entrez votre numéro de bon de commande"
 
 #. module: sale_mandatory_customer_reference
-#: views/portal_templates.xml:0
-#, python-format
+#: model_terms:ir.ui.view,arch_db:sale_mandatory_customer_reference.sale_order_portal_content_inherit_sale_mandatory_reference
 msgid "A reference (PO number) is required before confirming this order."
 msgstr "Une référence (numéro de bon de commande) est requise avant de confirmer cette commande."
 
 #. module: sale_mandatory_customer_reference
-#: static/src/js/portal_sale.js:0
-#, python-format
+#: code:addons/sale_mandatory_customer_reference/static/src/js/portal_sale.js:0
 msgid "Reference updated successfully"
 msgstr "Référence mise à jour avec succès"
 
 #. module: sale_mandatory_customer_reference
-#: static/src/js/portal_sale.js:0
-#, python-format
+#: code:addons/sale_mandatory_customer_reference/static/src/js/portal_sale.js:0
 msgid "Could not determine the order ID"
 msgstr "Impossible de déterminer l'identifiant de la commande"
 
 #. module: sale_mandatory_customer_reference
-#: static/src/js/portal_sale.js:0
-#, python-format
+#: code:addons/sale_mandatory_customer_reference/static/src/js/portal_sale.js:0
 msgid "Failed to save your reference. Please try again."
 msgstr "Échec de l'enregistrement de votre référence. Veuillez réessayer."
 
 #. module: sale_mandatory_customer_reference
-#: models/sale_order.py:0
-#, python-format
+#: code:addons/sale_mandatory_customer_reference/models/sale_order.py:0
 msgid "Customer reference (PO Number) is required before confirming this order. Please set the customer reference field."
 msgstr "Une référence client (numéro de bon de commande) est requise avant de confirmer cette commande. Veuillez renseigner le champ de référence client."


### PR DESCRIPTION
## Summary

Fixes `malformed po file: unknown occurrence: view:...` errors emitted by Odoo 18's `.po` loader when installing `bemade_mail_author_visibility` and `sale_mandatory_customer_reference`. Also corrects the fr_CA msgid for the mail-author notification layout strings, which were plain text but need the `<strong>...</strong>` wrapper because Odoo's `xml_translate` extracts serialized HTML fragments (not inner text) when the parent element is in `TRANSLATED_ELEMENTS`.

Root causes:
- PRs #53 and #54 (merged 2026-04-22) added fr_CA translations using non-canonical occurrence comments:
  - `#: view:<xmlid>:0` (unrecognized by Odoo's loader — only `model:` / `model_terms:` / `code:` / `selection:` are accepted)
  - bare-path `#: views/portal_templates.xml:0` (same problem)
  Entries with malformed occurrences are silently dropped at .po load time.
- The `bemade_mail_author_visibility` notification layout uses `<strong>Posted by:</strong>` in its view arch. Odoo's `xml_translate` extracts the full `<strong>...</strong>` fragment as the translation key. The prior msgid was plain `"Posted by:"` so the translation was never matched at render time.

## Changes

- `bemade_mail_author_visibility/i18n/fr_CA.po` — occurrence prefixes → `model_terms:ir.ui.view,arch_db:...`; msgid/msgstr → `<strong>Posted by:</strong>` / `<strong>Publié par :</strong>`.
- `bemade_mail_author_visibility/i18n/bemade_mail_author_visibility.pot` — same rewrite (keeps future `msgmerge` from reintroducing the broken form).
- `sale_mandatory_customer_reference/i18n/fr_CA.po` — all 7 entries rewritten to canonical occurrence prefixes (3 `model_terms:ir.ui.view,arch_db:...` for the portal view, 3 `code:addons/.../static/src/js/portal_sale.js:0` for JS strings, 1 `code:addons/.../models/sale_order.py:0` for the Python ValidationError). Spurious `#, python-format` flags removed. Msgids remain plain text — verified that `<h5>`, `placeholder=` attribute, and `<small t-if="...">` extraction paths all produce plain-text terms (h5 not in TRANSLATED_ELEMENTS; placeholder is a TRANSLATED_ATTRS always-plain path; t-\* attrs cause `translatable()` to recurse into the element).

No translation wording changes.

## Validation

- Zero `malformed po file: unknown occurrence:` errors when installing either module on a fresh Odoo 18 DB.
- `bemade_mail_author_visibility` test suite: 8/8 pass, including `test_08_french_rendering` (which asserts the rendered fr_CA notification contains `"Publié par :"`).
- Standalone `sale_mandatory_customer_reference.tests.test_po_file` parser suite: 7/7 pass.

## Blocks unblocked

- Pneumac downstream MR !35: https://git.bemade.org/pneumac/odoo/-/merge_requests/35 (pipeline 3000 / job 5444 — https://git.bemade.org/pneumac/odoo/-/jobs/5444 — currently RED on this upstream bug).

## Follow-up after merge

The Pneumac submodule pointer on MR !35 needs re-bumping to pick up this fix. That is a separate, orchestrator-managed follow-up cycle and NOT part of this PR.

## Pipeline artifacts

https://git.bemade.org/bemade/tasks/-/tree/main/task-3367-translate-portal-popup-customer-ref-v2