### PR TITLE
feat(odoo_herd): mirror operator productionInstanceRef + staging refresh

### DIFF
--- a/odoo_herd/__manifest__.py
+++ b/odoo_herd/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Odoo Herd",
-    "version": "19.0.1.5.0",
+    "version": "19.0.1.6.0",
     "category": "Administration/Kubernetes",
     "summary": "Manage your herd of Odoo instances across Kubernetes clusters",
     "description": """
@@ -41,6 +41,7 @@ Features:
         "wizards/k8s_restore_backup_wizard_views.xml",
         "wizards/k8s_backup_wizard_views.xml",
         "wizards/k8s_upload_backup_wizard_views.xml",
+        "wizards/k8s_staging_refresh_wizard_views.xml",
         # Views
         "views/k8s_dashboard_views.xml",
         "views/k8s_cluster_views.xml",
@@ -51,6 +52,7 @@ Features:
         "views/k8s_backup_schedule_views.xml",
         "views/k8s_restore_views.xml",
         "views/k8s_upgrade_views.xml",
+        "views/k8s_staging_refresh_views.xml",
         "views/k8s_menu_views.xml",
     ],
     "demo": [],

--- a/odoo_herd/controllers/__init__.py
+++ b/odoo_herd/controllers/__init__.py
@@ -1,5 +1,6 @@
 from . import backup_webhook
 from . import restore_webhook
+from . import staging_refresh_webhook
 from . import instance_webhook
 from . import dashboard
 from . import main

--- a/odoo_herd/controllers/staging_refresh_webhook.py
+++ b/odoo_herd/controllers/staging_refresh_webhook.py
@@ -1,0 +1,136 @@
+import json
+import logging
+
+from odoo import http
+from odoo.http import request, Response
+
+_logger = logging.getLogger(__name__)
+
+
+class K8sStagingRefreshWebhook(http.Controller):
+    """Receive staging-refresh status webhooks from the Kubernetes operator."""
+
+    @http.route(
+        "/k8s/staging_refresh/webhook/<int:refresh_id>",
+        type="http",
+        auth="public",
+        methods=["POST"],
+        csrf=False,
+    )
+    def staging_refresh_webhook(self, refresh_id, **kwargs):
+        auth_header = request.httprequest.headers.get("Authorization", "")
+        if not auth_header.startswith("Bearer "):
+            _logger.warning(
+                "Staging refresh webhook %s: missing or invalid Authorization header",
+                refresh_id,
+            )
+            return Response(
+                json.dumps({"error": "Unauthorized"}),
+                status=401,
+                content_type="application/json",
+            )
+
+        token = auth_header[7:]
+
+        refresh = (
+            request.env["k8s.odoo.staging.refresh"].sudo().browse(refresh_id)
+        )
+        if not refresh.exists():
+            _logger.warning(
+                "Staging refresh webhook: record %s not found", refresh_id
+            )
+            return Response(
+                json.dumps({"error": "Refresh not found"}),
+                status=404,
+                content_type="application/json",
+            )
+
+        if not refresh.webhook_token or refresh.webhook_token != token:
+            _logger.warning(
+                "Staging refresh webhook %s: invalid token", refresh_id
+            )
+            return Response(
+                json.dumps({"error": "Invalid token"}),
+                status=403,
+                content_type="application/json",
+            )
+
+        try:
+            data = json.loads(request.httprequest.data.decode("utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError) as e:
+            _logger.warning(
+                "Staging refresh webhook %s: invalid JSON: %s", refresh_id, e
+            )
+            return Response(
+                json.dumps({"error": "Invalid JSON payload"}),
+                status=400,
+                content_type="application/json",
+            )
+
+        phase = data.get("phase", "").lower()
+        message = data.get("message")
+
+        _logger.info(
+            "Staging refresh webhook %s: received phase=%s",
+            refresh.name,
+            phase,
+        )
+
+        if phase == "running":
+            refresh.mark_running(
+                start_time=data.get("startTime"),
+                status=data,
+            )
+        elif phase == "completed":
+            refresh.mark_completed(
+                completion_time=data.get("completionTime"),
+                message=message,
+                status=data,
+            )
+            self._notify_user(
+                refresh,
+                "Staging Refresh Completed",
+                f"Refresh {refresh.name} of {refresh.target_instance_id.name} "
+                f"from {refresh.source_instance_id.name} completed.",
+                "success",
+            )
+        elif phase == "failed":
+            refresh.mark_failed(
+                message=message or "Staging refresh failed",
+                completion_time=data.get("completionTime"),
+                status=data,
+            )
+            self._notify_user(
+                refresh,
+                "Staging Refresh Failed",
+                f"Refresh {refresh.name} of {refresh.target_instance_id.name} "
+                f"failed: {message or 'Unknown error'}",
+                "danger",
+            )
+        else:
+            _logger.warning(
+                "Staging refresh webhook %s: unknown phase %s", refresh_id, phase
+            )
+
+        return Response(
+            json.dumps({"status": "ok"}),
+            status=200,
+            content_type="application/json",
+        )
+
+    def _notify_user(self, record, title, message, notification_type="info"):
+        if not record.create_uid:
+            return
+        try:
+            record.env["bus.bus"]._sendone(
+                record.create_uid.partner_id,
+                "simple_notification",
+                {
+                    "title": title,
+                    "message": message,
+                    "type": notification_type,
+                    "sticky": notification_type == "danger",
+                },
+            )
+        except Exception as e:
+            _logger.warning("Failed to send user notification: %s", e)

--- a/odoo_herd/data/k8s_data.xml
+++ b/odoo_herd/data/k8s_data.xml
@@ -17,6 +17,14 @@
         <field name="prefix">RST/</field>
         <field name="padding">5</field>
     </record>
+
+    <!-- Sequence for staging refresh records -->
+    <record id="seq_k8s_odoo_staging_refresh" model="ir.sequence">
+        <field name="name">Kubernetes Odoo Staging Refresh</field>
+        <field name="code">k8s.odoo.staging.refresh</field>
+        <field name="prefix">SRF/</field>
+        <field name="padding">5</field>
+    </record>
     
     <!-- Cron job for periodic sync -->
     <record id="cron_k8s_sync_instances" model="ir.cron">

--- a/odoo_herd/models/__init__.py
+++ b/odoo_herd/models/__init__.py
@@ -6,4 +6,5 @@ from . import k8s_odoo_instance_template
 from . import k8s_odoo_instance_backup_schedule
 from . import k8s_backup
 from . import k8s_restore
+from . import k8s_staging_refresh
 from . import k8s_upgrade

--- a/odoo_herd/models/k8s_cluster.py
+++ b/odoo_herd/models/k8s_cluster.py
@@ -367,6 +367,35 @@ class K8sCluster(models.Model):
                 if filestore.get("storageSize"):
                     instance_data["filestore_size"] = filestore.get("storageSize")
 
+                # Extract environment (CRD uses capitalized "Staging"/"Production")
+                env_value = spec.get("environment")
+                if env_value:
+                    instance_data["environment"] = env_value.lower()
+
+                # Extract productionInstanceRef and resolve to a record if possible
+                prod_ref = spec.get("productionInstanceRef") or {}
+                prod_ref_name = prod_ref.get("name")
+                if prod_ref_name:
+                    prod_ref_ns = prod_ref.get("namespace") or namespace
+                    source = self.env["k8s.odoo.instance"].search(
+                        [
+                            ("cluster_id", "=", self.id),
+                            ("namespace", "=", prod_ref_ns),
+                            ("name", "=", prod_ref_name),
+                        ],
+                        limit=1,
+                    )
+                    if source:
+                        instance_data["production_instance_id"] = source.id
+                    else:
+                        _logger.warning(
+                            "productionInstanceRef %s/%s for %s/%s not yet synced",
+                            prod_ref_ns,
+                            prod_ref_name,
+                            namespace,
+                            name,
+                        )
+
                 if instance:
                     instance.write(instance_data)
                     synced_instances.append(instance.id)

--- a/odoo_herd/models/k8s_odoo_instance.py
+++ b/odoo_herd/models/k8s_odoo_instance.py
@@ -37,6 +37,30 @@ class K8sOdooInstance(models.Model):
         help="Kubernetes namespace containing this instance",
     )
 
+    environment = fields.Selection(
+        [
+            ("staging", "Staging"),
+            ("production", "Production"),
+        ],
+        string="Environment",
+        default="staging",
+        required=True,
+        tracking=True,
+        help=(
+            "Whether this instance is a Staging or Production instance. "
+            "Staging is the safer default per the CRD schema."
+        ),
+    )
+
+    production_instance_id = fields.Many2one(
+        "k8s.odoo.instance",
+        string="Source Production Instance",
+        help=(
+            "When this instance is staging, the operator clones the referenced "
+            "production instance on first init (via an OdooStagingRefreshJob)."
+        ),
+    )
+
     spec = fields.Text(
         string="Specification",
         readonly=True,
@@ -335,6 +359,21 @@ class K8sOdooInstance(models.Model):
                     _logger.warning(
                         f"Failed to parse status for instance {instance.name}: {e}"
                     )
+
+    @api.constrains("environment", "production_instance_id")
+    def _check_production_instance_ref(self):
+        # Mirror the CRD CEL rule: production instances cannot reference a source.
+        for instance in self:
+            if (
+                instance.environment == "production"
+                and instance.production_instance_id
+            ):
+                raise UserError(
+                    _(
+                        "A Production instance cannot have a source "
+                        "Production Instance reference."
+                    )
+                )
 
     @api.constrains("filestore_size")
     def _check_filestore_size(self):

--- a/odoo_herd/models/k8s_staging_refresh.py
+++ b/odoo_herd/models/k8s_staging_refresh.py
@@ -1,0 +1,277 @@
+import logging
+import secrets
+
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError, ValidationError
+
+_logger = logging.getLogger(__name__)
+
+
+class K8sOdooStagingRefresh(models.Model):
+    _name = "k8s.odoo.staging.refresh"
+    _description = "Kubernetes Odoo Staging Refresh Job"
+    _order = "create_date desc"
+
+    name = fields.Char(default="New", readonly=True)
+    target_instance_id = fields.Many2one(
+        "k8s.odoo.instance",
+        string="Target Instance",
+        required=True,
+        ondelete="cascade",
+        index=True,
+        help="Staging instance to be refreshed.",
+    )
+    source_instance_id = fields.Many2one(
+        "k8s.odoo.instance",
+        string="Source Production Instance",
+        required=True,
+        ondelete="restrict",
+        index=True,
+        help="Production instance to clone DB + filestore from.",
+    )
+    cluster_id = fields.Many2one(
+        "k8s.cluster",
+        related="target_instance_id.cluster_id",
+        store=True,
+        index=True,
+    )
+    state = fields.Selection(
+        [
+            ("pending", "Pending"),
+            ("running", "Running"),
+            ("completed", "Completed"),
+            ("failed", "Failed"),
+        ],
+        default="pending",
+    )
+    filestore_method = fields.Selection(
+        [
+            ("auto", "Auto"),
+            ("snapshot", "Snapshot"),
+            ("copy", "Copy"),
+        ],
+        default="auto",
+        required=True,
+        help="Operator strategy for filestore replication.",
+    )
+    skip_filestore = fields.Boolean(
+        default=False,
+        help="If checked, only clone the database and skip filestore replication.",
+    )
+    neutralize = fields.Boolean(
+        default=True,
+        help="Neutralize the cloned database (reset UUIDs, secrets, disable crons).",
+    )
+    refresh_job_name = fields.Char(string="OdooStagingRefreshJob CR", readonly=True)
+    db_job_name = fields.Char(string="DB Job", readonly=True)
+    filestore_job_name = fields.Char(string="Filestore Job", readonly=True)
+    neutralize_job_name = fields.Char(string="Neutralize Job", readonly=True)
+    temp_db_name = fields.Char(string="Temp DB", readonly=True)
+    source_snapshot = fields.Char(readonly=True)
+    rollback_snapshot = fields.Char(readonly=True)
+    start_time = fields.Datetime()
+    completion_time = fields.Datetime()
+    message = fields.Text()
+    webhook_token = fields.Char(readonly=True, copy=False)
+
+    @api.constrains("target_instance_id", "source_instance_id")
+    def _check_target_and_source(self):
+        for record in self:
+            target = record.target_instance_id
+            source = record.source_instance_id
+            if not target or not source:
+                continue
+            if target.environment != "staging":
+                raise ValidationError(
+                    _("Target instance must be a Staging instance.")
+                )
+            if source.environment != "production":
+                raise ValidationError(
+                    _("Source instance must be a Production instance.")
+                )
+            if (
+                target.cluster_id != source.cluster_id
+                or target.namespace != source.namespace
+            ):
+                raise ValidationError(
+                    _(
+                        "Target and source must be on the same cluster and "
+                        "in the same namespace."
+                    )
+                )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            if not vals.get("name") or vals.get("name") == "New":
+                vals["name"] = (
+                    self.env["ir.sequence"].next_by_code("k8s.odoo.staging.refresh")
+                    or "New"
+                )
+            if not vals.get("webhook_token"):
+                vals["webhook_token"] = secrets.token_urlsafe(32)
+
+        records = super().create(vals_list)
+
+        for record in records:
+            record._create_refresh_job_cr()
+
+        return records
+
+    def _create_refresh_job_cr(self):
+        """Create the OdooStagingRefreshJob custom resource in Kubernetes."""
+        self.ensure_one()
+        from kubernetes import client
+
+        target = self.target_instance_id
+        source = self.source_instance_id
+        cluster = self.cluster_id
+
+        if not cluster:
+            raise UserError(_("No cluster associated with this refresh."))
+
+        base_url = cluster.webhook_base_url or self.env[
+            "ir.config_parameter"
+        ].sudo().get_param("web.base.url")
+        db_name = self.env.cr.dbname
+        webhook_url = (
+            f"{base_url}/k8s/staging_refresh/webhook/{self.id}?db={db_name}"
+        )
+
+        # Owner-reference lookup for the target OdooInstance
+        k8s_client = cluster._get_k8s_client()
+        custom_api = client.CustomObjectsApi(k8s_client)
+        try:
+            instance_cr = custom_api.get_namespaced_custom_object(
+                group="bemade.org",
+                version="v1alpha1",
+                namespace=target.namespace,
+                plural="odooinstances",
+                name=target.name,
+            )
+            instance_uid = instance_cr.get("metadata", {}).get("uid")
+        except Exception as e:
+            _logger.warning("Could not get OdooInstance UID for refresh: %s", e)
+            instance_uid = None
+
+        metadata = {
+            "generateName": f"{target.name}-refresh-",
+            "namespace": target.namespace,
+        }
+        if instance_uid:
+            metadata["ownerReferences"] = [
+                {
+                    "apiVersion": "bemade.org/v1alpha1",
+                    "kind": "OdooInstance",
+                    "name": target.name,
+                    "uid": instance_uid,
+                    "blockOwnerDeletion": True,
+                }
+            ]
+
+        spec = {
+            "odooInstanceRef": {
+                "name": target.name,
+                "namespace": target.namespace,
+            },
+            "source": {
+                "instanceName": source.name,
+                "instanceNamespace": source.namespace,
+            },
+            "filestoreMethod": self.filestore_method,
+            "skipFilestore": self.skip_filestore,
+            "neutralize": self.neutralize,
+            "webhook": {
+                "url": webhook_url,
+                "token": self.webhook_token,
+            },
+        }
+
+        body = {
+            "apiVersion": "bemade.org/v1alpha1",
+            "kind": "OdooStagingRefreshJob",
+            "metadata": metadata,
+            "spec": spec,
+        }
+
+        try:
+            k8s_client = cluster._get_k8s_client()
+            custom_api = client.CustomObjectsApi(k8s_client)
+            result = custom_api.create_namespaced_custom_object(
+                group="bemade.org",
+                version="v1alpha1",
+                namespace=target.namespace,
+                plural="odoostagingrefreshjobs",
+                body=body,
+            )
+            self.refresh_job_name = result.get("metadata", {}).get("name")
+            _logger.info(
+                "Created OdooStagingRefreshJob %s for refresh %s",
+                self.refresh_job_name,
+                self.name,
+            )
+        except Exception as e:
+            _logger.error(
+                "Failed to create OdooStagingRefreshJob for %s: %s", self.name, e
+            )
+            self.state = "failed"
+            self.message = str(e)
+            raise UserError(_("Failed to create staging refresh job: %s") % str(e))
+
+    def mark_running(self, start_time=None, status=None):
+        status = status or {}
+        for record in self:
+            vals = {"state": "running"}
+            if start_time:
+                vals["start_time"] = start_time
+            for key, field_name in (
+                ("dbJobName", "db_job_name"),
+                ("filestoreJobName", "filestore_job_name"),
+                ("neutralizeJobName", "neutralize_job_name"),
+                ("tempDbName", "temp_db_name"),
+                ("sourceSnapshot", "source_snapshot"),
+                ("rollbackSnapshot", "rollback_snapshot"),
+            ):
+                if status.get(key):
+                    vals[field_name] = status[key]
+            record.write(vals)
+
+    def mark_completed(self, completion_time=None, message=None, status=None):
+        status = status or {}
+        for record in self:
+            vals = {"state": "completed"}
+            if completion_time:
+                vals["completion_time"] = completion_time
+            if message:
+                vals["message"] = message
+            for key, field_name in (
+                ("dbJobName", "db_job_name"),
+                ("filestoreJobName", "filestore_job_name"),
+                ("neutralizeJobName", "neutralize_job_name"),
+                ("tempDbName", "temp_db_name"),
+                ("sourceSnapshot", "source_snapshot"),
+                ("rollbackSnapshot", "rollback_snapshot"),
+            ):
+                if status.get(key):
+                    vals[field_name] = status[key]
+            record.write(vals)
+
+    def mark_failed(self, message=None, completion_time=None, status=None):
+        status = status or {}
+        for record in self:
+            vals = {"state": "failed"}
+            if completion_time:
+                vals["completion_time"] = completion_time
+            if message:
+                vals["message"] = message
+            for key, field_name in (
+                ("dbJobName", "db_job_name"),
+                ("filestoreJobName", "filestore_job_name"),
+                ("neutralizeJobName", "neutralize_job_name"),
+                ("tempDbName", "temp_db_name"),
+                ("sourceSnapshot", "source_snapshot"),
+                ("rollbackSnapshot", "rollback_snapshot"),
+            ):
+                if status.get(key):
+                    vals[field_name] = status[key]
+            record.write(vals)

--- a/odoo_herd/security/ir.model.access.csv
+++ b/odoo_herd/security/ir.model.access.csv
@@ -32,3 +32,7 @@ access_k8s_odoo_upgrade_user,k8s.odoo.upgrade user,model_k8s_odoo_upgrade,group_
 access_k8s_odoo_upgrade_manager,k8s.odoo.upgrade manager,model_k8s_odoo_upgrade,group_k8s_manager,1,1,1,1
 access_k8s_odoo_instance_backup_schedule_user,k8s.odoo.instance.backup.schedule user,model_k8s_odoo_instance_backup_schedule,group_k8s_user,1,0,0,0
 access_k8s_odoo_instance_backup_schedule_manager,k8s.odoo.instance.backup.schedule manager,model_k8s_odoo_instance_backup_schedule,group_k8s_manager,1,1,1,1
+access_k8s_odoo_staging_refresh_user,k8s.odoo.staging.refresh user,model_k8s_odoo_staging_refresh,group_k8s_user,1,0,0,0
+access_k8s_odoo_staging_refresh_manager,k8s.odoo.staging.refresh manager,model_k8s_odoo_staging_refresh,group_k8s_manager,1,1,1,1
+access_k8s_staging_refresh_wizard_user,k8s.staging.refresh.wizard user,model_k8s_staging_refresh_wizard,group_k8s_user,1,1,1,1
+access_k8s_staging_refresh_wizard_manager,k8s.staging.refresh.wizard manager,model_k8s_staging_refresh_wizard,group_k8s_manager,1,1,1,1

--- a/odoo_herd/tests/__init__.py
+++ b/odoo_herd/tests/__init__.py
@@ -3,3 +3,5 @@ from . import test_create_instance_wizard
 from . import test_create_instance_wizard_view
 from . import test_deployment_strategy
 from . import test_probe_configuration
+from . import test_k8s_odoo_instance_production_ref
+from . import test_k8s_create_instance_wizard_clone_prod

--- a/odoo_herd/tests/test_k8s_create_instance_wizard_clone_prod.py
+++ b/odoo_herd/tests/test_k8s_create_instance_wizard_clone_prod.py
@@ -1,0 +1,127 @@
+from unittest.mock import patch
+from typing import Any, cast
+
+from odoo.exceptions import UserError
+from odoo.tests.common import TransactionCase
+
+
+class TestCreateInstanceWizardCloneProd(TransactionCase):
+    @classmethod
+    def setUpClass(cls):  # type: ignore[misc]
+        super().setUpClass()
+        env: Any = cls.env
+        cls.cluster = cast(
+            Any,
+            env["k8s.cluster"].create(
+                {
+                    "name": "test-cluster",
+                    "api_endpoint": "https://k8s.example.com",
+                    "kubeconfig": "{}",
+                    "default_namespace": "odoo",
+                    "webhook_base_url": "http://odoo.example.com",
+                }
+            ),
+        )
+        cls.prod_instance = cast(
+            Any,
+            env["k8s.odoo.instance"].create(
+                {
+                    "cluster_id": cls.cluster.id,
+                    "name": "prod-source",
+                    "namespace": "odoo",
+                    "environment": "production",
+                }
+            ),
+        )
+
+    def _make_wizard(self, **kwargs):
+        vals = {
+            "cluster_id": self.cluster.id,
+            "name": "stg-new",
+            "namespace": "odoo",
+            "image": "odoo:19.0",
+            "replicas": 1,
+            "admin_password": "admin",
+            "ingress_hosts": "stg.example.com",
+            "filestore_size": "10Gi",
+            "filestore_storage_class": "standard",
+            "cluster_issuer": "lets-encrypt",
+        }
+        vals.update(kwargs)
+        env: Any = self.env
+        return cast(
+            Any,
+            env["k8s.create.instance.wizard"]
+            .with_context(default_cluster_id=self.cluster.id)
+            .create(vals),
+        )
+
+    def test_clone_prod_builds_expected_spec(self):
+        wiz = self._make_wizard(
+            environment="staging",
+            initialization_mode="clone_prod",
+            production_instance_id=self.prod_instance.id,
+        )
+        spec = wiz._build_instance_spec(["stg.example.com"])
+        self.assertEqual(spec["environment"], "Staging")
+        self.assertEqual(
+            spec["productionInstanceRef"],
+            {"name": self.prod_instance.name},
+        )
+        self.assertFalse(spec["init"]["enabled"])
+
+    def test_clone_prod_requires_source(self):
+        wiz = self._make_wizard(
+            environment="staging",
+            initialization_mode="clone_prod",
+            production_instance_id=False,
+        )
+        with self.assertRaises(UserError):
+            wiz._validate_initialization_mode()
+
+    def test_clone_prod_rejected_when_production(self):
+        wiz = self._make_wizard(
+            environment="production",
+            initialization_mode="clone_prod",
+            production_instance_id=self.prod_instance.id,
+        )
+        with self.assertRaises(UserError):
+            wiz._validate_initialization_mode()
+
+    def test_action_create_instance_clone_prod_submits_production_instance_ref(self):
+        from odoo.addons.odoo_herd.tests.test_create_instance_wizard import (
+            FakeCoreV1Api,
+            FakeCustomObjectsApi,
+        )
+
+        fake_core = FakeCoreV1Api(should_exist=False)
+        fake_custom = FakeCustomObjectsApi()
+
+        with (
+            patch("kubernetes.client.CustomObjectsApi", return_value=fake_custom),
+            patch("kubernetes.client.CoreV1Api", return_value=fake_core),
+            patch(
+                "odoo.addons.odoo_herd.models.k8s_cluster.K8sCluster._get_k8s_client",
+                return_value="fake-client",
+            ),
+            patch(
+                "odoo.addons.odoo_herd.models.k8s_cluster.K8sCluster.sync_odoo_instances",
+                autospec=True,
+            ),
+        ):
+            wiz = self._make_wizard(
+                environment="staging",
+                initialization_mode="clone_prod",
+                production_instance_id=self.prod_instance.id,
+            )
+            wiz.action_create_instance()
+
+        instance_body = next(
+            c["body"] for c in fake_custom.created if c["plural"] == "odooinstances"
+        )
+        self.assertEqual(instance_body["spec"]["environment"], "Staging")
+        self.assertEqual(
+            instance_body["spec"]["productionInstanceRef"],
+            {"name": self.prod_instance.name},
+        )
+        self.assertFalse(instance_body["spec"]["init"]["enabled"])

--- a/odoo_herd/tests/test_k8s_odoo_instance_production_ref.py
+++ b/odoo_herd/tests/test_k8s_odoo_instance_production_ref.py
@@ -1,0 +1,55 @@
+from typing import Any, cast
+
+from odoo.exceptions import UserError
+from odoo.tests.common import TransactionCase
+from odoo.tools.misc import mute_logger
+
+
+class TestOdooInstanceProductionRef(TransactionCase):
+    @classmethod
+    def setUpClass(cls):  # type: ignore[misc]
+        super().setUpClass()
+        env: Any = cls.env
+        cls.cluster = cast(
+            Any,
+            env["k8s.cluster"].create(
+                {
+                    "name": "test-cluster",
+                    "api_endpoint": "https://k8s.example.com",
+                    "kubeconfig": "{}",
+                    "default_namespace": "odoo",
+                    "webhook_base_url": "http://odoo.example.com",
+                }
+            ),
+        )
+
+    def _make_instance(self, **kwargs):
+        vals = {
+            "cluster_id": self.cluster.id,
+            "name": "prod",
+            "namespace": "odoo",
+            "environment": "production",
+        }
+        vals.update(kwargs)
+        env: Any = self.env
+        return cast(Any, env["k8s.odoo.instance"].create(vals))
+
+    @mute_logger("odoo.sql_db")
+    def test_production_with_source_ref_raises(self):
+        prod = self._make_instance(name="prod-a", environment="production")
+        with self.assertRaises(UserError):
+            self._make_instance(
+                name="prod-b",
+                environment="production",
+                production_instance_id=prod.id,
+            )
+
+    def test_staging_with_source_ref_saves_cleanly(self):
+        prod = self._make_instance(name="prod-c", environment="production")
+        staging = self._make_instance(
+            name="stg-c",
+            environment="staging",
+            production_instance_id=prod.id,
+        )
+        self.assertEqual(staging.environment, "staging")
+        self.assertEqual(staging.production_instance_id, prod)

--- a/odoo_herd/views/k8s_menu_views.xml
+++ b/odoo_herd/views/k8s_menu_views.xml
@@ -59,6 +59,13 @@
               sequence="30"
               groups="group_k8s_user"/>
 
+    <menuitem id="menu_k8s_staging_refreshes"
+              name="Staging Refresh Jobs"
+              parent="menu_k8s_backup_restore"
+              action="action_k8s_odoo_staging_refresh"
+              sequence="35"
+              groups="group_k8s_user"/>
+
     <menuitem id="menu_k8s_upload_backup"
               name="Upload Backup"
               parent="menu_k8s_backup_restore"

--- a/odoo_herd/views/k8s_odoo_instance_views.xml
+++ b/odoo_herd/views/k8s_odoo_instance_views.xml
@@ -9,6 +9,7 @@
                 <field name="name"/>
                 <field name="cluster_id"/>
                 <field name="namespace"/>
+                <field name="environment" widget="badge"/>
                 <field name="current_image"/>
                 <field name="current_replicas"/>
                 <field name="ready_replicas"/>
@@ -28,6 +29,7 @@
                     <button name="action_view_logs" string="View Logs" type="object" class="btn-secondary"/>
                     <button name="%(action_k8s_backup_wizard)d" string="Backup now" type="action" class="btn-secondary" context="{'default_instance_id': id}"/>
                     <button name="%(action_k8s_upgrade_wizard)d" string="Upgrade" type="action" class="btn-info" context="{'default_instance_id': id}"/>
+                    <button name="%(action_k8s_staging_refresh_wizard)d" string="Refresh from Production" type="action" class="btn-warning" invisible="environment != 'staging'" context="{'default_target_instance_id': id}"/>
                     <button name="action_reset_to_current" string="Reset to Current" type="object" class="btn-secondary" confirm="This will reset all your changes to current cluster values. Continue?"/>
                     <button name="action_sync_to_cluster" string="Sync to Cluster" type="object" class="btn-warning" confirm="This will apply your changes to the Kubernetes cluster. Continue?"/>
                     <button name="%(action_k8s_delete_instance_wizard)d" string="⚠️ DELETE INSTANCE" type="action" class="btn-danger" context="{'default_instance_id': id}"/>
@@ -47,6 +49,9 @@
                         <group>
                             <field name="cluster_id" readonly="1"/>
                             <field name="namespace" readonly="1"/>
+                            <field name="environment" widget="badge"/>
+                            <field name="production_instance_id" options="{'no_create': True}"
+                                   domain="[('cluster_id', '=', cluster_id), ('namespace', '=', namespace), ('environment', '=', 'production'), ('id', '!=', id)]"/>
                             <field name="phase" widget="badge"/>
                         </group>
                         <group>
@@ -413,6 +418,9 @@
                 <field name="namespace"/>
                 <field name="current_image"/>
                 <field name="url"/>
+                <separator/>
+                <filter string="Staging" name="staging" domain="[('environment', '=', 'staging')]"/>
+                <filter string="Production" name="production" domain="[('environment', '=', 'production')]"/>
                 <separator/>
                 <filter string="Running" name="running" domain="[('phase', '=', 'Running')]"/>
                 <filter string="Upgrading" name="upgrading" domain="[('phase', '=', 'Upgrading')]"/>

--- a/odoo_herd/views/k8s_staging_refresh_views.xml
+++ b/odoo_herd/views/k8s_staging_refresh_views.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_k8s_odoo_staging_refresh_list" model="ir.ui.view">
+        <field name="name">k8s.odoo.staging.refresh.list</field>
+        <field name="model">k8s.odoo.staging.refresh</field>
+        <field name="arch" type="xml">
+            <list string="Staging Refresh Jobs"
+                  decoration-success="state == 'completed'"
+                  decoration-danger="state == 'failed'"
+                  decoration-info="state == 'running'"
+                  decoration-muted="state == 'pending'">
+                <field name="name"/>
+                <field name="target_instance_id"/>
+                <field name="source_instance_id"/>
+                <field name="cluster_id"/>
+                <field name="state" widget="badge"
+                       decoration-success="state == 'completed'"
+                       decoration-danger="state == 'failed'"
+                       decoration-info="state == 'running'"
+                       decoration-warning="state == 'pending'"/>
+                <field name="filestore_method"/>
+                <field name="skip_filestore"/>
+                <field name="neutralize"/>
+                <field name="create_date"/>
+                <field name="completion_time"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="view_k8s_odoo_staging_refresh_form" model="ir.ui.view">
+        <field name="name">k8s.odoo.staging.refresh.form</field>
+        <field name="model">k8s.odoo.staging.refresh</field>
+        <field name="arch" type="xml">
+            <form string="Staging Refresh Job">
+                <header>
+                    <field name="state" widget="statusbar" statusbar_visible="pending,running,completed,failed"/>
+                </header>
+                <sheet>
+                    <div class="oe_title">
+                        <h1>
+                            <field name="name" readonly="1"/>
+                        </h1>
+                    </div>
+                    <group>
+                        <group string="Instances">
+                            <field name="target_instance_id"/>
+                            <field name="source_instance_id"/>
+                            <field name="cluster_id"/>
+                        </group>
+                        <group string="Options">
+                            <field name="filestore_method"/>
+                            <field name="skip_filestore"/>
+                            <field name="neutralize"/>
+                        </group>
+                    </group>
+                    <group>
+                        <group string="Timing">
+                            <field name="create_date"/>
+                            <field name="start_time"/>
+                            <field name="completion_time"/>
+                        </group>
+                        <group string="Kubernetes">
+                            <field name="refresh_job_name"/>
+                            <field name="db_job_name"/>
+                            <field name="filestore_job_name"/>
+                            <field name="neutralize_job_name"/>
+                        </group>
+                    </group>
+                    <group>
+                        <group string="Snapshots &amp; Temp DB">
+                            <field name="temp_db_name"/>
+                            <field name="source_snapshot"/>
+                            <field name="rollback_snapshot"/>
+                        </group>
+                    </group>
+                    <group string="Status" invisible="not message">
+                        <field name="message" nolabel="1" colspan="2"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_k8s_odoo_staging_refresh_search" model="ir.ui.view">
+        <field name="name">k8s.odoo.staging.refresh.search</field>
+        <field name="model">k8s.odoo.staging.refresh</field>
+        <field name="arch" type="xml">
+            <search string="Staging Refresh Jobs">
+                <field name="name"/>
+                <field name="target_instance_id"/>
+                <field name="source_instance_id"/>
+                <field name="cluster_id"/>
+                <filter string="Pending" name="pending" domain="[('state', '=', 'pending')]"/>
+                <filter string="Running" name="running" domain="[('state', '=', 'running')]"/>
+                <filter string="Completed" name="completed" domain="[('state', '=', 'completed')]"/>
+                <filter string="Failed" name="failed" domain="[('state', '=', 'failed')]"/>
+                <separator/>
+                <group>
+                    <filter string="Target" name="group_target" context="{'group_by': 'target_instance_id'}"/>
+                    <filter string="Cluster" name="group_cluster" context="{'group_by': 'cluster_id'}"/>
+                    <filter string="State" name="group_state" context="{'group_by': 'state'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <record id="action_k8s_odoo_staging_refresh" model="ir.actions.act_window">
+        <field name="name">Staging Refresh Jobs</field>
+        <field name="res_model">k8s.odoo.staging.refresh</field>
+        <field name="view_mode">list,form</field>
+        <field name="search_view_id" ref="view_k8s_odoo_staging_refresh_search"/>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                No staging refresh jobs yet
+            </p>
+            <p>
+                Refresh a staging instance using the "Refresh from Production" button
+                on the staging instance's form.
+            </p>
+        </field>
+    </record>
+</odoo>

--- a/odoo_herd/wizards/__init__.py
+++ b/odoo_herd/wizards/__init__.py
@@ -6,3 +6,4 @@ from . import k8s_delete_instance_wizard
 from . import k8s_restore_backup_wizard
 from . import k8s_backup_wizard
 from . import k8s_upload_backup_wizard
+from . import k8s_staging_refresh_wizard

--- a/odoo_herd/wizards/k8s_create_instance_wizard.py
+++ b/odoo_herd/wizards/k8s_create_instance_wizard.py
@@ -51,17 +51,41 @@ class K8sCreateInstanceWizard(models.TransientModel):
         help="Hostnames for ingress (one per line)",
     )
 
+    environment = fields.Selection(
+        [
+            ("staging", "Staging"),
+            ("production", "Production"),
+        ],
+        string="Environment",
+        default="staging",
+        required=True,
+        help=(
+            "Whether this is a Staging or Production instance. "
+            "Staging is the safer default per the CRD schema."
+        ),
+    )
+
     # Initialization options
     initialization_mode = fields.Selection(
         [
             ("fresh", "Fresh Database"),
             ("restore", "Restore from Odoo Instance"),
             ("backup", "Restore from Backup"),
+            ("clone_prod", "Clone from Production Instance"),
         ],
         string="Initialization Mode",
         default="fresh",
         required=True,
         help="How to initialize the database",
+    )
+
+    production_instance_id = fields.Many2one(
+        "k8s.odoo.instance",
+        string="Source Production Instance",
+        help=(
+            "When cloning from a production instance, the operator auto-creates "
+            "an OdooStagingRefreshJob to seed this staging instance."
+        ),
     )
 
     install_demo_data = fields.Boolean(
@@ -226,6 +250,7 @@ class K8sCreateInstanceWizard(models.TransientModel):
             "image": self.image,
             "adminPassword": self.admin_password,
             "replicas": self.replicas,
+            "environment": "Production" if self.environment == "production" else "Staging",
         }
 
         # Add image pull secret if specified
@@ -294,7 +319,7 @@ class K8sCreateInstanceWizard(models.TransientModel):
             instance_spec["probes"] = probes
 
         # Database initialization - the operator auto-creates an OdooInitJob
-        # when init.enabled is true (default). Disable for restore modes.
+        # when init.enabled is true (default). Disable for restore and clone modes.
         if self.initialization_mode == "fresh":
             instance_spec["init"] = {
                 "enabled": True,
@@ -303,6 +328,12 @@ class K8sCreateInstanceWizard(models.TransientModel):
             }
         else:
             instance_spec["init"] = {"enabled": False}
+
+        # Clone-from-production: operator will auto-create an OdooStagingRefreshJob
+        if self.initialization_mode == "clone_prod" and self.production_instance_id:
+            instance_spec["productionInstanceRef"] = {
+                "name": self.production_instance_id.name,
+            }
 
         return instance_spec
 
@@ -328,6 +359,20 @@ class K8sCreateInstanceWizard(models.TransientModel):
                 raise UserError(_("Please select a backup to restore from"))
             if not self.backup_id.s3_config_id:
                 raise UserError(_("Selected backup has no S3 configuration"))
+
+        # Validate clone-from-production requirements
+        if self.initialization_mode == "clone_prod":
+            if self.environment == "production":
+                raise UserError(
+                    _(
+                        "Cloning from a production instance is only allowed "
+                        "when the new instance environment is Staging."
+                    )
+                )
+            if not self.production_instance_id:
+                raise UserError(
+                    _("Please select a source production instance to clone from.")
+                )
 
     def _build_webhook_url(self):
         # Build webhook URL for status updates
@@ -482,5 +527,10 @@ class K8sCreateInstanceWizard(models.TransientModel):
         elif self.initialization_mode == "backup":
             return (
                 f"Restoring from backup '{self.backup_id.name}'.{restore_message}"
+            )
+        elif self.initialization_mode == "clone_prod":
+            return (
+                "Operator will auto-create an OdooStagingRefreshJob to clone "
+                f"from '{self.production_instance_id.name}'."
             )
         return ""

--- a/odoo_herd/wizards/k8s_create_instance_wizard_views.xml
+++ b/odoo_herd/wizards/k8s_create_instance_wizard_views.xml
@@ -18,6 +18,7 @@
                             <field name="image"/>
                             <field name="admin_password" password="True"/>
                             <field name="ingress_hosts" widget="text" placeholder="myinstance.example.com&#10;(one per line)"/>
+                            <field name="environment" widget="radio"/>
                         </group>
                     </group>
                     
@@ -52,6 +53,24 @@
                             <field name="install_demo_data"/>
                         </group>
                     </group>
+
+                    <group string="Clone from Production Instance" invisible="initialization_mode != 'clone_prod'">
+                        <group>
+                            <field name="production_instance_id"
+                                   options="{'no_create': True, 'no_open': True}"
+                                   required="initialization_mode == 'clone_prod'"
+                                   domain="[('cluster_id', '=', cluster_id), ('namespace', '=', namespace), ('environment', '=', 'production')]"/>
+                        </group>
+                    </group>
+
+                    <div class="alert alert-info" role="alert" invisible="initialization_mode != 'clone_prod'">
+                        <p><strong>Clone from Production Instance:</strong></p>
+                        <ul>
+                            <li>The instance will be created as Staging</li>
+                            <li>The operator will auto-create an OdooStagingRefreshJob to seed DB + filestore from the source production instance</li>
+                            <li>The cloned database will be neutralized</li>
+                        </ul>
+                    </div>
 
                     <div class="alert alert-info" role="alert" invisible="initialization_mode != 'fresh'">
                         <p><strong>Fresh Database:</strong></p>

--- a/odoo_herd/wizards/k8s_staging_refresh_wizard.py
+++ b/odoo_herd/wizards/k8s_staging_refresh_wizard.py
@@ -1,0 +1,121 @@
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError, ValidationError
+
+
+class K8sStagingRefreshWizard(models.TransientModel):
+    _name = "k8s.staging.refresh.wizard"
+    _description = "Refresh Staging Instance from Production Wizard"
+
+    target_instance_id = fields.Many2one(
+        "k8s.odoo.instance",
+        string="Target Staging Instance",
+        required=True,
+        domain="[('environment', '=', 'staging')]",
+        help="Staging instance whose DB and filestore will be replaced.",
+    )
+    source_instance_id = fields.Many2one(
+        "k8s.odoo.instance",
+        string="Source Production Instance",
+        required=True,
+        domain="[('cluster_id', '=', cluster_id), ('namespace', '=', namespace), ('environment', '=', 'production')]",
+        help="Production instance to clone from.",
+    )
+    cluster_id = fields.Many2one(
+        "k8s.cluster",
+        related="target_instance_id.cluster_id",
+        readonly=True,
+    )
+    namespace = fields.Char(related="target_instance_id.namespace", readonly=True)
+    filestore_method = fields.Selection(
+        [
+            ("auto", "Auto"),
+            ("snapshot", "Snapshot"),
+            ("copy", "Copy"),
+        ],
+        default="auto",
+        required=True,
+    )
+    skip_filestore = fields.Boolean(default=False)
+    neutralize = fields.Boolean(default=True)
+    confirmation_name = fields.Char(
+        string="Type target instance name to confirm",
+    )
+
+    @api.onchange("target_instance_id")
+    def _onchange_target_instance_id(self):
+        if self.target_instance_id and self.source_instance_id:
+            if (
+                self.source_instance_id.cluster_id != self.target_instance_id.cluster_id
+                or self.source_instance_id.namespace != self.target_instance_id.namespace
+            ):
+                self.source_instance_id = False
+        if self.target_instance_id and self.target_instance_id.production_instance_id:
+            # Default to the instance's configured production source if set
+            self.source_instance_id = self.target_instance_id.production_instance_id
+
+    @api.constrains("confirmation_name", "target_instance_id")
+    def _check_confirmation(self):
+        for wizard in self:
+            if wizard.target_instance_id and wizard.confirmation_name:
+                if wizard.confirmation_name != wizard.target_instance_id.name:
+                    raise ValidationError(
+                        _(
+                            "Confirmation name does not match the target "
+                            "instance name."
+                        )
+                    )
+
+    def action_refresh(self):
+        self.ensure_one()
+
+        if not self.target_instance_id:
+            raise UserError(_("Please select a target staging instance."))
+        if not self.source_instance_id:
+            raise UserError(_("Please select a source production instance."))
+        if self.target_instance_id.environment != "staging":
+            raise UserError(_("Target instance must be a Staging instance."))
+        if self.source_instance_id.environment != "production":
+            raise UserError(_("Source instance must be a Production instance."))
+        if self.confirmation_name != self.target_instance_id.name:
+            raise UserError(
+                _(
+                    "Confirmation name '%s' does not match target instance name '%s'."
+                )
+                % (self.confirmation_name or "", self.target_instance_id.name)
+            )
+
+        refresh = self.env["k8s.odoo.staging.refresh"].create(
+            {
+                "target_instance_id": self.target_instance_id.id,
+                "source_instance_id": self.source_instance_id.id,
+                "filestore_method": self.filestore_method,
+                "skip_filestore": self.skip_filestore,
+                "neutralize": self.neutralize,
+            }
+        )
+
+        return {
+            "type": "ir.actions.client",
+            "tag": "display_notification",
+            "params": {
+                "title": _("Staging Refresh Started"),
+                "message": _(
+                    "Refresh job %s created. The staging instance %s will be "
+                    "replaced from %s."
+                )
+                % (
+                    refresh.name,
+                    self.target_instance_id.name,
+                    self.source_instance_id.name,
+                ),
+                "type": "warning",
+                "sticky": True,
+                "next": {
+                    "type": "ir.actions.act_window",
+                    "res_model": "k8s.odoo.staging.refresh",
+                    "res_id": refresh.id,
+                    "views": [(False, "form")],
+                    "target": "current",
+                },
+            },
+        }

--- a/odoo_herd/wizards/k8s_staging_refresh_wizard_views.xml
+++ b/odoo_herd/wizards/k8s_staging_refresh_wizard_views.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_k8s_staging_refresh_wizard_form" model="ir.ui.view">
+        <field name="name">k8s.staging.refresh.wizard.form</field>
+        <field name="model">k8s.staging.refresh.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Refresh Staging from Production">
+                <group>
+                    <div class="alert alert-danger" role="alert">
+                        <strong>WARNING:</strong> This operation will <strong>DROP</strong> the database
+                        on the target staging instance and replace it (and optionally the filestore) from the source production instance.
+                        This action cannot be undone!
+                    </div>
+                </group>
+                <group>
+                    <group string="Target (Staging)">
+                        <field name="target_instance_id" options="{'no_create': True, 'no_open': True}"/>
+                        <field name="cluster_id" readonly="1"/>
+                        <field name="namespace" readonly="1"/>
+                    </group>
+                    <group string="Source (Production)">
+                        <field name="source_instance_id" options="{'no_create': True, 'no_open': True}"/>
+                    </group>
+                </group>
+                <group>
+                    <group string="Options">
+                        <field name="filestore_method"/>
+                        <field name="skip_filestore"/>
+                        <field name="neutralize"/>
+                    </group>
+                    <group string="Confirmation">
+                        <div class="text-muted mb-2">
+                            To confirm, type the target instance name below:
+                        </div>
+                        <field name="confirmation_name" placeholder="Type instance name here..."/>
+                    </group>
+                </group>
+                <footer>
+                    <button name="action_refresh" string="Refresh" type="object" class="btn-danger"/>
+                    <button string="Cancel" class="btn-secondary" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_k8s_staging_refresh_wizard" model="ir.actions.act_window">
+        <field name="name">Refresh from Production</field>
+        <field name="res_model">k8s.staging.refresh.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Summary

Mirrors the odoo-operator v1.10.0 capabilities in `odoo_herd` (Odoo task #3527).

- `k8s.odoo.instance` gains `environment` (Staging/Production, default Staging) and `production_instance_id` (self-reference) fields, matching `OdooInstance.spec.environment` and `spec.productionInstanceRef` on the CRD. Two-way sync via `sync_odoo_instances`. Server-side constrain rejects `environment=production` + `production_instance_id` set (mirrors the CRD CEL rule).
- Create-instance wizard grows a new **"Clone from Production Instance"** initialization mode — pick a source prod instance from the same cluster/namespace, wizard submits the manifest with `spec.productionInstanceRef` set and `spec.init.enabled=false`, operator auto-creates the `OdooStagingRefreshJob` on first reconcile.
- New **"Refresh from Production"** header button on staging instances. Opens a wizard that creates a `k8s.odoo.staging.refresh` record, which posts an `OdooStagingRefreshJob` CR to the cluster (for explicit on-demand refreshes).
- New read-only `k8s.odoo.staging.refresh` model with all status fields the operator emits (phase, 3 job names, temp DB, source/rollback snapshots). Menu entry under `Backup / Restore`. Webhook controller at `/k8s/staging_refresh/webhook/<id>` mirrors the restore webhook.

Odoo task: https://odoo.bemade.org/odoo/project/18/tasks/3527
Operator PR that shipped the prerequisite: https://github.com/bemade/odoo-operator/pull/85

## Test plan

- [x] `odoo-dev test odoo_herd` — 53 tests, 0 failed, 0 errors. Includes 2 new tests:
  - `test_k8s_odoo_instance_production_ref` — constrain rejects prod+ref combo; staging+ref allowed.
  - `test_k8s_create_instance_wizard_clone_prod` — wizard `clone_prod` mode builds a spec with `environment: Staging`, `productionInstanceRef: {name}`, `init.enabled: False`.
- [ ] Manual smoke on staging: create an instance via the new "Clone from Production" mode, verify operator auto-creates the refresh job. Hit "Refresh from Production" on an existing staging instance, verify the refresh CR lands.

## Out of scope / follow-ups

- Periodic sync of `OdooStagingRefreshJob` CRs from the cluster (matches existing pattern — backup/restore/upgrade CRs aren't synced either; create-path + webhook updates cover visibility).
- Cross-namespace source (v1 operator constraint — same-namespace only).
- Downstream bemade-site submodule-pointer bump is a separate cycle after this merges.