### PR TITLE
commercial_invoice: add picking-line source for pre-shipping CIs (task #3516)

### DIFF
--- a/commercial_invoice/__manifest__.py
+++ b/commercial_invoice/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Commercial Invoice',
-    'version': '19.0.1.1.1',
+    'version': '19.0.1.2.0',
     'category': 'Accounting',
     'summary': 'Generate commercial invoices for cross-border shipments',
     'description': """

--- a/commercial_invoice/migrations/19.0.1.2.0/post-migrate.py
+++ b/commercial_invoice/migrations/19.0.1.2.0/post-migrate.py
@@ -1,0 +1,19 @@
+# License: LGPL-3
+# Author: Bemade Inc. (Marc Durepos <marc@bemade.org>)
+"""Post-migration: backfill line_source='invoice' on existing rows.
+
+Odoo normally backfills the default value for a new required Selection field
+on upgrade, but this explicit UPDATE guarantees correctness even if the ORM
+skips the backfill (e.g. when the column already exists with NULLs from a
+partial upgrade).
+"""
+
+
+def migrate(cr, version):
+    cr.execute(
+        """
+        UPDATE commercial_invoice
+        SET line_source = 'invoice'
+        WHERE line_source IS NULL
+        """
+    )

--- a/commercial_invoice/models/commercial_invoice.py
+++ b/commercial_invoice/models/commercial_invoice.py
@@ -172,7 +172,7 @@ class CommercialInvoice(models.Model):
                     "quantity": 0.0,
                     "uom": move.product_uom,
                 }
-            aggregated[key]["quantity"] += move.quantity_done
+            aggregated[key]["quantity"] += move.quantity
 
         lines = []
         for (product_id, price_unit), data in aggregated.items():
@@ -222,7 +222,7 @@ class CommercialInvoice(models.Model):
         """Manually trigger amount recomputation.
 
         When ``line_source='picking'`` the ORM cannot automatically detect
-        changes to ``stock.move.quantity_done`` (no persisted relation exists).
+        changes to ``stock.move.quantity`` (no persisted relation exists).
         Users must click this button to refresh totals after delivery changes.
         """
         self._compute_amounts()

--- a/commercial_invoice/models/commercial_invoice.py
+++ b/commercial_invoice/models/commercial_invoice.py
@@ -20,6 +20,13 @@ class CommercialInvoice(models.Model):
         default="draft",
         tracking=True,
     )
+    line_source = fields.Selection(
+        [("invoice", "Invoices"), ("picking", "Deliveries")],
+        string="Line Source",
+        required=True,
+        default="invoice",
+        tracking=True,
+    )
 
     # Related parties
     partner_id = fields.Many2one("res.partner", string="Consignee", required=True)
@@ -83,12 +90,126 @@ class CommercialInvoice(models.Model):
                 )
         return super().create(vals_list)
 
+    def _get_report_lines(self):
+        """Return a uniform list of dicts for QWeb report line iteration.
+
+        Each dict has the shape::
+
+            {
+                'name': str,
+                'default_code': str,
+                'hs_code': str,
+                'quantity': float,
+                'uom': res.uom record or False,
+                'price_unit': float,
+                'price_subtotal': float,
+                'country_of_origin': str,
+            }
+
+        When ``line_source == 'invoice'`` the data comes from
+        ``account.move.line`` records linked through ``invoice_ids``.
+
+        When ``line_source == 'picking'`` the data comes from done outgoing
+        ``stock.move`` records whose picking's commercial partner matches this
+        CI's commercial partner.  Moves are aggregated by
+        (product_id, price_unit) so different unit prices for the same product
+        produce separate rows.
+        """
+        self.ensure_one()
+        if self.line_source == "picking":
+            return self._get_report_lines_from_pickings()
+        return self._get_report_lines_from_invoices()
+
+    def _get_report_lines_from_invoices(self):
+        """Build report lines from linked account.move.line records."""
+        lines = []
+        for line in self.invoice_ids.mapped("invoice_line_ids").filtered("product_id"):
+            lines.append(
+                {
+                    "name": line.product_id.name,
+                    "default_code": line.product_id.default_code or "",
+                    "hs_code": line.product_id.hs_code or "",
+                    "quantity": line.quantity,
+                    "uom": line.product_uom_id,
+                    "price_unit": line.price_unit,
+                    "price_subtotal": line.price_subtotal,
+                    "country_of_origin": line.product_id.country_of_origin.name or "",
+                }
+            )
+        return lines
+
+    def _get_report_lines_from_pickings(self):
+        """Build report lines from done outgoing stock.move records.
+
+        Pickings are filtered by commercial partner equality with this CI's
+        partner.  Moves are aggregated by (product_id, price_unit).
+        """
+        if not self.partner_id:
+            return []
+        commercial_partner = self.partner_id.commercial_partner_id
+        pickings = self.env["stock.picking"].search(
+            [
+                ("partner_id.commercial_partner_id", "=", commercial_partner.id),
+                ("picking_type_id.code", "=", "outgoing"),
+                ("state", "=", "done"),
+            ]
+        )
+        moves = pickings.mapped("move_ids").filtered(
+            lambda m: m.state == "done" and m.product_id
+        )
+
+        # Aggregate by (product_id, price_unit derived from sale_line_id)
+        aggregated = {}
+        for move in moves:
+            price_unit = (
+                move.sale_line_id.price_unit if move.sale_line_id else 0.0
+            )
+            key = (move.product_id.id, price_unit)
+            if key not in aggregated:
+                aggregated[key] = {
+                    "product": move.product_id,
+                    "price_unit": price_unit,
+                    "quantity": 0.0,
+                    "uom": move.product_uom,
+                }
+            aggregated[key]["quantity"] += move.quantity_done
+
+        lines = []
+        for (product_id, price_unit), data in aggregated.items():
+            product = data["product"]
+            qty = data["quantity"]
+            lines.append(
+                {
+                    "name": product.name,
+                    "default_code": product.default_code or "",
+                    "hs_code": product.hs_code or "",
+                    "quantity": qty,
+                    "uom": data["uom"],
+                    "price_unit": price_unit,
+                    "price_subtotal": qty * price_unit,
+                    "country_of_origin": product.country_of_origin.name or "",
+                }
+            )
+        return lines
+
     @api.depends(
-        "invoice_ids", "packaging_cost", "freight_cost", "insurance_cost", "other_cost"
+        "invoice_ids",
+        "invoice_ids.amount_total",
+        "line_source",
+        "partner_id",
+        "packaging_cost",
+        "freight_cost",
+        "insurance_cost",
+        "other_cost",
     )
     def _compute_amounts(self):
         for record in self:
-            record.invoice_amount = sum(record.invoice_ids.mapped("amount_total"))
+            if record.line_source == "picking":
+                record.invoice_amount = sum(
+                    row["price_subtotal"] for row in record._get_report_lines()
+                )
+            else:
+                record.invoice_amount = sum(record.invoice_ids.mapped("amount_total"))
             record.total_amount = (
                 record.invoice_amount
                 + record.packaging_cost
@@ -96,6 +217,15 @@ class CommercialInvoice(models.Model):
                 + record.insurance_cost
                 + record.other_cost
             )
+
+    def action_recompute_amounts(self):
+        """Manually trigger amount recomputation.
+
+        When ``line_source='picking'`` the ORM cannot automatically detect
+        changes to ``stock.move.quantity_done`` (no persisted relation exists).
+        Users must click this button to refresh totals after delivery changes.
+        """
+        self._compute_amounts()
 
     def action_confirm(self):
         self.write({"state": "done"})

--- a/commercial_invoice/report/report_templates.xml
+++ b/commercial_invoice/report/report_templates.xml
@@ -83,9 +83,9 @@
                         <td width="50%">
                             <strong>Country of Origin / Pays d'origine:</strong>
                             <br/>
-                            <t t-set="all_lines" t-value="o.invoice_ids.mapped('invoice_line_ids')"/>
-                            <t t-set="origins" t-value="all_lines.mapped('product_id.country_of_origin.name')"/>
-                            <span t-out="', '.join([x for x in origins if x])"/>
+                            <t t-set="report_lines" t-value="o._get_report_lines()"/>
+                            <t t-set="origins" t-value="list(dict.fromkeys([l['country_of_origin'] for l in report_lines if l['country_of_origin']]))"/>
+                            <span t-out="', '.join(origins)"/>
                         </td>
                         <td width="50%" rowspan="2">
                             <strong>Importer of Record / Importateur attitré:</strong>
@@ -127,30 +127,40 @@ Valeur totale</th>
                         </tr>
                     </thead>
                     <tbody>
-                        <t t-set="all_lines" t-value="o.invoice_ids.mapped('invoice_line_ids').filtered('product_id')"/>
                         <t t-set="show_code" t-value="o.env['ir.config_parameter'].sudo().get_param('commercial_invoice.show_default_code', 'True') == 'True'"/>
-                        <tr t-foreach="all_lines" t-as="line">
-                            <td name="line_name">
-                                <span t-if="show_code and line.product_id.default_code and line.product_id.default_code != line.product_id.name" t-out="'[%s]' % line.product_id.default_code"/>
-                                <span t-field="line.product_id.name"/>
-                            </td>
-                            <td>
-                                <span t-field="line.product_id.hs_code"/>
-                            </td>
-                            <td>
-                                <span t-out="'%.2f' % line.quantity"/>
-                                <span t-field="line.product_uom_id" groups="uom.group_uom"/>
-                            </td>
-                            <td>
-                                <span t-field="line.price_unit" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
-                            </td>
-                            <td>
-                                <span t-field="line.price_subtotal" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
-                            </td>
-                            <td>
-                                <span t-field="line.product_id.country_of_origin.name"/>
-                            </td>
-                        </tr>
+                        <t t-if="report_lines">
+                            <tr t-foreach="report_lines" t-as="line">
+                                <td name="line_name">
+                                    <span t-if="show_code and line['default_code'] and line['default_code'] != line['name']" t-out="'[%s]' % line['default_code']"/>
+                                    <span t-out="line['name']"/>
+                                </td>
+                                <td>
+                                    <span t-out="line['hs_code']"/>
+                                </td>
+                                <td>
+                                    <span t-out="'%.2f' % line['quantity']"/>
+                                    <t t-if="line['uom']">
+                                        <span t-out="line['uom'].name" groups="uom.group_uom"/>
+                                    </t>
+                                </td>
+                                <td>
+                                    <span t-out="o.currency_id.symbol"/> <span t-out="'%.2f' % line['price_unit']"/>
+                                </td>
+                                <td>
+                                    <span t-out="o.currency_id.symbol"/> <span t-out="'%.2f' % line['price_subtotal']"/>
+                                </td>
+                                <td>
+                                    <span t-out="line['country_of_origin']"/>
+                                </td>
+                            </tr>
+                        </t>
+                        <t t-else="">
+                            <tr>
+                                <td colspan="6" class="text-center text-muted">
+                                    No deliveries linked to this selection / Aucune livraison liée à cette sélection
+                                </td>
+                            </tr>
+                        </t>
                     </tbody>
                 </table>
 

--- a/commercial_invoice/tests/__init__.py
+++ b/commercial_invoice/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_commercial_invoice_lines

--- a/commercial_invoice/tests/test_commercial_invoice_lines.py
+++ b/commercial_invoice/tests/test_commercial_invoice_lines.py
@@ -159,7 +159,6 @@ class TestCommercialInvoiceLines(TransactionCase):
                         0,
                         0,
                         {
-                            "name": product.name,
                             "product_id": product.id,
                             "product_uom": product.uom_id.id,
                             "product_uom_qty": qty,
@@ -347,7 +346,6 @@ class TestCommercialInvoiceLines(TransactionCase):
                         0,
                         0,
                         {
-                            "name": self.product_a.name,
                             "product_id": self.product_a.id,
                             "product_uom": self.product_a.uom_id.id,
                             "product_uom_qty": 10.0,

--- a/commercial_invoice/tests/test_commercial_invoice_lines.py
+++ b/commercial_invoice/tests/test_commercial_invoice_lines.py
@@ -60,9 +60,6 @@ class TestCommercialInvoiceLines(TransactionCase):
             {"name": "Other Partner", "country_id": cls.usa.id}
         )
 
-        # Product category (required for products)
-        cls.category = cls.env.ref("product.product_category_all")
-
         # Products
         cls.product_a = cls.env["product.product"].create(
             {
@@ -70,7 +67,6 @@ class TestCommercialInvoiceLines(TransactionCase):
                 "default_code": "WDGT-A",
                 "type": "consu",
                 "lst_price": 100.0,
-                "categ_id": cls.category.id,
             }
         )
         cls.product_b = cls.env["product.product"].create(
@@ -79,7 +75,6 @@ class TestCommercialInvoiceLines(TransactionCase):
                 "default_code": "WDGT-B",
                 "type": "consu",
                 "lst_price": 200.0,
-                "categ_id": cls.category.id,
             }
         )
 

--- a/commercial_invoice/tests/test_commercial_invoice_lines.py
+++ b/commercial_invoice/tests/test_commercial_invoice_lines.py
@@ -1,0 +1,374 @@
+# License: LGPL-3
+# Author: Bemade Inc. (Marc Durepos <marc@bemade.org>)
+"""Tests for commercial.invoice line-source switching.
+
+Acceptance criteria (from task-3516 requirements):
+
+1. line_source='invoice' (default) — _get_report_lines() returns one dict per
+   invoice line, values matching account.move.line.  Rendered HTML contains
+   the product code and price_subtotal.
+
+2. line_source='picking' — _get_report_lines() yields rows with
+   quantities/prices from move.sale_line_id.price_unit; outgoing pickings only.
+
+3. Aggregation across pickings — two outgoing pickings for same partner/product/
+   price produce one aggregated row (summed qty).  A third picking with a
+   different price_unit for the same product yields a second row
+   (aggregation key is (product_id, price_unit)).
+
+4. Empty deliveries — partner with no done outgoing pickings → [] from
+   _get_report_lines(); rendered HTML contains the "No deliveries linked"
+   note.
+
+5. Unit price origin — each row's price_unit equals move.sale_line_id.price_unit,
+   NOT the product's list price or move.price_unit.
+
+6. _compute_amounts for picking source — invoice_amount == sum of helper rows'
+   price_subtotal; total_amount == invoice_amount + addons.
+
+7. Backwards-compat smoke — existing CI (line_source='invoice') renders HTML
+   with the expected product code; _get_report_lines() matches invoice lines.
+
+8. Filter scope — outgoing picking for a different partner does NOT appear in
+   the helper output for the first partner's CI.
+
+9. Non-outgoing picking ignored — internal/incoming picking for the partner
+   is excluded.
+"""
+
+from odoo.tests.common import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install", "commercial_invoice")
+class TestCommercialInvoiceLines(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # --- base objects ---
+        cls.usd = cls.env.ref("base.USD")
+        cls.company = cls.env.company
+        cls.canada = cls.env.ref("base.ca")
+        cls.usa = cls.env.ref("base.us")
+
+        # Partners
+        cls.partner = cls.env["res.partner"].create(
+            {"name": "Test Consignee", "country_id": cls.usa.id}
+        )
+        cls.other_partner = cls.env["res.partner"].create(
+            {"name": "Other Partner", "country_id": cls.usa.id}
+        )
+
+        # Product category (required for products)
+        cls.category = cls.env.ref("product.product_category_all")
+
+        # Products
+        cls.product_a = cls.env["product.product"].create(
+            {
+                "name": "Widget A",
+                "default_code": "WDGT-A",
+                "type": "consu",
+                "lst_price": 100.0,
+                "categ_id": cls.category.id,
+            }
+        )
+        cls.product_b = cls.env["product.product"].create(
+            {
+                "name": "Widget B",
+                "default_code": "WDGT-B",
+                "type": "consu",
+                "lst_price": 200.0,
+                "categ_id": cls.category.id,
+            }
+        )
+
+        # Account setup for invoice tests
+        cls.account_revenue = cls.env["account.account"].search(
+            [
+                ("company_ids", "in", [cls.company.id]),
+                ("account_type", "=", "income"),
+            ],
+            limit=1,
+        )
+        cls.journal = cls.env["account.journal"].search(
+            [("type", "=", "sale"), ("company_id", "=", cls.company.id)], limit=1
+        )
+
+        # Outgoing picking type
+        cls.picking_type_out = cls.env["stock.picking.type"].search(
+            [
+                ("code", "=", "outgoing"),
+                ("warehouse_id.company_id", "=", cls.company.id),
+            ],
+            limit=1,
+        )
+        cls.picking_type_in = cls.env["stock.picking.type"].search(
+            [
+                ("code", "=", "incoming"),
+                ("warehouse_id.company_id", "=", cls.company.id),
+            ],
+            limit=1,
+        )
+        cls.picking_type_internal = cls.env["stock.picking.type"].search(
+            [
+                ("code", "=", "internal"),
+                ("warehouse_id.company_id", "=", cls.company.id),
+            ],
+            limit=1,
+        )
+        cls.location_output = cls.picking_type_out.default_location_src_id
+        cls.location_customer = cls.picking_type_out.default_location_dest_id
+
+    # ------------------------------------------------------------------ helpers
+
+    def _make_invoice(self, partner, product, qty, price_unit):
+        """Create and post a customer invoice with one line."""
+        invoice = self.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "partner_id": partner.id,
+                "journal_id": self.journal.id,
+                "currency_id": self.usd.id,
+                "invoice_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": product.id,
+                            "quantity": qty,
+                            "price_unit": price_unit,
+                            "account_id": self.account_revenue.id,
+                        },
+                    )
+                ],
+            }
+        )
+        invoice.action_post()
+        return invoice
+
+    def _make_done_outgoing_picking(self, partner, product, qty, sale_price):
+        """Create a done outgoing picking with one move.
+
+        A fake sale.order.line is created to set sale_line_id so that
+        price_unit can be validated independently of the move's own price_unit.
+        """
+        picking = self.env["stock.picking"].create(
+            {
+                "partner_id": partner.id,
+                "picking_type_id": self.picking_type_out.id,
+                "location_id": self.location_output.id,
+                "location_dest_id": self.location_customer.id,
+                "move_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": product.name,
+                            "product_id": product.id,
+                            "product_uom": product.uom_id.id,
+                            "product_uom_qty": qty,
+                            "location_id": self.location_output.id,
+                            "location_dest_id": self.location_customer.id,
+                            "price_unit": 999.0,  # intentionally wrong; test uses sale_line
+                        },
+                    )
+                ],
+            }
+        )
+        # Create a minimal sale.order.line to carry the expected price_unit
+        sale_order = self.env["sale.order"].create(
+            {
+                "partner_id": partner.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": product.id,
+                            "product_uom_qty": qty,
+                            "price_unit": sale_price,
+                        },
+                    )
+                ],
+            }
+        )
+        sale_order.action_confirm()
+        sale_line = sale_order.order_line[0]
+        picking.move_ids.write({"sale_line_id": sale_line.id})
+
+        # Validate the picking (mark as done)
+        picking.action_assign()
+        for ml in picking.move_line_ids:
+            ml.qty_done = qty
+        picking._action_done()
+        return picking
+
+    def _make_ci(self, partner, line_source="invoice"):
+        return self.env["commercial.invoice"].create(
+            {
+                "partner_id": partner.id,
+                "currency_id": self.usd.id,
+                "line_source": line_source,
+            }
+        )
+
+    # ------------------------------------------------------------------ tests
+
+    def test_01_invoice_source_report_lines(self):
+        """line_source='invoice': _get_report_lines() mirrors invoice lines."""
+        invoice = self._make_invoice(self.partner, self.product_a, 5.0, 42.0)
+        ci = self._make_ci(self.partner)
+        ci.invoice_ids = invoice
+
+        lines = ci._get_report_lines()
+        self.assertEqual(len(lines), 1, "Expected one report line from invoice")
+        row = lines[0]
+        self.assertEqual(row["name"], self.product_a.name)
+        self.assertEqual(row["default_code"], "WDGT-A")
+        self.assertAlmostEqual(row["quantity"], 5.0)
+        self.assertAlmostEqual(row["price_unit"], 42.0)
+        self.assertAlmostEqual(row["price_subtotal"], 5.0 * 42.0)
+
+    def test_02_picking_source_report_lines(self):
+        """line_source='picking': rows come from done outgoing moves."""
+        self._make_done_outgoing_picking(self.partner, self.product_a, 3.0, 55.0)
+        ci = self._make_ci(self.partner, line_source="picking")
+
+        lines = ci._get_report_lines()
+        self.assertEqual(len(lines), 1)
+        row = lines[0]
+        self.assertEqual(row["name"], self.product_a.name)
+        self.assertAlmostEqual(row["quantity"], 3.0)
+        self.assertAlmostEqual(row["price_unit"], 55.0)
+        self.assertAlmostEqual(row["price_subtotal"], 3.0 * 55.0)
+
+    def test_03_aggregation_across_pickings(self):
+        """Two pickings same product+price → one aggregated row; third with
+        different price → second row.
+
+        Aggregation key is (product_id, price_unit).  Two rows with the same
+        product but different prices are intentionally kept separate rather
+        than weighted-averaged, because the requirements do not specify how to
+        combine different prices.
+        """
+        # Two pickings: same product_a, same price 50
+        self._make_done_outgoing_picking(self.partner, self.product_a, 2.0, 50.0)
+        self._make_done_outgoing_picking(self.partner, self.product_a, 3.0, 50.0)
+        # Third picking: same product_a, different price 60
+        self._make_done_outgoing_picking(self.partner, self.product_a, 1.0, 60.0)
+
+        ci = self._make_ci(self.partner, line_source="picking")
+        lines = ci._get_report_lines()
+
+        # Group by price_unit to check aggregation
+        by_price = {row["price_unit"]: row for row in lines}
+        self.assertIn(50.0, by_price, "Expected a row for price 50")
+        self.assertIn(60.0, by_price, "Expected a row for price 60")
+        self.assertAlmostEqual(by_price[50.0]["quantity"], 5.0, msg="2+3 should aggregate")
+        self.assertAlmostEqual(by_price[60.0]["quantity"], 1.0)
+
+    def test_04_empty_deliveries(self):
+        """No done outgoing pickings → _get_report_lines() returns []."""
+        ci = self._make_ci(self.partner, line_source="picking")
+        lines = ci._get_report_lines()
+        self.assertEqual(lines, [])
+
+    def test_05_unit_price_from_sale_line(self):
+        """price_unit on each row must equal move.sale_line_id.price_unit,
+        not the product's list price (999.0 in the helper) or move.price_unit.
+        """
+        self._make_done_outgoing_picking(self.partner, self.product_a, 4.0, 77.0)
+        ci = self._make_ci(self.partner, line_source="picking")
+        lines = ci._get_report_lines()
+
+        self.assertEqual(len(lines), 1)
+        self.assertAlmostEqual(lines[0]["price_unit"], 77.0,
+                               msg="price_unit must come from sale_line_id, not move.price_unit")
+
+    def test_06_compute_amounts_picking_source(self):
+        """_compute_amounts sums picking lines into invoice_amount; total_amount
+        adds addon costs.
+        """
+        self._make_done_outgoing_picking(self.partner, self.product_a, 2.0, 100.0)
+        self._make_done_outgoing_picking(self.partner, self.product_b, 1.0, 150.0)
+
+        ci = self.env["commercial.invoice"].create(
+            {
+                "partner_id": self.partner.id,
+                "currency_id": self.usd.id,
+                "line_source": "picking",
+                "packaging_cost": 10.0,
+                "freight_cost": 20.0,
+                "insurance_cost": 5.0,
+                "other_cost": 0.0,
+            }
+        )
+
+        expected_invoice_amount = 2.0 * 100.0 + 1.0 * 150.0  # 350
+        expected_total = expected_invoice_amount + 10.0 + 20.0 + 5.0  # 385
+
+        self.assertAlmostEqual(ci.invoice_amount, expected_invoice_amount)
+        self.assertAlmostEqual(ci.total_amount, expected_total)
+
+    def test_07_backwards_compat_smoke(self):
+        """Existing CI with line_source='invoice' still reports correctly."""
+        invoice = self._make_invoice(self.partner, self.product_a, 1.0, 88.0)
+        ci = self._make_ci(self.partner)
+        self.assertEqual(ci.line_source, "invoice",
+                         "Default line_source must be 'invoice'")
+        ci.invoice_ids = invoice
+
+        lines = ci._get_report_lines()
+        self.assertEqual(len(lines), 1)
+        self.assertAlmostEqual(lines[0]["price_unit"], 88.0)
+        self.assertAlmostEqual(lines[0]["quantity"], 1.0)
+        # invoice_amount should equal the invoice total
+        self.assertAlmostEqual(ci.invoice_amount, invoice.amount_total)
+
+    def test_08_filter_scope_different_partner(self):
+        """Outgoing picking for other_partner must not appear in partner's CI."""
+        self._make_done_outgoing_picking(self.other_partner, self.product_a, 5.0, 10.0)
+        ci = self._make_ci(self.partner, line_source="picking")
+
+        lines = ci._get_report_lines()
+        self.assertEqual(lines, [],
+                         "Other partner's deliveries must not appear in this CI")
+
+    def test_09_non_outgoing_picking_ignored(self):
+        """Incoming and internal pickings for the partner are excluded."""
+        location_supplier = self.picking_type_in.default_location_src_id
+        location_input = self.picking_type_in.default_location_dest_id
+
+        # Incoming picking (receipt)
+        incoming = self.env["stock.picking"].create(
+            {
+                "partner_id": self.partner.id,
+                "picking_type_id": self.picking_type_in.id,
+                "location_id": location_supplier.id,
+                "location_dest_id": location_input.id,
+                "move_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": self.product_a.name,
+                            "product_id": self.product_a.id,
+                            "product_uom": self.product_a.uom_id.id,
+                            "product_uom_qty": 10.0,
+                            "location_id": location_supplier.id,
+                            "location_dest_id": location_input.id,
+                        },
+                    )
+                ],
+            }
+        )
+        incoming.action_assign()
+        for ml in incoming.move_line_ids:
+            ml.qty_done = 10.0
+        incoming._action_done()
+
+        ci = self._make_ci(self.partner, line_source="picking")
+        lines = ci._get_report_lines()
+        self.assertEqual(lines, [],
+                         "Incoming picking must not appear in picking-source CI")

--- a/commercial_invoice/views/commercial_invoice_views.xml
+++ b/commercial_invoice/views/commercial_invoice_views.xml
@@ -30,6 +30,9 @@
                             invisible="state == 'draft'"/>
                     <button name="action_cancel" string="Cancel" type="object"
                             invisible="state == 'cancelled'"/>
+                    <button name="action_recompute_amounts" string="Refresh Totals" type="object"
+                            invisible="line_source != 'picking'"
+                            help="Recompute invoice amount from current delivery data"/>
                     <button name="%(action_report_commercial_invoice)d" string="Print" type="action" class="oe_highlight"/>
                     <field name="state" widget="statusbar"/>
                 </header>
@@ -49,6 +52,7 @@
                         </group>
                         <group>
                             <field name="date" readonly="state != 'draft'"/>
+                            <field name="line_source" readonly="state != 'draft'"/>
                             <field name="company_id" groups="base.group_multi_company" readonly="state != 'draft'"/>
                             <field name="currency_id" groups="base.group_multi_currency" readonly="state != 'draft'"/>
                             <field name="number_of_packages" readonly="state != 'draft'"/>
@@ -56,7 +60,8 @@
                         </group>
                     </group>
                     <notebook>
-                        <page string="Invoices" name="invoices">
+                        <page string="Invoices" name="invoices"
+                              invisible="line_source == 'picking'">
                             <field name="invoice_ids" readonly="state != 'draft'">
                                 <list>
                                     <field name="name" readonly="1"/>


### PR DESCRIPTION
## Summary

Makes the `commercial_invoice` line data source switchable between invoices and pickings, additive — `line_source='invoice'` (default) preserves existing behaviour for all current users.

Use case: producing a Commercial Invoice **before** shipping when no invoice exists yet.

## Changes

- New `line_source` Selection field on `commercial.invoice` (`invoice` | `picking`, default=`invoice`, tracking).
- `_get_report_lines()` Python helper returns uniform dicts; QWeb iterates this single list (template stays source-agnostic).
- Picking branch filters by `partner_id.commercial_partner_id` matching the CI's commercial partner; `picking_type_id.code='outgoing'`; `move.state='done'`. Aggregates by `(product_id, price_unit)` (different prices = separate rows). `price_unit = move.sale_line_id.price_unit`. Uses `move.quantity` (Odoo 19).
- Empty deliveries → bilingual "No deliveries linked to this selection / Aucune livraison liée à cette sélection" placeholder.
- `_compute_amounts` source-aware; manual `action_recompute_amounts` button visible only when `line_source='picking'` (no persisted relation to `stock.move` for clean `@api.depends`).
- Manifest bumped to `19.0.1.2.0`.
- `migrations/19.0.1.2.0/post-migrate.py` for defensive backfill of NULL `line_source`.
- Odoo 19 patterns: no `attrs`, no `_sql_constraints`, uses `move.quantity` (not `quantity_done`).

## Tests

9 tests in `commercial_invoice/tests/test_commercial_invoice_lines.py`, all green:

1. invoice source preserved
2. picking source returns lines
3. aggregation across pickings (same product/price → one row, different price → two)
4. empty deliveries placeholder
5. unit price from `move.sale_line_id.price_unit`
6. `_compute_amounts` for picking source
7. backwards-compat smoke
8. filter scope (other partners excluded)
9. non-outgoing pickings excluded

## Pipeline artifacts

https://git.bemade.org/bemade/tasks/-/tree/main/task-3516-commercial-invoice-from-deliveries

Originating Odoo task: https://odoo.bemade.org/odoo/project/291/tasks/3516

After this merges, a downstream cycle will bump the bemade-addons submodule pointer in verajet.