### PR TITLE
crm_account_management: fix buying-trends widget layout + products RPC

### DIFF
--- a/crm_account_management/models/organizational_unit.py
+++ b/crm_account_management/models/organizational_unit.py
@@ -733,7 +733,14 @@ class OrganizationalUnit(models.Model):
             record.won_opportunities_amount = sum(won_opps.mapped("expected_revenue"))
 
     def get_top_products(self, limit=10, date_from=None, date_to=None, sort_by="total_amount"):
-        """Get top products purchased by this account."""
+        """Get top products purchased by this account.
+
+        Aggregation runs in PostgreSQL via ``_read_group`` over
+        ``sale.order.line``, grouped by ``product_id``. The aggregated
+        rows are then enriched with the product template id, name and
+        ``default_code`` in a single batched read so the call scales to
+        thousands of order lines without prefetching every record.
+        """
         self.ensure_one()
         partners = self._get_all_partners()
         if not partners:
@@ -742,7 +749,6 @@ class OrganizationalUnit(models.Model):
         if not date_to:
             date_to = date.today()
 
-        # Use ORM to handle translated fields properly
         domain = [
             ("order_id.partner_id", "in", partners.ids),
             ("order_id.state", "=", "sale"),
@@ -750,43 +756,70 @@ class OrganizationalUnit(models.Model):
         ]
         if date_from:
             domain.append(("order_id.date_order", ">=", date_from))
-        order_lines = self.env["sale.order.line"].search(domain)
 
-        # Aggregate by product template
-        product_data = {}
-        for line in order_lines:
-            pt_id = line.product_id.product_tmpl_id.id
-            pt_name = line.product_id.name
-            default_code = line.product_id.default_code or ""
-            if pt_id not in product_data:
-                product_data[pt_id] = {
-                    "product_id": pt_id,
-                    "product_name": pt_name,
-                    "default_code": default_code,
-                    "total_qty": 0.0,
-                    "total_amount": 0.0,
+        # PostgreSQL-side aggregation: avoids reading thousands of SOLs
+        # into memory and respects sale.order.line record rules through
+        # the ORM's standard read_group implementation.
+        groups = self.env["sale.order.line"]._read_group(
+            domain,
+            groupby=["product_id"],
+            aggregates=["product_uom_qty:sum", "price_subtotal:sum"],
+        )
+
+        product_ids = [p.id for p, _qty, _amt in groups if p]
+        if not product_ids:
+            return []
+
+        # Single batched fetch of presentation fields. Using sudo on the
+        # product read is safe — access to the line was already enforced
+        # by _read_group above; we are only resolving display attributes.
+        products = self.env["product.product"].browse(product_ids).sudo()
+        product_info = {
+            p.id: {
+                "tmpl_id": p.product_tmpl_id.id,
+                "name": p.display_name or p.name or "",
+                "default_code": p.default_code or "",
+            }
+            for p in products
+        }
+
+        # Roll up variants under their template (preserves the legacy
+        # behaviour where ``product_id`` in the returned dict refers to
+        # ``product.template`` and variants are merged).
+        by_tmpl = {}
+        for product, qty, amount in groups:
+            if not product:
+                continue
+            info = product_info.get(product.id)
+            if not info:
+                continue
+            tmpl_id = info["tmpl_id"]
+            entry = by_tmpl.get(tmpl_id)
+            if entry is None:
+                by_tmpl[tmpl_id] = {
+                    "product_id": tmpl_id,
+                    "product_name": info["name"],
+                    "default_code": info["default_code"],
+                    "total_qty": qty or 0.0,
+                    "total_amount": amount or 0.0,
                 }
-            product_data[pt_id]["total_qty"] += line.product_uom_qty
-            product_data[pt_id]["total_amount"] += line.price_subtotal
+            else:
+                entry["total_qty"] += qty or 0.0
+                entry["total_amount"] += amount or 0.0
+        product_data = list(by_tmpl.values())
 
         if sort_by == "default_code":
-            sorted_products = sorted(
-                product_data.values(), key=lambda x: x["default_code"] or ""
-            )
+            product_data.sort(key=lambda x: x["default_code"] or "")
         elif sort_by == "product_name":
-            sorted_products = sorted(product_data.values(), key=lambda x: x["product_name"])
+            product_data.sort(key=lambda x: x["product_name"] or "")
         elif sort_by == "total_qty":
-            sorted_products = sorted(
-                product_data.values(), key=lambda x: x["total_qty"], reverse=True
-            )
+            product_data.sort(key=lambda x: x["total_qty"], reverse=True)
         else:
-            sorted_products = sorted(
-                product_data.values(), key=lambda x: x["total_amount"], reverse=True
-            )
+            product_data.sort(key=lambda x: x["total_amount"], reverse=True)
 
         if limit is None:
-            return sorted_products
-        return sorted_products[:limit]
+            return product_data
+        return product_data[:limit]
 
     def get_sales_by_period(self, period="month", periods=12, date_from=None, date_to=None):
         """Get sales data by period for trend analysis."""

--- a/crm_account_management/static/src/js/buying_trends_widget.js
+++ b/crm_account_management/static/src/js/buying_trends_widget.js
@@ -22,6 +22,7 @@ export class BuyingTrendsWidget extends Component {
             period: "month",
             productPeriod: "12m",
             sortBy: "total_amount",
+            productsError: "",
         });
 
         onWillStart(async () => {
@@ -65,7 +66,12 @@ export class BuyingTrendsWidget extends Component {
                 [[ouId], this.state.period, 12]
             );
             this.state.salesData = salesData;
+        } catch (error) {
+            console.error("Error loading sales trend data:", error);
+            this.state.salesData = [];
+        }
 
+        try {
             const { dateFrom, dateTo } = this._getProductDateRange();
             const topProducts = await this.orm.call(
                 "organizational.unit",
@@ -74,8 +80,11 @@ export class BuyingTrendsWidget extends Component {
                 { sort_by: this.state.sortBy }
             );
             this.state.topProducts = topProducts;
+            this.state.productsError = "";
         } catch (error) {
-            console.error("Error loading buying trends data:", error);
+            console.error("Error loading top products data:", error);
+            this.state.topProducts = [];
+            this.state.productsError = String(error && error.message ? error.message : error);
         }
 
         this.state.loading = false;

--- a/crm_account_management/static/src/xml/buying_trends_widget.xml
+++ b/crm_account_management/static/src/xml/buying_trends_widget.xml
@@ -98,6 +98,12 @@
                                         </tbody>
                                     </table>
                                 </t>
+                                <t t-elif="state.productsError">
+                                    <p class="text-danger text-center py-4">
+                                        <i class="fa fa-exclamation-triangle me-1"/>
+                                        <t t-esc="state.productsError"/>
+                                    </p>
+                                </t>
                                 <t t-else="">
                                     <p class="text-muted text-center py-4">No product data available</p>
                                 </t>

--- a/crm_account_management/static/src/xml/buying_trends_widget.xml
+++ b/crm_account_management/static/src/xml/buying_trends_widget.xml
@@ -15,8 +15,8 @@
                     <div class="col-lg-7 mb-3">
                         <div class="card">
                             <div class="card-header d-flex justify-content-between align-items-center">
-                                <strong>Sales Trend</strong>
-                                <select class="form-select form-select-sm w-auto"
+                                <strong class="text-truncate min-w-0 me-2">Sales Trend</strong>
+                                <select class="form-select form-select-sm w-auto flex-shrink-0"
                                         t-on-change="onPeriodChange">
                                     <option value="month" t-att-selected="state.period === 'month'">Monthly</option>
                                     <option value="quarter" t-att-selected="state.period === 'quarter'">Quarterly</option>
@@ -40,8 +40,8 @@
                     <div class="col-lg-5 mb-3">
                         <div class="card">
                             <div class="card-header d-flex justify-content-between align-items-center">
-                                <strong>Products Purchased</strong>
-                                <select class="form-select form-select-sm w-auto"
+                                <strong class="text-truncate min-w-0 me-2">Products Purchased</strong>
+                                <select class="form-select form-select-sm w-auto flex-shrink-0"
                                         t-on-change="onProductPeriodChange">
                                     <option value="12m" t-att-selected="state.productPeriod === '12m'">Last 12 Months</option>
                                     <option value="all" t-att-selected="state.productPeriod === 'all'">All Time</option>

--- a/crm_account_management/tests/test_us02_buying_trends.py
+++ b/crm_account_management/tests/test_us02_buying_trends.py
@@ -624,3 +624,118 @@ class TestUS02BuyingTrends(OUTestCommon):
                 self.assertIn(field, period_data, f"Should include {field} field")
             self.assertIsInstance(period_data["period"], date)
             self.assertIsInstance(period_data["total"], (int, float))
+
+    # =========================================================================
+    # Regression tests for task-3181: buying-trends widget layout + RPC errors
+    # =========================================================================
+
+    def test_buying_trends_widget_at_sheet_level(self):
+        """The buying_trends widget must mount at the form sheet level, not
+        inside a <group>, so it can span the full form width.
+        """
+        from lxml import etree
+
+        view = self.env.ref("crm_account_management.organizational_unit_view_form")
+        arch = etree.fromstring(view.arch)
+        widgets = arch.xpath("//widget[@name='buying_trends']")
+        self.assertEqual(
+            len(widgets), 1,
+            "There should be exactly one buying_trends widget on the form",
+        )
+        widget = widgets[0]
+        # Walk up the ancestor chain: must hit <sheet> before any <group>.
+        ancestor = widget.getparent()
+        while ancestor is not None and ancestor.tag != "sheet":
+            self.assertNotEqual(
+                ancestor.tag, "group",
+                "buying_trends widget must NOT be wrapped in a <group> "
+                "(causes the narrow-column layout regression)",
+            )
+            ancestor = ancestor.getparent()
+        self.assertIsNotNone(
+            ancestor,
+            "buying_trends widget must live inside the form <sheet>",
+        )
+
+    def test_buying_trends_header_layout_classes(self):
+        """The card-header rows must keep a defensive flex layout: titles
+        carry text-truncate min-w-0 and selectors carry flex-shrink-0 so the
+        title and period selector cannot overlap at narrow widths.
+        """
+        # The QWeb template is registered under web.assets_backend, not
+        # as an ir.ui.view, so read the asset file directly.
+        import os
+        from odoo.modules import module as odoo_module
+        path = os.path.join(
+            odoo_module.get_module_path("crm_account_management"),
+            "static", "src", "xml", "buying_trends_widget.xml",
+        )
+        with open(path, "r", encoding="utf-8") as fh:
+            content = fh.read()
+
+        # Both card headers retain the flex container classes.
+        self.assertEqual(
+            content.count(
+                'card-header d-flex justify-content-between align-items-center'
+            ),
+            2,
+            "Both card headers must use the flex layout container",
+        )
+        # Both <strong> titles must carry the truncation/min-width classes.
+        self.assertIn(
+            '<strong class="text-truncate min-w-0 me-2">Sales Trend</strong>',
+            content,
+        )
+        self.assertIn(
+            '<strong class="text-truncate min-w-0 me-2">Products Purchased</strong>',
+            content,
+        )
+        # Both <select>s must be flex-shrink-0 so they keep their natural width.
+        self.assertEqual(
+            content.count('flex-shrink-0'), 2,
+            "Both card-header <select>s must carry flex-shrink-0",
+        )
+
+    def test_products_rpc_error_surfaces(self):
+        """The products empty branch must distinguish a true empty result
+        from an RPC failure: the QWeb template must render an explicit
+        error message (driven by state.productsError) before falling back
+        to 'No product data available'.
+        """
+        import os
+        from odoo.modules import module as odoo_module
+        path = os.path.join(
+            odoo_module.get_module_path("crm_account_management"),
+            "static", "src", "xml", "buying_trends_widget.xml",
+        )
+        with open(path, "r", encoding="utf-8") as fh:
+            xml_content = fh.read()
+
+        self.assertIn(
+            't-elif="state.productsError"', xml_content,
+            "Products card must render a distinct error branch when "
+            "state.productsError is non-empty",
+        )
+        self.assertIn(
+            't-esc="state.productsError"', xml_content,
+            "The error branch must surface state.productsError to the user",
+        )
+
+        js_path = os.path.join(
+            odoo_module.get_module_path("crm_account_management"),
+            "static", "src", "js", "buying_trends_widget.js",
+        )
+        with open(js_path, "r", encoding="utf-8") as fh:
+            js_content = fh.read()
+
+        # productsError state field must exist and be assigned in the
+        # top-products catch block (split from the sales-trend block).
+        self.assertIn("productsError", js_content)
+        self.assertIn("this.state.productsError", js_content)
+        # Two independent try/catch blocks now wrap the two RPCs.
+        self.assertGreaterEqual(
+            js_content.count("} catch (error) {"), 2,
+            "loadData must split the two RPC awaits into independent "
+            "try/catch blocks so a top-products failure does not "
+            "silently coexist with a successful sales-trend fetch",
+        )

--- a/crm_account_management/tests/test_us20_top_products.py
+++ b/crm_account_management/tests/test_us20_top_products.py
@@ -333,3 +333,82 @@ class TestUS20TopProducts(OUTestCommon):
         by_name = ou.get_top_products(sort_by="product_name")
         product_names = [p["product_name"] for p in by_name]
         self.assertEqual(product_names, sorted(product_names))
+
+    # =========================================================================
+    # Regression test for task-3181 — defect 3
+    # AC: get_top_products tolerates large datasets without raising and
+    # returns aggregated rows whose totals match a reference Python sum.
+    # =========================================================================
+
+    def test_get_top_products_large_dataset(self):
+        """get_top_products must aggregate cleanly over 1000+ SOL rows
+        spanning 100+ distinct products without timing out or raising.
+        Validates the _read_group rewrite (defect 3 root-cause fix).
+        """
+        company = self.partner_model.create(
+            {
+                "name": "Large Account",
+                "is_company": True,
+            }
+        )
+        ou = self.ou_model.search([("owner_id", "=", company.id)])
+
+        # Seed 120 distinct products.
+        n_products = 120
+        products = self.product_model.create([
+            {
+                "name": f"Bulk Product {i:03d}",
+                "default_code": f"BULK-{i:03d}",
+                "list_price": 10.0 + i,
+            }
+            for i in range(n_products)
+        ])
+
+        # Seed 1050 sale.order.lines (10 SOs of ~105 lines each).
+        # _make_order keeps the API consistent with the rest of the suite.
+        n_orders = 10
+        lines_per_order = 105
+        expected_total_qty = {p.product_tmpl_id.id: 0.0 for p in products}
+        expected_total_amount = {p.product_tmpl_id.id: 0.0 for p in products}
+
+        for o in range(n_orders):
+            order_lines = []
+            for li in range(lines_per_order):
+                product = products[(o * lines_per_order + li) % n_products]
+                qty = 1.0 + ((o + li) % 5)
+                order_lines.append((0, 0, {
+                    "product_id": product.id,
+                    "product_uom_qty": qty,
+                }))
+                expected_total_qty[product.product_tmpl_id.id] += qty
+                expected_total_amount[product.product_tmpl_id.id] += (
+                    qty * product.list_price
+                )
+            order = self._make_order({
+                "partner_id": company.id,
+                "order_line": order_lines,
+            })
+            order.action_confirm()
+
+        # Top-N call: must not raise, must respect limit.
+        top10 = ou.get_top_products(limit=10)
+        self.assertEqual(len(top10), 10, "Should respect limit=10")
+
+        # Unlimited call: must return one row per distinct template.
+        all_rows = ou.get_top_products(limit=None)
+        self.assertEqual(
+            len(all_rows), n_products,
+            "Should aggregate to exactly one row per distinct product",
+        )
+
+        # Per-row totals must match the Python reference computed above.
+        for row in all_rows:
+            tmpl_id = row["product_id"]
+            self.assertAlmostEqual(
+                row["total_qty"], expected_total_qty[tmpl_id], places=2,
+                msg=f"qty mismatch for tmpl {tmpl_id}",
+            )
+            self.assertAlmostEqual(
+                row["total_amount"], expected_total_amount[tmpl_id], places=2,
+                msg=f"amount mismatch for tmpl {tmpl_id}",
+            )

--- a/crm_account_management/views/organizational_unit_views.xml
+++ b/crm_account_management/views/organizational_unit_views.xml
@@ -184,10 +184,9 @@
                     </group>
 
                     <!-- Buying Trends Widget -->
-                    <group string="Buying Trends">
-                        <field name="id" invisible="1"/>
-                        <widget name="buying_trends" ou_id="id"/>
-                    </group>
+                    <separator string="Buying Trends"/>
+                    <field name="id" invisible="1"/>
+                    <widget name="buying_trends" ou_id="id"/>
 
                     <!-- Account Details -->
                     <group string="Account Details">


### PR DESCRIPTION
Fixes RWI bug reported on Odoo task 3181 (https://odoo.bemade.org/odoo/project/289/tasks/3181) where the buying-trends widgets on the customer account form were rendered narrow with clipped Y-axis labels and the Products Purchased card showed 'No product data available' for customers with substantial sales history.

## Defects fixed

1. **Layout / width regression** — `<group string="Buying Trends">` constrained the widget to the left grid cell. Replaced with a sheet-level `<separator>` + `<widget>`, freeing the widget to span the full sheet.
2. **Header overlap** — defensive: added `text-truncate min-w-0 me-2` to titles and `flex-shrink-0` to selectors so the layout stays correct under narrow viewports.
3. **Silent products-fetch failure** — single shared try/catch in `buying_trends_widget.js loadData` swallowed RPC rejections. Split into two independent try blocks; added `state.productsError` rendered as a distinct error branch. Server-side `get_top_products` rewritten to use `_read_group` so a 2.6k-line aggregation runs in PostgreSQL instead of as a Python loop with full prefetch.

## Tests

4 regression tests (3 in `test_us02_buying_trends.py`, 1 in `test_us20_top_products.py`). 87/87 pass on Odoo 19.

## 18.0 cherry-pick

Companion PR: #<TBD> (`fix/buying-trends-widget-layout-and-rpc-18`). All 4 commits cherry-picked cleanly; needs Pneumac stack to verify before merge.

## Pipeline artifacts

https://git.bemade.org/bemade/tasks/-/tree/main/task-3181-rwi-pneumac-crm-dep-v2