### PR TITLE
fix(mrp_mts_else_mto): add RST description to manifest

### DIFF
--- a/mrp_mts_else_mto/__manifest__.py
+++ b/mrp_mts_else_mto/__manifest__.py
@@ -21,6 +21,21 @@
     "name": "MRP MTS Else MTO Parent Link Fix",
     "version": "19.0.1.0.0",
     "summary": "Fix parent-child MO relationships with mts_else_mto rules",
+    "description": """
+MRP MTS Else MTO Parent Link Fix
+================================
+
+Fixes parent-child Manufacturing Order relationships when using
+``mts_else_mto`` (Make To Stock else Make To Order) procurement rules.
+
+Without this module, child MOs created via ``mts_else_mto`` rules are not
+linked back to their parent MO, so the Parent/Child smart buttons do not
+appear and quantity changes do not propagate.
+
+This module overrides ``stock.move._prepare_procurement_values()`` to
+include ``move_dest_ids`` when the rule's ``procure_method`` is
+``mts_else_mto``, restoring the parent link.
+""",
     "category": "Manufacturing/Manufacturing",
     "author": "Bemade Inc.",
     "website": "http://www.bemade.org",


### PR DESCRIPTION
## Summary
- Without an explicit `description`, Odoo falls back to `README.md` and parses it as RST during module load, emitting docutils ERROR/3 and WARNING/2 messages on every install/update (one ERROR + ~14 WARNINGs in our case).
- This adds a short RST `description` to the manifest so Odoo uses that instead of the markdown README. `README.md` is unchanged and still serves GitHub readers.

## Test plan
- [x] `odoo-dev test verajet_config` no longer prints `<string>:N: (ERROR/3)` / `(WARNING/2)` blocks attributable to `mrp_mts_else_mto` during module load.