### PR TITLE
Sports clinic updates: injury audit view, plain-text notes, Admin menu

### DIFF
--- a/bemade_sports_clinic/__manifest__.py
+++ b/bemade_sports_clinic/__manifest__.py
@@ -76,8 +76,8 @@ This module provides a complete sports medicine clinic management solution with 
         # "data/project_portal_demo_data.xml",  # Temporarily disabled for clean upgrade
         "data/cron_actions.xml",
         "views/sports_team_views.xml",
-        "views/sports_clinic_menus.xml",
         "views/sports_patient_injury_views.xml",
+        "views/sports_clinic_menus.xml",
         "views/sports_patient_views.xml",
         "views/sports_clinic_portal_views.xml",
         "views/sports_patient_injury_portal.xml",

--- a/bemade_sports_clinic/controllers/team_staff_portal.py
+++ b/bemade_sports_clinic/controllers/team_staff_portal.py
@@ -327,7 +327,8 @@ class TeamStaffPortal(CustomerPortal):
                 removal_team_id = sole_team_id
 
         can_request_removal = bool(is_coach and removal_team_id)
-        
+        can_direct_remove = bool(is_treatment_prof and removal_team_id)
+
         return http.request.render(
             template='bemade_sports_clinic.portal_my_player_injuries',
             qcontext={
@@ -339,8 +340,8 @@ class TeamStaffPortal(CustomerPortal):
                 'page_name': 'my_player',
                 'is_treatment_prof': is_treatment_prof,
                 'patient_info': patient_info,
-                # Removal request context for coaches
                 'can_request_removal': can_request_removal,
+                'can_direct_remove': can_direct_remove,
                 'removal_team_id': removal_team_id,
                 'team_context_id': team_context_id,
             }

--- a/bemade_sports_clinic/models/event_batch_invoicing_wizard.py
+++ b/bemade_sports_clinic/models/event_batch_invoicing_wizard.py
@@ -29,8 +29,11 @@ class SportsEventBatchInvoicingWizard(models.TransientModel):
 
     def _build_event_line_description(self, ts):
         event = ts.event_id
-        date_only = event.date_start and event.date_start.date() or None
-        date_str = fields.Date.to_string(date_only) if date_only else ''
+        if event.date_start:
+            local_start = fields.Datetime.context_timestamp(self, event.date_start)
+            date_str = fields.Date.to_string(local_start.date())
+        else:
+            date_str = ''
         if event.event_type == 'clinic':
             name = event.name or ''
             return f"{name}\n{date_str}"
@@ -38,14 +41,17 @@ class SportsEventBatchInvoicingWizard(models.TransientModel):
         venue = event.venue_id.name or ''
         return f"{team}\n{date_str} @ {venue}"
 
-    def _ensure_sale_order_for_partner(self, partner):
+    def _ensure_sale_order_for_partner(self, partner, earliest_date=None):
         so = self.env['sale.order'].search([
             ('partner_id', '=', partner.id),
             ('state', '=', 'draft')
         ], order='id desc', limit=1)
         if so:
             return so
-        return self.env['sale.order'].create({'partner_id': partner.id})
+        vals = {'partner_id': partner.id}
+        if earliest_date:
+            vals['date_order'] = earliest_date
+        return self.env['sale.order'].create(vals)
 
     def action_process(self):
         self.ensure_one()
@@ -72,7 +78,8 @@ class SportsEventBatchInvoicingWizard(models.TransientModel):
         created_sos = self.env['sale.order']
         for partner_id, evs in partners.items():
             partner = self.env['res.partner'].browse(partner_id)
-            so = self._ensure_sale_order_for_partner(partner)
+            earliest_date = min((e.date_start for e in evs if e.date_start), default=None)
+            so = self._ensure_sale_order_for_partner(partner, earliest_date=earliest_date)
             lang = partner.lang or so.partner_id.lang or self.env.user.lang
             created_sos |= so
             for ev in evs:

--- a/bemade_sports_clinic/models/event_invoicing_wizard.py
+++ b/bemade_sports_clinic/models/event_invoicing_wizard.py
@@ -75,8 +75,11 @@ class SportsEventInvoicingWizard(models.TransientModel):
         return self.env['product.product'].browse(pid) if pid else self.env['product.product']
 
     def _build_event_description(self, event):
-        date_only = event.date_start and event.date_start.date() or None
-        date_str = fields.Date.to_string(date_only) if date_only else ''
+        if event.date_start:
+            local_start = fields.Datetime.context_timestamp(self, event.date_start)
+            date_str = fields.Date.to_string(local_start.date())
+        else:
+            date_str = ''
         if event.event_type == 'clinic':
             name = event.name or ''
             return f"{name}\n{date_str}"
@@ -92,8 +95,11 @@ class SportsEventInvoicingWizard(models.TransientModel):
 
     def _build_line_description(self, ts):
         event = ts.event_id
-        date_only = event.date_start and event.date_start.date() or None
-        date_str = fields.Date.to_string(date_only) if date_only else ''
+        if event.date_start:
+            local_start = fields.Datetime.context_timestamp(self, event.date_start)
+            date_str = fields.Date.to_string(local_start.date())
+        else:
+            date_str = ''
         if event.event_type == 'clinic':
             name = event.name or ''
             return f"{name}\n{date_str}"
@@ -135,10 +141,9 @@ class SportsEventInvoicingWizard(models.TransientModel):
             ('state', '=', 'draft')
         ], order='id desc', limit=1)
         if not sale_order:
-            # Create a new draft quotation for this customer (pricelist & taxes handled by sale)
             sale_order = self.env['sale.order'].create({
                 'partner_id': customer.id,
-                # date_order defaults to now, pricelist auto from partner
+                'date_order': self.event_id.date_start,
             })
         # Merge per event like batch: single SOL per type
         created_lines = 0

--- a/bemade_sports_clinic/models/event_vendor_po_wizard.py
+++ b/bemade_sports_clinic/models/event_vendor_po_wizard.py
@@ -65,8 +65,11 @@ class SportsEventVendorPOWizard(models.TransientModel):
 
     def _build_line_description(self, ts):
         event = ts.event_id
-        date_only = event.date_start and event.date_start.date() or None
-        date_str = fields.Date.to_string(date_only) if date_only else ''
+        if event.date_start:
+            local_start = fields.Datetime.context_timestamp(self, event.date_start)
+            date_str = fields.Date.to_string(local_start.date())
+        else:
+            date_str = ''
         if event.event_type == 'clinic':
             name = (event.name or '')
             return f"{name}\n{date_str}"

--- a/bemade_sports_clinic/tests/__init__.py
+++ b/bemade_sports_clinic/tests/__init__.py
@@ -9,3 +9,4 @@ from . import test_mail_activity_portal_integration
 from . import test_project_task_portal_security
 from . import test_portal_activity_default_todo
 from . import test_portal_injury_autoassign_integration
+from . import test_event_invoicing_wizard

--- a/bemade_sports_clinic/tests/__init__.py
+++ b/bemade_sports_clinic/tests/__init__.py
@@ -10,3 +10,4 @@ from . import test_project_task_portal_security
 from . import test_portal_activity_default_todo
 from . import test_portal_injury_autoassign_integration
 from . import test_event_invoicing_wizard
+from . import test_team_org_backlink

--- a/bemade_sports_clinic/tests/test_event_invoicing_wizard.py
+++ b/bemade_sports_clinic/tests/test_event_invoicing_wizard.py
@@ -1,0 +1,187 @@
+# Acceptance criteria:
+# - When the single-event "Add to SO" wizard creates a new sale.order, date_order is set to
+#   the event's start date (not today/now).
+# - When an existing draft SO is used, its date_order is not changed by the wizard.
+# - When the batch "Add to SO" wizard creates a new sale.order, date_order is set to the
+#   earliest event start date among the events being processed for that partner.
+# - SO line descriptions use the local date of the event start, not the UTC date.
+#   (An event starting 8 PM EST on Nov 4 is midnight UTC on Nov 5 — must show Nov 4.)
+
+import datetime
+from datetime import timedelta
+
+import pytz
+
+from odoo import Command, fields
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("-at_install", "post_install")
+class TestEventInvoicingWizardDate(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.organization = cls.env["res.partner"].create({"name": "Test Org", "is_company": True})
+        cls.team = cls.env["sports.team"].create({
+            "name": "Test Team",
+            "parent_id": cls.organization.id,
+        })
+
+        cls.coverage_product = cls.env["product.product"].create({
+            "name": "Coverage",
+            "type": "service",
+            "uom_id": cls.env.ref("uom.product_uom_hour").id,
+        })
+        cls.travel_product = cls.env["product.product"].create({
+            "name": "Travel",
+            "type": "service",
+            "uom_id": cls.env.ref("uom.product_uom_hour").id,
+        })
+        cls.clinic_product = cls.env["product.product"].create({
+            "name": "Clinic",
+            "type": "service",
+            "uom_id": cls.env.ref("uom.product_uom_hour").id,
+        })
+
+        ICP = cls.env["ir.config_parameter"].sudo()
+        ICP.set_param("bemade_sports_clinic.product_event_coverage_customer_id", cls.coverage_product.id)
+        ICP.set_param("bemade_sports_clinic.product_event_travel_customer_id", cls.travel_product.id)
+        ICP.set_param("bemade_sports_clinic.product_event_clinic_customer_id", cls.clinic_product.id)
+
+        cls.therapist_user = cls.env["res.users"].with_context(no_reset_password=True).create({
+            "name": "Test Therapist",
+            "login": "therapist.invoice.test@example.com",
+            "groups_id": [Command.link(cls.env.ref("base.group_user").id)],
+        })
+
+        past_start = fields.Datetime.now() - timedelta(days=7, hours=2)
+        past_end = past_start + timedelta(hours=2)
+
+        cls.event = cls.env["sports.event"].create({
+            "name": "Test Event",
+            "team_ids": [Command.link(cls.team.id)],
+            "date_start": past_start,
+            "date_end": past_end,
+        })
+
+        cls.timesheet = cls.env["sports.event.timesheet"].create({
+            "event_id": cls.event.id,
+            "user_id": cls.therapist_user.id,
+            "coverage_duration": 2.0,
+        })
+
+    def test_new_so_date_order_is_event_start_date(self):
+        """When no draft SO exists, the created SO's date_order matches the event start date."""
+        wizard = self.env["sports.event.invoicing.wizard"].with_context(
+            active_id=self.event.id
+        ).create({"event_id": self.event.id})
+        wizard.action_process()
+
+        so = self.env["sale.order"].search(
+            [("partner_id", "=", self.organization.id)], limit=1
+        )
+        self.assertTrue(so, "A sale order should have been created")
+        self.assertEqual(
+            so.date_order.date(),
+            self.event.date_start.date(),
+            "SO date_order should equal the event start date, not today",
+        )
+
+    def test_existing_so_date_order_is_not_changed(self):
+        """When an existing draft SO is used, its date_order is preserved."""
+        original_date = fields.Datetime.now() - timedelta(days=30)
+        existing_so = self.env["sale.order"].create({
+            "partner_id": self.organization.id,
+            "date_order": original_date,
+        })
+
+        extra_ts = self.env["sports.event.timesheet"].create({
+            "event_id": self.event.id,
+            "user_id": self.therapist_user.id,
+            "coverage_duration": 1.0,
+        })
+        wizard = self.env["sports.event.invoicing.wizard"].with_context(
+            active_id=self.event.id
+        ).create({
+            "event_id": self.event.id,
+            "customer_sale_order_id": existing_so.id,
+        })
+        wizard.action_process()
+
+        existing_so.invalidate_recordset()
+        self.assertEqual(
+            existing_so.date_order.date(),
+            original_date.date(),
+            "Existing SO date_order should not be modified by the wizard",
+        )
+
+    def test_batch_wizard_new_so_uses_earliest_event_start_date(self):
+        """Batch wizard dates the new SO to the earliest event start among the selected events."""
+        earlier_start = self.event.date_start - timedelta(days=3)
+        earlier_event = self.env["sports.event"].create({
+            "name": "Earlier Event",
+            "team_ids": [Command.link(self.team.id)],
+            "date_start": earlier_start,
+            "date_end": earlier_start + timedelta(hours=2),
+        })
+        self.env["sports.event.timesheet"].create({
+            "event_id": earlier_event.id,
+            "user_id": self.therapist_user.id,
+            "coverage_duration": 1.5,
+        })
+
+        wizard = self.env["sports.event.batch_invoicing.wizard"].with_context(
+            active_ids=[self.event.id, earlier_event.id]
+        ).create({
+            "event_ids": [Command.set([self.event.id, earlier_event.id])],
+        })
+        wizard.action_process()
+
+        so = self.env["sale.order"].search(
+            [("partner_id", "=", self.organization.id)], order="id desc", limit=1
+        )
+        self.assertTrue(so, "A sale order should have been created")
+        self.assertEqual(
+            so.date_order.date(),
+            earlier_start.date(),
+            "Batch SO date_order should be the earliest event start date",
+        )
+
+    def test_so_line_description_uses_local_date_not_utc(self):
+        """Event starting 8 PM EST (= midnight+1h UTC next day) must appear in the
+        description as the local date, not the UTC date."""
+        est = pytz.timezone("America/Toronto")
+        # Nov 4 2025 20:00 EST = Nov 5 2025 01:00 UTC — raw .date() gives Nov 5 (wrong)
+        local_evening = est.localize(datetime.datetime(2025, 11, 4, 20, 0, 0))
+        utc_start = local_evening.astimezone(pytz.utc).replace(tzinfo=None)
+        utc_end = utc_start + timedelta(hours=2)
+
+        event = self.env["sports.event"].create({
+            "name": "Evening Game",
+            "team_ids": [Command.link(self.team.id)],
+            "date_start": utc_start,
+            "date_end": utc_end,
+        })
+        self.env["sports.event.timesheet"].create({
+            "event_id": event.id,
+            "user_id": self.therapist_user.id,
+            "coverage_duration": 2.0,
+        })
+
+        # Run the wizard with America/Toronto timezone in context
+        wizard = self.env["sports.event.invoicing.wizard"].with_context(
+            active_id=event.id, tz="America/Toronto"
+        ).create({"event_id": event.id})
+        wizard.action_process()
+
+        sol = self.env["sale.order.line"].search(
+            [("order_id.partner_id", "=", self.organization.id)], order="id desc", limit=1
+        )
+        self.assertTrue(sol, "A sale order line should have been created")
+        self.assertIn(
+            "2025-11-04",
+            sol.name,
+            "Description should contain the local date (Nov 4), not the UTC date (Nov 5)",
+        )

--- a/bemade_sports_clinic/tests/test_team_org_backlink.py
+++ b/bemade_sports_clinic/tests/test_team_org_backlink.py
@@ -1,0 +1,56 @@
+# Acceptance criteria:
+# - Creating a sports.team from the organization form view's "Teams" tab (owned_team_ids)
+#   must set parent_id to the organization automatically, via default_parent_id context.
+# - The team must appear in org.owned_team_ids after creation.
+
+from odoo.tests import TransactionCase, tagged
+from odoo.tests.common import Form
+
+
+@tagged("-at_install", "post_install")
+class TestTeamOrgBacklink(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.org = cls.env["res.partner"].create({"name": "Test Org", "is_company": True})
+
+    def test_create_team_from_org_form_sets_parent_id(self):
+        """Simulates clicking 'New' on owned_team_ids from the org form view.
+
+        The One2many widget must inject default_parent_id so the team's
+        parent_id is set to the organization without the user explicitly choosing it.
+        """
+        # Simulate the context the One2many widget injects when opening a new-record dialog
+        team_form = Form(
+            self.env["sports.team"].with_context(default_parent_id=self.org.id)
+        )
+        team_form.name = "Juniors"
+        team = team_form.save()
+
+        self.assertEqual(
+            team.parent_id,
+            self.org,
+            "Team parent_id should be set to the organization via default_parent_id context",
+        )
+        self.assertIn(
+            team,
+            self.org.owned_team_ids,
+            "Newly created team should appear in org.owned_team_ids",
+        )
+
+    def test_owned_team_ids_field_passes_default_parent_id(self):
+        """The owned_team_ids field on the partner form must have context={'default_parent_id': id}
+        so Odoo's One2many widget injects the correct default when the user clicks New.
+
+        This test verifies the view XML has the context attribute set.
+        """
+        view = self.env.ref(
+            "bemade_sports_clinic.res_partner_view_form_sports_teams"
+        )
+        self.assertIn(
+            "default_parent_id",
+            view.arch,
+            "owned_team_ids field must include context with default_parent_id "
+            "so new teams created from the org form are linked automatically",
+        )

--- a/bemade_sports_clinic/views/res_partner_views.xml
+++ b/bemade_sports_clinic/views/res_partner_views.xml
@@ -17,7 +17,7 @@
                     <group>
                         <field name="is_venue" string="Is Venue" help="Check this box if this contact represents a venue/location"/>
                     </group>
-                    <field invisible="is_company == False" name="owned_team_ids" string="Teams"/>
+                    <field invisible="is_company == False" name="owned_team_ids" string="Teams" context="{'default_parent_id': id}"/>
                     <field invisible="is_company == True" name="teams_served_ids" string="Teams Served">
                         <list editable="bottom" create="False" delete="True">
                             <field name="name"/>

--- a/bemade_sports_clinic/views/sports_clinic_menus.xml
+++ b/bemade_sports_clinic/views/sports_clinic_menus.xml
@@ -67,10 +67,17 @@
 
         <!-- Staff submenu (admin visibility) -->
         <menuitem id="sports_clinic_staff_menu"
-                  name="Staff"
+                  name="Admin"
                   parent="sports_clinic_root"
                   groups="bemade_sports_clinic.group_sports_clinic_admin"
                   sequence="80"/>
+
+        <menuitem id="sports_clinic_patient_injuries_audit"
+                  name="Injuries (Audit)"
+                  parent="sports_clinic_staff_menu"
+                  groups="base.group_no_one"
+                  action="action_view_patient_injury_audit"
+                  sequence="5"/>
         <menuitem id="sports_clinic_staff_timesheets"
                   name="Timesheets"
                   parent="sports_clinic_staff_menu"

--- a/bemade_sports_clinic/views/sports_clinic_portal_views.xml
+++ b/bemade_sports_clinic/views/sports_clinic_portal_views.xml
@@ -1085,8 +1085,13 @@
                     <a t-att-href="team_context_id and ('/my/patient/injury/new?patient_id=%s&amp;team_id=%s' % (player.id, team_context_id)) or ('/my/patient/injury/new?patient_id=%s' % player.id)" class="btn bg-o-color-1 text-white">
                         <i class="fa fa-plus"></i> <span t-if="request.env.user.has_group('bemade_sports_clinic.group_portal_treatment_professional')">Add Injury</span><span t-else="">Report Injury</span>
                     </a>
-                    <!-- Coach: Request Removal (visible only if can_request_removal True) -->
-                    <button t-if="is_treatment_prof" type="button" class="btn bg-o-color-2 text-white"
+                    <!-- Therapist: Direct removal button -->
+                    <button t-if="can_direct_remove" type="button" class="btn bg-o-color-2 text-white"
+                            data-bs-toggle="modal" t-attf-data-bs-target="#directRemoveModal{{ player.id }}">
+                        <i class="fa fa-user-times"></i> Remove Player
+                    </button>
+                    <!-- Coach: Request removal for review -->
+                    <button t-if="can_request_removal" type="button" class="btn bg-o-color-2 text-white"
                             data-bs-toggle="modal" t-attf-data-bs-target="#requestRemovalModal{{ player.id }}">
                         <i class="fa fa-user-times"></i> Request Removal
                     </button>
@@ -1106,7 +1111,31 @@
                     </a>
                 </div>
 
-                <!-- Request Removal Modal -->
+                <!-- Therapist: Direct Remove Modal -->
+                <div t-if="can_direct_remove and removal_team_id" t-attf-id="directRemoveModal{{ player.id }}" class="modal fade" tabindex="-1" aria-hidden="true">
+                    <div class="modal-dialog">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <h5 class="modal-title">Remove Player from Team</h5>
+                                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                            </div>
+                            <form t-attf-action="/my/team/{{ removal_team_id }}/player/{{ player.id }}/remove" method="post">
+                                <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+                                <div class="modal-body">
+                                    <p>Are you sure you want to remove <strong t-field="player.name"/> from this team?</p>
+                                </div>
+                                <div class="modal-footer">
+                                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                                    <button type="submit" class="btn btn-danger">
+                                        <i class="fa fa-user-times"></i> Remove Player
+                                    </button>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Coach: Request Removal Modal -->
                 <div t-if="can_request_removal and removal_team_id" t-attf-id="requestRemovalModal{{ player.id }}" class="modal fade" tabindex="-1" aria-hidden="true">
                     <div class="modal-dialog">
                         <div class="modal-content">

--- a/bemade_sports_clinic/views/sports_patient_injury_views.xml
+++ b/bemade_sports_clinic/views/sports_patient_injury_views.xml
@@ -115,8 +115,8 @@
                         </group>
                         <group>
                             <field name="parental_consent"/>
-                            <field name="internal_notes" widget="html"/>
-                            <field name="external_notes" widget="html"/>
+                            <field name="internal_notes"/>
+                            <field name="external_notes"/>
                             <field name="treatment_professional_ids"
                                    widget="many2many_tags_avatar"/>
                         </group>
@@ -191,6 +191,125 @@
                         context="{'default_patient_id': patient_id}"/>
             </list>
         </field>
+    </record>
+
+    <record id="sports_patient_injury_view_list_audit" model="ir.ui.view">
+        <field name="name">sports.patient.injury.view.list.audit</field>
+        <field name="model">sports.patient.injury</field>
+        <field name="arch" type="xml">
+            <list string="Patient Injuries (Audit)">
+                <field name="patient_id"/>
+                <field name="team_id"/>
+                <field name="stage"/>
+                <field name="injury_date" widget="date"/>
+                <field name="injury_date_na"/>
+                <field name="diagnosis"/>
+                <field name="parental_consent"/>
+                <field name="predicted_resolution_date" widget="date"/>
+                <field name="resolution_date" widget="date"/>
+                <field name="treatment_professional_ids" widget="many2many_avatar_user"/>
+                <field name="internal_notes" optional="hide"/>
+                <field name="external_notes" optional="hide"/>
+                <field name="document_count"/>
+                <field name="create_date" optional="hide"/>
+                <field name="write_date" optional="hide"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="sports_patient_injury_view_search_audit" model="ir.ui.view">
+        <field name="name">sports.patient.injury.view.search.audit</field>
+        <field name="model">sports.patient.injury</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="patient_id"/>
+                <field name="team_id"/>
+                <field name="stage"/>
+                <field name="diagnosis"/>
+                <field name="treatment_professional_ids"/>
+                <field name="injury_date"/>
+                <field name="predicted_resolution_date"/>
+                <field name="resolution_date"/>
+                <filter string="Unverified" name="stage_unverified" domain="[('stage', '=', 'unverified')]"/>
+                <filter string="Active" name="stage_active" domain="[('stage', '=', 'active')]"/>
+                <filter string="Resolved" name="stage_resolved" domain="[('stage', '=', 'resolved')]"/>
+            </search>
+        </field>
+    </record>
+
+    <record id="action_view_patient_injury_audit" model="ir.actions.act_window">
+        <field name="name">Injuries (Audit)</field>
+        <field name="res_model">sports.patient.injury</field>
+        <field name="view_mode">list,form</field>
+        <field name="search_view_id" ref="sports_patient_injury_view_search_audit"/>
+    </record>
+    <record id="action_view_patient_injury_audit_list" model="ir.actions.act_window.view">
+        <field name="sequence" eval="1"/>
+        <field name="view_mode">list</field>
+        <field name="act_window_id" ref="action_view_patient_injury_audit"/>
+        <field name="view_id" ref="sports_patient_injury_view_list_audit"/>
+    </record>
+    <record id="action_view_patient_injury_audit_form" model="ir.actions.act_window.view">
+        <field name="sequence" eval="2"/>
+        <field name="view_mode">form</field>
+        <field name="act_window_id" ref="action_view_patient_injury_audit"/>
+        <field name="view_id" ref="sports_patient_injury_view_form"/>
+    </record>
+
+    <record id="server_action_cleanup_injury_notes_strip_html" model="ir.actions.server">
+        <field name="name">Cleanup Injury Notes (Strip HTML)</field>
+        <field name="model_id" ref="model_sports_patient_injury"/>
+        <field name="binding_model_id" ref="model_sports_patient_injury"/>
+        <field name="binding_view_types">list</field>
+        <field name="state">code</field>
+        <field name="groups_id" eval="[(4, ref('bemade_sports_clinic.group_sports_clinic_admin'))]"/>
+        <field name="code"><![CDATA[
+updated = 0
+
+def _strip_html_tags(value):
+    if not value:
+        return value
+    out = []
+    in_tag = False
+    for ch in value:
+        if ch == '<':
+            in_tag = True
+            continue
+        if ch == '>':
+            in_tag = False
+            continue
+        if not in_tag:
+            out.append(ch)
+    return ''.join(out)
+
+for injury in records:
+    vals = {}
+
+    if injury.internal_notes and '<' in injury.internal_notes:
+        cleaned = (_strip_html_tags(injury.internal_notes) or '').strip()
+        if cleaned != (injury.internal_notes or '').strip():
+            vals['internal_notes'] = cleaned
+
+    if injury.external_notes and '<' in injury.external_notes:
+        cleaned = (_strip_html_tags(injury.external_notes) or '').strip()
+        if cleaned != (injury.external_notes or '').strip():
+            vals['external_notes'] = cleaned
+
+    if vals:
+        injury.write(vals)
+        updated += 1
+
+action = {
+    'type': 'ir.actions.client',
+    'tag': 'display_notification',
+    'params': {
+        'title': 'Cleanup complete',
+        'message': f'Updated {updated} injury record(s).',
+        'type': 'success',
+        'sticky': False,
+    }
+}
+        ]]></field>
     </record>
     </data>
 </odoo>

--- a/bemade_sports_clinic/views/sports_patient_views.xml
+++ b/bemade_sports_clinic/views/sports_patient_views.xml
@@ -189,7 +189,8 @@
                                                 <field name="sequence" widget="handle"/>
                                                 <field name="name"/>
                                                 <field name="contact_type"/>
-                                                <field name="mobile" widget="phone"/>
+                                                <field name="mobile" widget="phone" options="{'enable_sms': false}"/>
+                                                <field name="email"/>
                                             </list>
                                         </field>
                                     </group>


### PR DESCRIPTION
## Summary

- Rename Staff menu to Admin
- Add Injuries (Audit) submenu (debug/technical users) with a dedicated list and search view exposing all fields including notes, dates, and consent
- Remove \`widget="html"\` from \`internal_notes\` and \`external_notes\` — fields are now plain text
- Add server action (admin, list view) to strip residual HTML tags from existing injury note records
- Fix manifest load order: injury views must load before menus since menus reference an action defined in the injury views file
- Backport four previously-merged fixes from the archived GitLab repo that had not yet reached the GitHub remote:
  - portal player removal broken for therapists
  - Add to SO/PO uses local event date, not UTC
  - set default_parent_id context on owned_team_ids (task 929)
  - add email column and remove SMS icon from patient contacts list (task 993)

## Test plan

- [ ] Verify Staff menu is now labelled Admin
- [ ] Enable debug mode and confirm Injuries (Audit) submenu appears under Admin
- [ ] Confirm injury form no longer shows HTML toolbar on internal/external notes fields
- [ ] Run Cleanup Injury Notes server action on a record with HTML notes and verify tags are stripped
- [ ] Install on a clean 18.0 DB to confirm manifest load order error is resolved