### PR TITLE
fix(odoo_herd): follow-ups for productionInstanceRef rollout

### DIFF
--- a/odoo_herd/models/k8s_odoo_instance.py
+++ b/odoo_herd/models/k8s_odoo_instance.py
@@ -83,7 +83,12 @@ class K8sOdooInstance(models.Model):
             ("Stopped", "Stopped"),
             ("Upgrading", "Upgrading"),
             ("Restoring", "Restoring"),
+            ("CloningFromSource", "Cloning From Source"),
             ("BackingUp", "Backing Up"),
+            ("MigratingFilestore", "Migrating Filestore"),
+            ("FinalizingFilestoreMigration", "Finalizing Filestore Migration"),
+            ("MigratingDatabase", "Migrating Database"),
+            ("FinalizingDatabaseMigration", "Finalizing Database Migration"),
             ("Error", "Error"),
         ],
         string="Phase",
@@ -737,6 +742,18 @@ class K8sOdooInstance(models.Model):
         # Database cluster
         if self.database_cluster:
             patch["spec"]["database"] = {"cluster": self.database_cluster}
+
+        # Environment (Staging/Production)
+        if self.environment:
+            patch["spec"]["environment"] = (
+                "Production" if self.environment == "production" else "Staging"
+            )
+
+        # Production instance reference (staging only)
+        if self.production_instance_id and self.environment == "staging":
+            patch["spec"]["productionInstanceRef"] = {
+                "name": self.production_instance_id.name,
+            }
 
         # Deployment Strategy
         strategy = {"type": self.deployment_strategy_type}

--- a/odoo_herd/wizards/k8s_create_instance_wizard.py
+++ b/odoo_herd/wizards/k8s_create_instance_wizard.py
@@ -401,15 +401,29 @@ class K8sCreateInstanceWizard(models.TransientModel):
 
         _logger.info(f"Creating OdooInstance {self.name} in namespace {self.namespace}")
 
-        custom_api.create_namespaced_custom_object(
-            group="bemade.org",  # pyright: ignore
-            version="v1alpha1",
-            namespace=self.namespace,
-            plural="odooinstances",
-            body=body,
-        )
-
-        _logger.info(f"Successfully created OdooInstance {self.name}")
+        try:
+            custom_api.create_namespaced_custom_object(
+                group="bemade.org",  # pyright: ignore
+                version="v1alpha1",
+                namespace=self.namespace,
+                plural="odooinstances",
+                body=body,
+            )
+            _logger.info(f"Successfully created OdooInstance {self.name}")
+        except ApiException as e:
+            # Idempotent: Odoo retries the wizard transaction on serialization
+            # conflicts, which re-runs this non-idempotent k8s call. If the CR
+            # already exists from a prior attempt in the same logical apply,
+            # treat it as success and let sync_odoo_instances pick it up.
+            if e.status == 409:
+                _logger.warning(
+                    "OdooInstance %s/%s already exists — treating as idempotent "
+                    "success (likely a wizard transaction retry)",
+                    self.namespace,
+                    self.name,
+                )
+                return
+            raise
 
     def _create_backup_restore_job(self, custom_api):
         backup = self.backup_id


### PR DESCRIPTION
## Summary

Three follow-ups on PR #58 surfaced during first live use on bemade-site:

1. **Phase Selection missing `CloningFromSource`** — sync failed with `Wrong value for k8s.odoo.instance.phase: 'CloningFromSource'`. Added the missing phase plus 4 operator migration phases (`MigratingFilestore`, `FinalizingFilestoreMigration`, `MigratingDatabase`, `FinalizingDatabaseMigration`) that were also never represented.
2. **"Sync to Cluster" doesn't push `environment` / `productionInstanceRef`** — users couldn't retroactively bind an existing staging to a source prod via the UI. Both fields now emitted from `_build_patch_data`.
3. **Wizard 409 on retry** — Odoo retries the wizard transaction on serialization conflicts, re-running the non-idempotent `create_namespaced_custom_object`. The first call succeeded; the second got 409, surfacing to the user as a hard failure while the CR was actually created. Now treats 409 as idempotent success and lets `sync_odoo_instances` pick up the CR. Pre-existing, but hit more often with the new clone-from-production flow.

Surfaced by Marc testing `bemade-staging` creation from prod on the live cluster.

## Test plan

- [x] `odoo-dev test odoo_herd` — all pass.
- [ ] Redeploy to bemade-site; repeat the Clone from Production flow and confirm the three symptoms are gone.