### PR TITLE
Fix: team_id domain OWL eval + fr_CA translations refresh (18.0.3.6.13)

### DIFF
--- a/bemade_sports_clinic/__manifest__.py
+++ b/bemade_sports_clinic/__manifest__.py
@@ -18,7 +18,7 @@
 #
 {
     'name': 'Sports Clinic Management',
-    'version': '18.0.3.6.13',
+    'version': '18.0.3.6.14',
     'summary': 'Comprehensive sports medicine clinic management with portal access and activity tracking.',
     'description': """
 Sports Clinic Management System

--- a/bemade_sports_clinic/__manifest__.py
+++ b/bemade_sports_clinic/__manifest__.py
@@ -18,7 +18,7 @@
 #
 {
     'name': 'Sports Clinic Management',
-    'version': '18.0.3.6.12',
+    'version': '18.0.3.6.13',
     'summary': 'Comprehensive sports medicine clinic management with portal access and activity tracking.',
     'description': """
 Sports Clinic Management System

--- a/bemade_sports_clinic/i18n/fr_CA.po
+++ b/bemade_sports_clinic/i18n/fr_CA.po
@@ -70,7 +70,7 @@ msgstr " Diagnostic : %s."
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/team_management_portal.py:0
 msgid "%s has been created and added to the team."
-msgstr ""
+msgstr msgstr "%s a été créé et ajouté à l'équipe."
 
 #. module: bemade_sports_clinic
 #. odoo-python
@@ -81,43 +81,43 @@ msgstr "%s a été retiré avec succès de l'équipe."
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_add_link_player_page
 msgid "(DOB:"
-msgstr ""
+msgstr msgstr "(DDN :"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_events_list
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_timesheets_list
 msgid "(Page"
-msgstr ""
+msgstr msgstr "(Page"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_events_list
 msgid "(sched"
-msgstr ""
+msgstr msgstr "(prévu"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_create_injury
 msgid "-- Select team --"
-msgstr ""
+msgstr msgstr "-- Sélectionner une équipe --"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_home
 msgid "/my/activities"
-msgstr ""
+msgstr msgstr "/my/activities"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_home
 msgid "/my/events"
-msgstr ""
+msgstr msgstr "/my/events"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_home
 msgid "/my/players"
-msgstr ""
+msgstr msgstr "/my/players"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_home
 msgid "/my/teams"
-msgstr ""
+msgstr msgstr "/my/teams"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_activity_detail
@@ -132,12 +132,12 @@ msgstr "<i class=\"fa fa-ambulance\"/> Blessures"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_create_player
 msgid "<i class=\"fa fa-arrow-left me-1\"/> Back to Players"
-msgstr ""
+msgstr msgstr "<i class=\/> Retour aux joueurs"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_add_link_player_page
 msgid "<i class=\"fa fa-arrow-left me-1\"/> Back to Team"
-msgstr ""
+msgstr msgstr "<i class=\/> Retour à l'équipe"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_activity_detail
@@ -148,7 +148,7 @@ msgstr "<i class=\"fa fa-arrow-left\"/> Retour aux activités"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_create
 msgid "<i class=\"fa fa-arrow-left\"/> Cancel"
-msgstr ""
+msgstr msgstr "<i class=\/> Annuler"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_player_injuries
@@ -184,7 +184,7 @@ msgstr "<i class=\"fa fa-calendar\"/> Reprogrammer"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic._timesheet_card
 msgid "<i class=\"fa fa-car me-1\"/> Travel Start"
-msgstr ""
+msgstr msgstr "<i class=\/> Début du déplacement"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_activity_detail
@@ -194,7 +194,7 @@ msgstr "<i class=\"fa fa-check\"/> Terminer"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_detail
 msgid "<i class=\"fa fa-check\"/> Complete Anyway"
-msgstr ""
+msgstr msgstr "<i class=\/> Terminer quand même"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.activity_list_table
@@ -204,7 +204,7 @@ msgstr "<i class=\"fa fa-check\"/> Terminé"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_detail
 msgid "<i class=\"fa fa-check\"/> Mark Complete"
-msgstr ""
+msgstr msgstr "<i class=\/> Marquer comme terminé"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_team_players
@@ -227,7 +227,7 @@ msgstr ""
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_detail
 msgid "<i class=\"fa fa-check-circle\"/> Event marked completed."
-msgstr ""
+msgstr msgstr "<i class=\/> Événement marqué comme terminé."
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_detail
@@ -242,7 +242,7 @@ msgstr "<i class=\"fa fa-check-circle\"/> Rapport de blessure soumis"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_detail
 msgid "<i class=\"fa fa-check-circle\"/> Timesheet saved."
-msgstr ""
+msgstr msgstr "<i class=\/> Feuille de temps enregistrée."
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_player_injuries
@@ -257,35 +257,35 @@ msgstr "<i class=\"fa fa-clipboard-list\"/> Voir les notes"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic._timesheet_card
 msgid "<i class=\"fa fa-clock-o me-1\"/> Coverage End"
-msgstr ""
+msgstr msgstr "<i class=\/> Fin de la couverture"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic._timesheet_card
 msgid "<i class=\"fa fa-clock-o me-1\"/> Coverage Start"
-msgstr ""
+msgstr msgstr "<i class=\/> Début de la couverture"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_patient_card
 msgid ""
 "<i class=\"fa fa-clock-o\" title=\"Estimated Return\"/>\n"
 "                                <span class=\"ms-1 d-none d-md-inline\">Estimated Return:</span>"
-msgstr ""
+msgstr msgstr "<i class=\ title=\/>\n                                <span class=\>Retour estimé :</span>"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_detail
 msgid "<i class=\"fa fa-clock-o\"/> Add My Timesheet"
-msgstr ""
+msgstr msgstr "<i class=\/> Ajouter ma feuille de temps"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_detail
 msgid "<i class=\"fa fa-clock-o\"/> Timesheets"
-msgstr ""
+msgstr msgstr "<i class=\/> Feuilles de temps"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_create
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_edit
 msgid "<i class=\"fa fa-clock-o\"/> Timing Information"
-msgstr ""
+msgstr msgstr "<i class=\/> Information sur les horaires"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_injury_documents
@@ -303,7 +303,7 @@ msgstr "<i class=\"fa fa-edit\"/> Modifier"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_detail
 msgid "<i class=\"fa fa-edit\"/> Edit Event"
-msgstr ""
+msgstr msgstr "<i class=\/> Modifier l'événement"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_injury_documents
@@ -319,12 +319,12 @@ msgstr "<i class=\"fa fa-edit\"/> Modifier le joueur"
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_create
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_edit
 msgid "<i class=\"fa fa-exclamation-circle\"/> Error:"
-msgstr ""
+msgstr msgstr "<i class=\/> Erreur :"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_detail
 msgid "<i class=\"fa fa-exclamation-circle\"/> Timesheet error:"
-msgstr ""
+msgstr msgstr "<i class=\/> Erreur de feuille de temps :"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_edit_injury
@@ -338,14 +338,14 @@ msgstr ""
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_player_injuries
 msgid "<i class=\"fa fa-exclamation-triangle\"/> <strong>Allergies</strong>"
-msgstr ""
+msgstr msgstr "<i class=\/> <strong>Allergies</strong>"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_detail
 msgid ""
 "<i class=\"fa fa-exclamation-triangle\"/> Some assigned therapists have not "
 "added timesheets:"
-msgstr ""
+msgstr msgstr "<i class=\/> Certains thérapeutes assignés n'ont pas ajouté de feuille de temps :"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_player_injuries
@@ -355,7 +355,7 @@ msgstr "<i class=\"fa fa-exclamation-triangle\"/> Oui, Pas de contact"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_teams
 msgid "<i class=\"fa fa-eye\"/> View"
-msgstr ""
+msgstr msgstr "<i class=\/> Voir"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_player_injuries
@@ -365,34 +365,34 @@ msgstr "<i class=\"fa fa-eye\"/> Voir l'équipe"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_player_injuries
 msgid "<i class=\"fa fa-file\"/> Documents"
-msgstr ""
+msgstr msgstr "<i class=\/> Documents"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_player_injuries
 msgid "<i class=\"fa fa-file-medical\"/> Docs"
-msgstr ""
+msgstr msgstr "<i class=\/> Docs"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_edit_injury
 msgid "<i class=\"fa fa-file-medical\"/> Documents"
-msgstr ""
+msgstr msgstr "<i class=\/> Documents"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic._timesheet_card
 msgid "<i class=\"fa fa-flag-checkered me-1\"/> Travel End"
-msgstr ""
+msgstr msgstr "<i class=\/> Fin du déplacement"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic._timesheet_card
 msgid "<i class=\"fa fa-hourglass-half me-1\"/> Coverage Hours"
-msgstr ""
+msgstr msgstr "<i class=\/> Heures de couverture"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_add_link_player_page
 msgid ""
 "<i class=\"fa fa-info-circle me-1\"/> No matching players found. You can "
 "also create a new player below."
-msgstr ""
+msgstr msgstr "<i class=\/> Aucun joueur correspondant trouvé. Vous pouvez aussi créer un nouveau joueur ci-dessous."
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_create
@@ -418,17 +418,17 @@ msgstr "<i class=\"fa fa-info-circle\"/> Aucun personnel assigné pour l'instant
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_detail
 msgid "<i class=\"fa fa-info-circle\"/> Overview"
-msgstr ""
+msgstr msgstr "<i class=\/> Vue d'ensemble"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_add_link_player_page
 msgid "<i class=\"fa fa-link me-1\"/> Link to Team"
-msgstr ""
+msgstr msgstr "<i class=\/> Associer à l'équipe"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic._timesheet_card
 msgid "<i class=\"fa fa-lock\"/> Locked"
-msgstr ""
+msgstr msgstr "<i class=\/> Verrouillé"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_player_injuries
@@ -438,7 +438,7 @@ msgstr "<i class=\"fa fa-notes-medical\"/> <strong>Notes médicales</strong>"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_edit_player
 msgid "<i class=\"fa fa-paper-plane me-1\"/> Submit Request"
-msgstr ""
+msgstr msgstr "<i class=\/> Soumettre la demande"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_player_injuries
@@ -449,7 +449,7 @@ msgstr "<i class=\"fa fa-paper-plane\"/> Soumettre la demande"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic._timesheet_card
 msgid "<i class=\"fa fa-pencil\"/> Edit"
-msgstr ""
+msgstr msgstr "<i class=\/> Modifier"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_player_injuries
@@ -464,7 +464,7 @@ msgstr "<i class=\"fa fa-plus me-1\"/> Ajouter un joueur"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_team_players
 msgid "<i class=\"fa fa-plus me-1\"/> Request Player Addition"
-msgstr ""
+msgstr msgstr "<i class=\/> Demander l'ajout d'un joueur"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_player_injuries
@@ -474,7 +474,7 @@ msgstr "<i class=\"fa fa-plus\"/> Ajouter un contact d'urgence"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_events_list
 msgid "<i class=\"fa fa-plus\"/> Add Event"
-msgstr ""
+msgstr msgstr "<i class=\/> Ajouter un événement"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_player_injuries
@@ -485,22 +485,22 @@ msgstr "<i class=\"fa fa-plus\"/> Ajouter un premier contact"
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_create
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_edit
 msgid "<i class=\"fa fa-plus\"/> Add Venue"
-msgstr ""
+msgstr msgstr "<i class=\/> Ajouter un lieu"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_players
 msgid "<i class=\"fa fa-plus\"/> Create Player"
-msgstr ""
+msgstr msgstr "<i class=\/> Créer un joueur"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_create
 msgid "<i class=\"fa fa-plus\"/> New sports event"
-msgstr ""
+msgstr msgstr "<i class=\/> Nouvel événement sportif"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic._timesheet_card
 msgid "<i class=\"fa fa-road me-1\"/> Travel Hours"
-msgstr ""
+msgstr msgstr "<i class=\/> Heures de déplacement"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_player_injuries
@@ -511,7 +511,7 @@ msgstr "<i class=\"fa fa-running\"/> OK pour pratiquer"
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_add_link_player_page
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_create_player
 msgid "<i class=\"fa fa-save me-1\"/> Create Player"
-msgstr ""
+msgstr msgstr "<i class=\/> Créer un joueur"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_add_player
@@ -521,12 +521,12 @@ msgstr "<i class=\"fa fa-save me-1\"/> Enregistrer le joueur"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_create
 msgid "<i class=\"fa fa-save\"/> Create Event"
-msgstr ""
+msgstr msgstr "<i class=\/> Créer un événement"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic._timesheet_card
 msgid "<i class=\"fa fa-save\"/> Save"
-msgstr ""
+msgstr msgstr "<i class=\/> Enregistrer"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_edit_activity
@@ -541,14 +541,14 @@ msgstr "<i class=\"fa fa-save\"/> Enregistrer les modifications"
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_add_link_player_page
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_create_player
 msgid "<i class=\"fa fa-search me-1\"/> Search"
-msgstr ""
+msgstr msgstr "<i class=\/> Rechercher"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_patient_card
 msgid ""
 "<i class=\"fa fa-stethoscope\" title=\"Last Consultation Date\"/>\n"
 "                                <span class=\"ms-1 d-none d-md-inline\">Last Consultation:</span>"
-msgstr ""
+msgstr msgstr "<i class=\ title=\/>\n                                <span class=\>Dernière consultation :</span>"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_detail
@@ -684,7 +684,7 @@ msgstr "<option value=\"\">Tous les professionnels assignés</option>"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_players
 msgid "<option value=\"\">All Match Status</option>"
-msgstr ""
+msgstr msgstr "<option value=\>Tous les statuts de match</option>"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_create
@@ -698,7 +698,7 @@ msgstr "<option value=\"\">Toutes les organisations</option>"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_players
 msgid "<option value=\"\">All Practice Status</option>"
-msgstr ""
+msgstr msgstr "<option value=\>Tous les statuts de pratique</option>"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_events_list
@@ -710,7 +710,7 @@ msgstr "<option value=\"\">Toutes les équipes</option>"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_player_form_body
 msgid "<option value=\"\">No country available</option>"
-msgstr ""
+msgstr msgstr "<option value=\>Aucun pays disponible</option>"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_create_activity
@@ -720,7 +720,7 @@ msgstr "<option value=\"\">Sélectionner le type d'activité</option>"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_player_form_body
 msgid "<option value=\"\">Select Province/Territory...</option>"
-msgstr ""
+msgstr msgstr "<option value=\>Sélectionner une province/territoire...</option>"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.activity_list_table
@@ -854,7 +854,7 @@ msgstr ""
 msgid ""
 "<small class=\"text-muted d-block\">Select all teams participating in this "
 "event.</small>"
-msgstr ""
+msgstr msgstr "<small class=\>Sélectionnez toutes les équipes qui participent à cet événement.</small>"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_create
@@ -862,7 +862,7 @@ msgstr ""
 msgid ""
 "<small class=\"text-muted d-block\">Selecting an organization filters the "
 "teams below.</small>"
-msgstr ""
+msgstr msgstr "<small class=\>Sélectionner une organisation filtre les équipes ci-dessous.</small>"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_edit_injury
@@ -919,14 +919,14 @@ msgid ""
 "<small class=\"text-muted\">Select one or more professionals to assign. If "
 "left blank, team therapists will be auto-assigned. You will not be auto-"
 "assigned unless selected.</small>"
-msgstr ""
+msgstr msgstr "<small class=\>Sélectionnez un ou plusieurs professionnels à assigner. Si laissé vide, les thérapeutes de l'équipe seront assignés automatiquement. Vous ne serez pas assigné automatiquement à moins d'être sélectionné.</small>"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_create_injury
 msgid ""
 "<small class=\"text-muted\">The selected team determines assigned "
 "therapists.</small>"
-msgstr ""
+msgstr msgstr "<small class=\>L'équipe sélectionnée détermine les thérapeutes assignés.</small>"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_activity_detail
@@ -970,7 +970,7 @@ msgid ""
 "                                            <i class=\"fa fa-ban me-1\"/>\n"
 "                                            Match\n"
 "                                        </span>"
-msgstr ""
+msgstr msgstr "<span class=\ title=\>\n                                            <i class=\/>\n                                            Match\n                                        </span>"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_patient_card
@@ -979,7 +979,7 @@ msgid ""
 "                                <i class=\"fa fa-ban me-1\"/>\n"
 "                                Match\n"
 "                            </span>"
-msgstr ""
+msgstr msgstr "<span class=\ title=\>\n                                <i class=\/>\n                                Match\n                            </span>"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_player_injuries
@@ -988,7 +988,7 @@ msgid ""
 "                                            <i class=\"fa fa-ban me-1\"/>\n"
 "                                            Practice\n"
 "                                        </span>"
-msgstr ""
+msgstr msgstr "<span class=\ title=\>\n                                            <i class=\/>\n                                            Pratique\n                                        </span>"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_patient_card
@@ -997,7 +997,7 @@ msgid ""
 "                                <i class=\"fa fa-ban me-1\"/>\n"
 "                                Practice\n"
 "                            </span>"
-msgstr ""
+msgstr msgstr "<span class=\ title=\>\n                                <i class=\/>\n                                Pratique\n                            </span>"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_events_list
@@ -1007,7 +1007,7 @@ msgstr "<span class=\"badge bg-primary\">Mes événements</span>"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_add_link_player_page
 msgid "<span class=\"badge bg-secondary ms-2\">Archived</span>"
-msgstr ""
+msgstr msgstr "<span class=\>Archivé</span>"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_player_injuries
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid ""
 "<span class=\"badge bg-secondary text-white\" title=\"Match: "
 "Unknown\">Match</span>"
-msgstr ""
+msgstr msgstr "<span class=\ title=\Inconnu\"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_player_injuries
@@ -1023,7 +1023,7 @@ msgstr ""
 msgid ""
 "<span class=\"badge bg-secondary text-white\" title=\"Practice: "
 "Unknown\">Practice</span>"
-msgstr ""
+msgstr msgstr "<span class=\ title=\Inconnu\"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_events_list
@@ -1037,7 +1037,7 @@ msgid ""
 "                                            <i class=\"fa fa-check me-1\"/>\n"
 "                                            Match\n"
 "                                        </span>"
-msgstr ""
+msgstr msgstr "<span class=\ title=\>\n                                            <i class=\/>\n                                            Match\n                                        </span>"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_patient_card
@@ -1046,7 +1046,7 @@ msgid ""
 "                                <i class=\"fa fa-check me-1\"/>\n"
 "                                Match\n"
 "                            </span>"
-msgstr ""
+msgstr msgstr "<span class=\ title=\>\n                                <i class=\/>\n                                Match\n                            </span>"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_player_injuries
@@ -1055,7 +1055,7 @@ msgid ""
 "                                            <i class=\"fa fa-check me-1\"/>\n"
 "                                            Practice\n"
 "                                        </span>"
-msgstr ""
+msgstr msgstr "<span class=\ title=\>\n                                            <i class=\/>\n                                            Pratique\n                                        </span>"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_patient_card
@@ -1064,7 +1064,7 @@ msgid ""
 "                                <i class=\"fa fa-check me-1\"/>\n"
 "                                Practice\n"
 "                            </span>"
-msgstr ""
+msgstr msgstr "<span class=\ title=\>\n                                <i class=\/>\n                                Pratique\n                            </span>"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_player_injuries
@@ -1073,7 +1073,7 @@ msgid ""
 "                                            <i class=\"fa fa-exclamation-triangle me-1\"/>\n"
 "                                            Practice\n"
 "                                        </span>"
-msgstr ""
+msgstr msgstr "<span class=\ title=\>\n                                            <i class=\/>\n                                            Pratique\n                                        </span>"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_patient_card
@@ -1082,7 +1082,7 @@ msgid ""
 "                                <i class=\"fa fa-exclamation-triangle me-1\"/>\n"
 "                                Practice\n"
 "                            </span>"
-msgstr ""
+msgstr msgstr "<span class=\ title=\>\n                                <i class=\/>\n                                Pratique\n                            </span>"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_events_list
@@ -1092,12 +1092,12 @@ msgstr "<span class=\"badge bg-warning\">Événements non-assignés</span>"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_events_list
 msgid "<span class=\"badge rounded-pill bg-danger\">-</span>"
-msgstr ""
+msgstr msgstr "<span class=\>-</span>"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_users_form_inherit
 msgid "<span class=\"o_stat_text\">Assign Team Roles</span>"
-msgstr ""
+msgstr msgstr "<span class=\>Assigner les rôles d'équipe</span>"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.sports_patient_view_form
@@ -1111,7 +1111,7 @@ msgstr ""
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic._timesheet_card
 msgid "<span class=\"text-muted\">No Organization</span>"
-msgstr ""
+msgstr msgstr "<span class=\>Aucune organisation</span>"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic._timesheet_card
@@ -1150,7 +1150,7 @@ msgstr "<span class=\"text-muted\">A définir</span>"
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic._timesheet_card
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_events_list
 msgid "<span class=\"text-muted\">•</span>"
-msgstr ""
+msgstr msgstr "<span class=\>•</span>"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_team_players
@@ -1165,7 +1165,7 @@ msgstr "<strong>0</strong> événements trouvés"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_timesheets_list
 msgid "<strong>0</strong> timesheets found"
-msgstr ""
+msgstr msgstr "<strong>0</strong> feuille de temps trouvée"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_player_injuries
@@ -1387,7 +1387,7 @@ msgstr "Une équipe ne peut avoir qu'un seul thérapeute en chef."
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/team_management_portal.py:0
 msgid "Access Denied"
-msgstr ""
+msgstr msgstr "Accès refusé"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_res_users__accessible_team_ids
@@ -1409,7 +1409,7 @@ msgstr "Action requise"
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_attachments
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_player_injuries
 msgid "Actions"
-msgstr ""
+msgstr msgstr "Actions"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_patient__active
@@ -1426,12 +1426,12 @@ msgstr "Nombre de blessures actives"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_create_player
 msgid "Active Matches"
-msgstr ""
+msgstr msgstr "Matchs actifs"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_add_link_player_page
 msgid "Active Players"
-msgstr ""
+msgstr msgstr "Joueurs actifs"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event__activity_ids
@@ -1449,17 +1449,17 @@ msgstr "Activités"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_activities
 msgid "Activities for injury"
-msgstr ""
+msgstr msgstr "Activités pour la blessure"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_activities
 msgid "Activities for player"
-msgstr ""
+msgstr msgstr "Activités pour le joueur"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_activities
 msgid "Activities for team"
-msgstr ""
+msgstr msgstr "Activités pour l'équipe"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.activity_list_table
@@ -1532,7 +1532,7 @@ msgstr "Activité créée avec succès."
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_breadcrumbs_sports_clinic
 msgid "Add Activity"
-msgstr ""
+msgstr msgstr "Ajouter une activité"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_add_contact
@@ -1562,7 +1562,7 @@ msgstr "Ajouter une blessure pour"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_detail
 msgid "Add My Timesheet"
-msgstr ""
+msgstr msgstr "Ajouter ma feuille de temps"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_add_player
@@ -1582,35 +1582,35 @@ msgstr "Ajouter une note"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_breadcrumbs_sports_clinic
 msgid "Add Player"
-msgstr ""
+msgstr msgstr "Ajouter un joueur"
 
 #. module: bemade_sports_clinic
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/team_management_portal.py:0
 msgid "Add Player Failed"
-msgstr ""
+msgstr msgstr "Échec de l'ajout du joueur"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.sports_event_view_form
 msgid "Add Recurrence"
-msgstr ""
+msgstr msgstr "Ajouter une récurrence"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_detail
 msgid "Add Timesheet"
-msgstr ""
+msgstr msgstr "Ajouter une feuille de temps"
 
 #. module: bemade_sports_clinic
 #: model:ir.model,name:bemade_sports_clinic.model_sports_event_vendor_po_wizard
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_event_vendor_po_wizard_form
 msgid "Add Timesheets to Vendor Purchase Order"
-msgstr ""
+msgstr msgstr "Ajouter des feuilles de temps au bon de commande fournisseur"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_create
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_edit
 msgid "Add Venue"
-msgstr ""
+msgstr msgstr "Ajouter un lieu"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.activity_list_table
@@ -1627,23 +1627,23 @@ msgstr "Ajoutez des notes sur la réalisation de cette activité..."
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_add_link_player_page
 msgid "Add or Link Player"
-msgstr ""
+msgstr msgstr "Ajouter ou associer un joueur"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.sports_event_view_form
 msgid "Add to SO"
-msgstr ""
+msgstr msgstr "Ajouter à la commande client"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_event_batch_invoicing_wizard
 msgid "Add to Sale Orders"
-msgstr ""
+msgstr msgstr "Ajouter aux commandes clients"
 
 #. module: bemade_sports_clinic
 #: model:ir.actions.act_window,name:bemade_sports_clinic.action_open_event_vendor_po_wizard
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_event_vendor_po_wizard_form
 msgid "Add to Vendor PO"
-msgstr ""
+msgstr msgstr "Ajouter au bon de commande fournisseur"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_treatment_note__user_id
@@ -1670,7 +1670,7 @@ msgstr "Adresse"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_player_form_body
 msgid "Address Information"
-msgstr ""
+msgstr msgstr "Informations d'adresse"
 
 #. module: bemade_sports_clinic
 #: model:res.groups,name:bemade_sports_clinic.group_sports_clinic_admin
@@ -1712,13 +1712,13 @@ msgstr "Toutes les notes de traitement associées à cette blessure"
 msgid ""
 "All users who are treatment professionals (internal and portal). Used to "
 "filter staff selection."
-msgstr ""
+msgstr msgstr "Tous les utilisateurs qui sont des professionnels de la santé (internes et portail). Utilisé pour filtrer la sélection du personnel."
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_patient__allergies
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_player_form_body
 msgid "Allergies"
-msgstr ""
+msgstr msgstr "Allergies"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_team__allowed_user_ids
@@ -1728,7 +1728,7 @@ msgstr "Utilisateurs autorisés"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_add_link_player_page
 msgid "Already on Team"
-msgstr ""
+msgstr msgstr "Déjà dans l'équipe"
 
 #. module: bemade_sports_clinic
 #. odoo-python
@@ -1758,7 +1758,7 @@ msgstr ""
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_create_injury
 msgid "An error occurred. Please review the form."
-msgstr ""
+msgstr msgstr "Une erreur s'est produite. Veuillez vérifier le formulaire."
 
 #. module: bemade_sports_clinic
 #. odoo-python
@@ -1777,22 +1777,22 @@ msgstr "Une blessure a été supprimée."
 #: code:addons/bemade_sports_clinic/controllers/player_management_portal.py:0
 #: code:addons/bemade_sports_clinic/controllers/team_management_portal.py:0
 msgid "An unexpected error occurred."
-msgstr ""
+msgstr msgstr "Une erreur inattendue s'est produite."
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_team_role_mass_assign_wizard_form
 msgid "Apply"
-msgstr ""
+msgstr msgstr "Appliquer"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_create_player
 msgid "Archived Matches"
-msgstr ""
+msgstr msgstr "Matchs archivés"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_add_link_player_page
 msgid "Archived Players"
-msgstr ""
+msgstr msgstr "Joueurs archivés"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.activity_list_table
@@ -1817,18 +1817,18 @@ msgstr ""
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_team_role_mass_assign_line__selected
 msgid "Assign"
-msgstr ""
+msgstr msgstr "Assigner"
 
 #. module: bemade_sports_clinic
 #: model:ir.actions.act_window,name:bemade_sports_clinic.action_team_role_mass_assign
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_team_role_mass_assign_wizard_form
 msgid "Assign Team Roles"
-msgstr ""
+msgstr msgstr "Assigner les rôles d'équipe"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_player_form_body
 msgid "Assign Teams"
-msgstr ""
+msgstr msgstr "Assigner les équipes"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.activity_list_table
@@ -1838,7 +1838,7 @@ msgstr "Assigné à :"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_events_list
 msgid "Assigned"
-msgstr ""
+msgstr msgstr "Assigné"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event__assigned_staff_ids
@@ -1866,7 +1866,7 @@ msgstr "Assignés"
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/events_portal.py:0
 msgid "At least one team is required."
-msgstr ""
+msgstr msgstr "Au moins une équipe est requise."
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event__message_attachment_count
@@ -1892,23 +1892,23 @@ msgstr "Auteur"
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_recurrence_wizard__base_event_id
 msgid "Base Event"
-msgstr ""
+msgstr msgstr "Événement de base"
 
 #. module: bemade_sports_clinic
 #: model:ir.model,name:bemade_sports_clinic.model_sports_event_batch_invoicing_wizard
 msgid "Batch Add Events to Sale Orders"
-msgstr ""
+msgstr msgstr "Ajouter des événements en lot aux commandes clients"
 
 #. module: bemade_sports_clinic
 #: model:ir.actions.act_window,name:bemade_sports_clinic.action_event_batch_invoicing_wizard
 #: model:ir.actions.server,name:bemade_sports_clinic.server_action_event_batch_invoicing_wizard
 msgid "Batch Add to SO"
-msgstr ""
+msgstr msgstr "Ajout en lot à la commande client"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_event_batch_invoicing_wizard
 msgid "Batch Add to Sale Orders"
-msgstr ""
+msgstr msgstr "Ajout en lot aux commandes clients"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_patient_injury__body_location
@@ -1981,7 +1981,7 @@ msgstr "Cochez cette case si ce contact représente un lieu/lieu"
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,help:bemade_sports_clinic.field_sports_event_vendor_po_wizard__purchase_order_id
 msgid "Choose an open (draft) vendor purchase order for the therapist."
-msgstr ""
+msgstr msgstr "Choisir un bon de commande fournisseur ouvert (brouillon) pour le thérapeute."
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_patient__city
@@ -2015,19 +2015,19 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_create
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_edit
 msgid "Clinic"
-msgstr ""
+msgstr msgstr "Clinique"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_res_config_settings__product_event_clinic_customer_id
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_res_config_settings_bemade_sports_clinic
 msgid "Clinic Product (Customer Invoice)"
-msgstr ""
+msgstr msgstr "Produit clinique (facture client)"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_res_config_settings__product_event_clinic_vendor_id
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_res_config_settings_bemade_sports_clinic
 msgid "Clinic Product (Vendor PO)"
-msgstr ""
+msgstr msgstr "Produit clinique (BC fournisseur)"
 
 #. module: bemade_sports_clinic
 #. odoo-python
@@ -2035,7 +2035,7 @@ msgstr ""
 msgid ""
 "Clinic events cannot include travel time. Travel End must equal Coverage "
 "End."
-msgstr ""
+msgstr msgstr "Les événements de clinique ne peuvent pas inclure de temps de déplacement. La fin du déplacement doit égaler la fin de la couverture."
 
 #. module: bemade_sports_clinic
 #. odoo-python
@@ -2043,7 +2043,7 @@ msgstr ""
 msgid ""
 "Clinic events cannot include travel time. Travel Start must equal Coverage "
 "Start."
-msgstr ""
+msgstr msgstr "Les événements de clinique ne peuvent pas inclure de temps de déplacement. Le début du déplacement doit égaler le début de la couverture."
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic._timesheet_card
@@ -2076,7 +2076,7 @@ msgstr "Entraîneur"
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/team_management_portal.py:0
 msgid "Coach requests player addition"
-msgstr ""
+msgstr msgstr "L'entraîneur demande l'ajout d'un joueur"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.activity_list_table
@@ -2100,7 +2100,7 @@ msgstr "Complété"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.sports_event_timesheet_form
 msgid "Computed"
-msgstr ""
+msgstr msgstr "Calculé"
 
 #. module: bemade_sports_clinic
 #: model:ir.model,name:bemade_sports_clinic.model_res_config_settings
@@ -2125,7 +2125,7 @@ msgstr "Consentement pour divulgation au parent"
 #: model:ir.model,name:bemade_sports_clinic.model_res_partner
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_patient__partner_id
 msgid "Contact"
-msgstr ""
+msgstr msgstr "Contact"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_player_injuries
@@ -2135,7 +2135,7 @@ msgstr "Informations de contact"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_player_form_body
 msgid "Contact Name"
-msgstr ""
+msgstr msgstr "Nom du contact"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_patient_contact__contact_type
@@ -2151,7 +2151,7 @@ msgstr "Type de contact <span class=\"text-danger\">*</span>"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.sports_patient_view_form
 msgid "Contacts"
-msgstr ""
+msgstr msgstr "Contacts"
 
 #. module: bemade_sports_clinic
 #: model:ir.model,name:bemade_sports_clinic.model_task_to_event_wizard
@@ -2180,47 +2180,47 @@ msgstr "Pays"
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_sports_event_invoicing_wizard_form
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_timesheet_tree_for_invoicing_wizard
 msgid "Coverage (h)"
-msgstr ""
+msgstr msgstr "Couverture (h)"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.sports_event_view_form
 msgid "Coverage Duration"
-msgstr ""
+msgstr msgstr "Durée de la couverture"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_timesheet__coverage_duration
 msgid "Coverage Duration (Hours)"
-msgstr ""
+msgstr msgstr "Durée de la couverture (heures)"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_timesheet__coverage_end
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic._timesheet_card
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_detail
 msgid "Coverage End"
-msgstr ""
+msgstr msgstr "Fin de la couverture"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_res_config_settings__product_event_coverage_customer_id
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_res_config_settings_bemade_sports_clinic
 msgid "Coverage Product (Customer Invoice)"
-msgstr ""
+msgstr msgstr "Produit de couverture (facture client)"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_timesheet__coverage_start
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic._timesheet_card
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_detail
 msgid "Coverage Start"
-msgstr ""
+msgstr msgstr "Début de la couverture"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.sports_event_timesheet_tree
 msgid "Coverage Total"
-msgstr ""
+msgstr msgstr "Total de la couverture"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_sports_event_recurrence_wizard
 msgid "Create"
-msgstr ""
+msgstr msgstr "Créer"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_breadcrumbs_activities
@@ -2231,13 +2231,13 @@ msgstr "Créer une activité"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_sports_event_invoicing_wizard_form
 msgid "Create Customer Quotation from Timesheets"
-msgstr ""
+msgstr msgstr "Créer une soumission client à partir des feuilles de temps"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_breadcrumbs_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_create
 msgid "Create Event"
-msgstr ""
+msgstr msgstr "Créer un événement"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_create_injury
@@ -2247,7 +2247,7 @@ msgstr "Créer une blessure"
 #. module: bemade_sports_clinic
 #: model:ir.actions.server,name:bemade_sports_clinic.ir_cron_create_injury_verification_tasks_ir_actions_server
 msgid "Create Injury Verification Activities"
-msgstr ""
+msgstr msgstr "Créer des activités de vérification de blessure"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.sports_event_view_form
@@ -2257,39 +2257,39 @@ msgstr "Créer une tâche de gestion"
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_vendor_po_wizard__create_new_if_missing
 msgid "Create New Draft PO if none selected"
-msgstr ""
+msgstr msgstr "Créer un nouveau BC brouillon si aucun n'est sélectionné"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_add_link_player_page
 msgid "Create New Player"
-msgstr ""
+msgstr msgstr "Créer un nouveau joueur"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_breadcrumbs_sports_clinic
 msgid "Create Player"
-msgstr ""
+msgstr msgstr "Créer un joueur"
 
 #. module: bemade_sports_clinic
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/team_management_portal.py:0
 msgid "Create Player Failed"
-msgstr ""
+msgstr msgstr "Échec de la création du joueur"
 
 #. module: bemade_sports_clinic
 #: model:ir.actions.act_window,name:bemade_sports_clinic.action_sports_event_invoicing_wizard
 msgid "Create Quotation from Timesheets"
-msgstr ""
+msgstr msgstr "Créer une soumission à partir des feuilles de temps"
 
 #. module: bemade_sports_clinic
 #: model:ir.model,name:bemade_sports_clinic.model_sports_event_recurrence_wizard
 msgid "Create Recurrent Copies of Event"
-msgstr ""
+msgstr msgstr "Créer des copies récurrentes de l'événement"
 
 #. module: bemade_sports_clinic
 #: model:ir.actions.act_window,name:bemade_sports_clinic.action_sports_event_recurrence_wizard
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_sports_event_recurrence_wizard
 msgid "Create Recurring Events"
-msgstr ""
+msgstr msgstr "Créer des événements récurrents"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.actions.act_window,help:bemade_sports_clinic.sports_event_action
@@ -2304,7 +2304,7 @@ msgstr "Créer votre première note de traitement"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_sports_event_invoicing_wizard_form
 msgid "Create/Update Quotation"
-msgstr ""
+msgstr msgstr "Créer/Mettre à jour la soumission"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_attachments
@@ -2377,12 +2377,12 @@ msgstr "Client"
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_timesheet__customer_invoiced_complete
 msgid "Customer Invoiced Complete"
-msgstr ""
+msgstr msgstr "Facturation client complétée"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_invoicing_wizard__customer_sale_order_id
 msgid "Customer Quotation"
-msgstr ""
+msgstr msgstr "Soumission client"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_create_player
@@ -2400,19 +2400,19 @@ msgstr "DDN :"
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.sports_event_view_search
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_treatment_note_search
 msgid "Date"
-msgstr ""
+msgstr msgstr "Date"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_events_list
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_timesheets_list
 msgid "Date (asc)"
-msgstr ""
+msgstr msgstr "Date (croissant)"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_events_list
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_timesheets_list
 msgid "Date (desc)"
-msgstr ""
+msgstr msgstr "Date (décroissant)"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_patient__date_of_birth
@@ -2424,7 +2424,7 @@ msgstr "Date de naissance"
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_create_player
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_team_players
 msgid "Date of Birth"
-msgstr ""
+msgstr msgstr "Date de naissance"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_add_player
@@ -2434,7 +2434,7 @@ msgstr "Date de naissance"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_player_form_body
 msgid "Date of Birth <span class=\"text-danger\">*</span>"
-msgstr ""
+msgstr msgstr "Date de naissance <span class=\>*</span>"
 
 #. module: bemade_sports_clinic
 #. odoo-python
@@ -2442,7 +2442,7 @@ msgstr ""
 #: code:addons/bemade_sports_clinic/controllers/team_management_portal.py:0
 msgid ""
 "Date of Birth must not be in the future and not be more than 120 years ago."
-msgstr ""
+msgstr msgstr "La date de naissance ne doit pas être dans le futur ni de plus de 120 ans dans le passé."
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_patient_injury__injury_date
@@ -2455,7 +2455,7 @@ msgstr "Date de la blessure"
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/team_management_portal.py:0
 msgid "Date of birth is required"
-msgstr ""
+msgstr msgstr "La date de naissance est requise"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_project_task__date_deadline
@@ -2465,22 +2465,22 @@ msgstr "Date limite"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_res_config_settings_bemade_sports_clinic
 msgid "Default product used for event coverage on Customer Invoices"
-msgstr ""
+msgstr msgstr "Produit par défaut utilisé pour la couverture d'événement sur les factures clients"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_res_config_settings_bemade_sports_clinic
 msgid "Default product used for therapist coverage on Purchase Orders"
-msgstr ""
+msgstr msgstr "Produit par défaut utilisé pour la couverture du thérapeute sur les bons de commande"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_res_config_settings_bemade_sports_clinic
 msgid "Default product used for therapist travel on Purchase Orders"
-msgstr ""
+msgstr msgstr "Produit par défaut utilisé pour les déplacements du thérapeute sur les bons de commande"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_res_config_settings_bemade_sports_clinic
 msgid "Default product used for travel time on Customer Invoices"
-msgstr ""
+msgstr msgstr "Produit par défaut utilisé pour le temps de déplacement sur les factures clients"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,help:bemade_sports_clinic.field_task_to_event_wizard__venue_id
@@ -2508,12 +2508,12 @@ msgstr "Supprimer la blessure"
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_player_injuries
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.sports_event_view_form
 msgid "Description"
-msgstr ""
+msgstr msgstr "Description"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_sports_event_invoicing_wizard_form
 msgid "Description for created lines..."
-msgstr ""
+msgstr msgstr "Description pour les lignes créées..."
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,help:bemade_sports_clinic.field_project_project__description
@@ -2625,7 +2625,7 @@ msgstr "Document téléchargé avec succès."
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.sports_patient_injury_view_form
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.sports_patient_view_form
 msgid "Documents"
-msgstr ""
+msgstr msgstr "Documents"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields.selection,name:bemade_sports_clinic.selection__sports_event__state__draft
@@ -2639,7 +2639,7 @@ msgstr "Brouillon"
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,help:bemade_sports_clinic.field_sports_event_invoicing_wizard__customer_sale_order_id
 msgid "Draft customer quotation to which coverage/travel lines will be added."
-msgstr ""
+msgstr msgstr "Soumission client brouillon à laquelle les lignes de couverture/déplacement seront ajoutées."
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.activity_list_table
@@ -2687,7 +2687,7 @@ msgstr "Modifier la blessure"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_breadcrumbs_sports_clinic
 msgid "Edit Player"
-msgstr ""
+msgstr msgstr "Modifier le joueur"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_edit_player
@@ -2698,7 +2698,7 @@ msgstr "Modifier les informations du joueur"
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic._timesheet_card
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_detail
 msgid "Edit Timesheet"
-msgstr ""
+msgstr msgstr "Modifier la feuille de temps"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_patient__email
@@ -2730,22 +2730,22 @@ msgstr "Équipes desservies"
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_recurrence_preview__date_end
 msgid "End"
-msgstr ""
+msgstr msgstr "Fin"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_recurrence_wizard__end_mode
 msgid "End Mode"
-msgstr ""
+msgstr msgstr "Mode de fin"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields.selection,name:bemade_sports_clinic.selection__sports_event_recurrence_wizard__end_mode__count
 msgid "End after N occurrences"
-msgstr ""
+msgstr msgstr "Terminer après N occurrences"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields.selection,name:bemade_sports_clinic.selection__sports_event_recurrence_wizard__end_mode__until
 msgid "End by date"
-msgstr ""
+msgstr msgstr "Terminer à une date"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_project_task__date_end
@@ -2755,12 +2755,12 @@ msgstr "Date de fin"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_sports_event_recurrence_wizard
 msgid "Ends"
-msgstr ""
+msgstr msgstr "Se termine"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_player_form_body
 msgid "Enter allergies information here"
-msgstr ""
+msgstr msgstr "Entrez les informations sur les allergies ici"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_injury_documents
@@ -2775,7 +2775,7 @@ msgstr "Entrez le nom du document"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_player_form_body
 msgid "Enter internal notes here"
-msgstr ""
+msgstr msgstr "Entrez les notes internes ici"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_treatment_note_form
@@ -2791,7 +2791,7 @@ msgstr "Entrez la note de traitement"
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/team_management_portal.py:0
 msgid "Error"
-msgstr ""
+msgstr msgstr "Erreur"
 
 #. module: bemade_sports_clinic
 #. odoo-python
@@ -2810,7 +2810,7 @@ msgstr "Erreur lors de la demande de suppression: %s"
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_timesheet__event_id
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.sports_event_timesheet_search
 msgid "Event"
-msgstr ""
+msgstr msgstr "Événement"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.sports_event_view_form
@@ -2820,7 +2820,7 @@ msgstr "Détails de l'événement"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.sports_event_view_form
 msgid "Event Duration"
-msgstr ""
+msgstr msgstr "Durée de l'événement"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event__duration
@@ -2869,7 +2869,7 @@ msgstr "Début de l'événement"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.sports_event_view_form
 msgid "Event Start/End"
-msgstr ""
+msgstr msgstr "Début/fin de l'événement"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_detail
@@ -2879,7 +2879,7 @@ msgstr "Début de l'événement:"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.sports_event_timesheet_form
 msgid "Event Timesheet"
-msgstr ""
+msgstr msgstr "Feuille de temps de l'événement"
 
 #. module: bemade_sports_clinic
 #: model:ir.actions.act_window,name:bemade_sports_clinic.action_view_timesheets
@@ -2888,7 +2888,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_timesheets_list
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.sports_event_timesheet_tree
 msgid "Event Timesheets"
-msgstr ""
+msgstr msgstr "Feuilles de temps de l'événement"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.sports_event_view_form
@@ -2921,41 +2921,41 @@ msgstr "Durée de l'événement en heures"
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/events_portal.py:0
 msgid "Event end time is required."
-msgstr ""
+msgstr msgstr "L'heure de fin de l'événement est requise."
 
 #. module: bemade_sports_clinic
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/events_portal.py:0
 msgid "Event marked Completed via portal"
-msgstr ""
+msgstr msgstr "Événement marqué comme terminé via le portail"
 
 #. module: bemade_sports_clinic
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/events_portal.py:0
 msgid "Event name is required."
-msgstr ""
+msgstr msgstr "Le nom de l'événement est requis."
 
 #. module: bemade_sports_clinic
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/access_control_mixin.py:0
 msgid "Event not found."
-msgstr ""
+msgstr msgstr "Événement introuvable."
 
 #. module: bemade_sports_clinic
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/events_portal.py:0
 msgid "Event start time is required."
-msgstr ""
+msgstr msgstr "L'heure de début de l'événement est requise."
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,help:bemade_sports_clinic.field_sports_event_timesheet__event_id
 msgid "Event this timesheet belongs to"
-msgstr ""
+msgstr msgstr "Événement auquel cette feuille de temps appartient"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,help:bemade_sports_clinic.field_sports_event_invoicing_wizard__timesheet_ids
 msgid "Event timesheets included in this invoicing run. Editable inline."
-msgstr ""
+msgstr msgstr "Feuilles de temps d'événement incluses dans cette facturation. Modifiables sur place."
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_batch_invoicing_wizard__event_ids
@@ -2971,17 +2971,17 @@ msgstr "Événements"
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/team_management_portal.py:0
 msgid "Existing player %s has been %s."
-msgstr ""
+msgstr msgstr "Le joueur existant %s a été %s."
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_team_players
 msgid "Explain why this player should be added"
-msgstr ""
+msgstr msgstr "Expliquez pourquoi ce joueur devrait être ajouté"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_player_injuries
 msgid "Explain why this player should be removed"
-msgstr ""
+msgstr msgstr "Expliquez pourquoi ce joueur devrait être retiré"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_patient_injury__external_notes
@@ -3060,12 +3060,12 @@ msgstr "Prénom *"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_player_form_body
 msgid "First Name <span class=\"text-danger\">*</span>"
-msgstr ""
+msgstr msgstr "Prénom <span class=\>*</span>"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_players
 msgid "First name"
-msgstr ""
+msgstr msgstr "Prénom"
 
 #. module: bemade_sports_clinic
 #. odoo-python
@@ -3097,7 +3097,7 @@ msgstr "Abonnés (partenaires)"
 #. odoo-python
 #: code:addons/bemade_sports_clinic/models/res_config_settings.py:0
 msgid "Followers and team staff group memberships have been recomputed."
-msgstr ""
+msgstr msgstr "Les abonnés et les appartenances de groupe du personnel d'équipe ont été recalculés."
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,help:bemade_sports_clinic.field_sports_event__activity_type_icon
@@ -3127,7 +3127,7 @@ msgstr "Pour :"
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_recurrence_wizard__by_fr
 msgid "Fri"
-msgstr ""
+msgstr msgstr "Ven"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_events_list
@@ -3139,7 +3139,7 @@ msgstr "Date de début"
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_timesheet__fully_processed
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.sports_event_timesheet_search
 msgid "Fully Processed"
-msgstr ""
+msgstr msgstr "Entièrement traité"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields.selection,name:bemade_sports_clinic.selection__sports_event__event_type__game
@@ -3170,7 +3170,7 @@ msgstr "Regrouper par"
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_events_list
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_timesheets_list
 msgid "Group by"
-msgstr ""
+msgstr msgstr "Grouper par"
 
 #. module: bemade_sports_clinic
 #: model:ir.actions.server,name:bemade_sports_clinic.ir_cron_handle_pending_removals_ir_actions_server
@@ -3194,7 +3194,7 @@ msgstr "A accès au portail"
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event__has_uninvoiced_timesheets
 msgid "Has Uninvoiced Timesheets"
-msgstr ""
+msgstr msgstr "A des feuilles de temps non facturées"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_team__head_coach_id
@@ -3245,12 +3245,12 @@ msgstr "En santé :"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_breadcrumbs_sports_clinic
 msgid "Home"
-msgstr ""
+msgstr msgstr "Accueil"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,help:bemade_sports_clinic.field_sports_event_timesheet__coverage_duration
 msgid "Hours of coverage (coverage_end - coverage_start)"
-msgstr ""
+msgstr msgstr "Heures de couverture (coverage_end - coverage_start)"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_project_task_security_test__id
@@ -3272,7 +3272,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_team_role_mass_assign_line__id
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_team_role_mass_assign_wizard__id
 msgid "ID"
-msgstr ""
+msgstr msgstr "ID"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event__activity_exception_icon
@@ -3483,7 +3483,7 @@ msgstr "Utilisateur interne"
 #: code:addons/bemade_sports_clinic/controllers/team_management_portal.py:0
 msgid ""
 "Internal error: target model not found. Please contact an administrator."
-msgstr ""
+msgstr msgstr "Erreur interne : modèle cible introuvable. Veuillez contacter un administrateur."
 
 #. module: bemade_sports_clinic
 #: model:mail.message.subtype,description:bemade_sports_clinic.subtype_patient_injury_internal_update
@@ -3511,12 +3511,12 @@ msgstr "model specified. invalide"
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_timesheet__invoice_coverage_line_id
 msgid "Invoice Line (Coverage)"
-msgstr ""
+msgstr msgstr "Ligne de facture (couverture)"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_timesheet__invoice_travel_line_id
 msgid "Invoice Line (Travel)"
-msgstr ""
+msgstr msgstr "Ligne de facture (déplacement)"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields.selection,name:bemade_sports_clinic.selection__sports_event__state__invoiced
@@ -3524,12 +3524,12 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_edit
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.sports_event_view_search
 msgid "Invoiced"
-msgstr ""
+msgstr msgstr "Facturé"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic._timesheet_card
 msgid "Invoiced (read-only)"
-msgstr ""
+msgstr msgstr "Facturé (lecture seule)"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event__message_is_follower
@@ -3583,7 +3583,7 @@ msgstr "Nom de famille *"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_player_form_body
 msgid "Last Name <span class=\"text-danger\">*</span>"
-msgstr ""
+msgstr msgstr "Nom de famille <span class=\>*</span>"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_project_task_security_test__write_uid
@@ -3632,7 +3632,7 @@ msgstr "Dernière mise à jour le"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_players
 msgid "Last name"
-msgstr ""
+msgstr msgstr "Nom de famille"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_player_injuries
@@ -3642,7 +3642,7 @@ msgstr "Lien vers la blessure (optionnel)"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.sports_event_timesheet_form
 msgid "Links"
-msgstr ""
+msgstr msgstr "Liens"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event__task_id
@@ -3652,12 +3652,12 @@ msgstr "Tâche de gestion"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.sports_event_view_form
 msgid "Mark Completed"
-msgstr ""
+msgstr msgstr "Marquer comme terminé"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.sports_event_view_form
 msgid "Mark In Progress"
-msgstr ""
+msgstr msgstr "Marquer en cours"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.sports_patient_injury_view_form
@@ -3672,12 +3672,12 @@ msgstr "Marquer ce projet comme lié aux activités de la clinique sportive"
 #. module: bemade_sports_clinic
 #: model:ir.model,name:bemade_sports_clinic.model_team_role_mass_assign_line
 msgid "Mass assign team roles - line"
-msgstr ""
+msgstr msgstr "Assignation en lot des rôles d'équipe - ligne"
 
 #. module: bemade_sports_clinic
 #: model:ir.model,name:bemade_sports_clinic.model_team_role_mass_assign_wizard
 msgid "Mass assign team roles to a user across teams"
-msgstr ""
+msgstr msgstr "Assigner en lot les rôles d'équipe à un utilisateur sur plusieurs équipes"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_patient__match_status
@@ -3727,7 +3727,7 @@ msgstr "Type de message"
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_treatment_note__message_ids
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_messages
 msgid "Messages"
-msgstr ""
+msgstr msgstr "Messages"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_messages
@@ -3742,7 +3742,7 @@ msgstr "Léger"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_events_list
 msgid "Missing Timesheets"
-msgstr ""
+msgstr msgstr "Feuilles de temps manquantes"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_patient__mobile
@@ -3761,12 +3761,12 @@ msgstr "Modéré"
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_recurrence_wizard__by_mo
 msgid "Mon"
-msgstr ""
+msgstr msgstr "Lun"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_events_list
 msgid "Month"
-msgstr ""
+msgstr msgstr "Mois"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields.selection,name:bemade_sports_clinic.selection__sports_patient_contact__contact_type__mother
@@ -3832,7 +3832,7 @@ msgstr "Nom"
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_create
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_edit
 msgid "Name *"
-msgstr ""
+msgstr msgstr "Nom *"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_add_contact
@@ -3864,7 +3864,7 @@ msgstr "Nouvelle date d'échéance :"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_create_player
 msgid "New Player Details"
-msgstr ""
+msgstr msgstr "Détails du nouveau joueur"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event__activity_calendar_event_id
@@ -3917,19 +3917,19 @@ msgstr "Non"
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/events_portal.py:0
 msgid "No Date"
-msgstr ""
+msgstr msgstr "Aucune date"
 
 #. module: bemade_sports_clinic
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/timesheets_portal.py:0
 msgid "No Organization"
-msgstr ""
+msgstr msgstr "Aucune organisation"
 
 #. module: bemade_sports_clinic
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/events_portal.py:0
 msgid "No Team"
-msgstr ""
+msgstr msgstr "Aucune équipe"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.activity_list_table
@@ -3974,7 +3974,7 @@ msgstr "Aucune blessure enregistrée"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_create_player
 msgid "No matching players found. You can create a new one below."
-msgstr ""
+msgstr msgstr "Aucun joueur correspondant trouvé. Vous pouvez en créer un nouveau ci-dessous."
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_player_injuries
@@ -3985,13 +3985,13 @@ msgstr "Aucune information médicale disponible"
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/team_management_portal.py:0
 msgid "No reason provided"
-msgstr ""
+msgstr msgstr "Aucune raison fournie"
 
 #. module: bemade_sports_clinic
 #. odoo-python
 #: code:addons/bemade_sports_clinic/models/team_role_mass_assign_wizard.py:0
 msgid "No target user provided."
-msgstr ""
+msgstr msgstr "Aucun utilisateur cible fourni."
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_player_injuries
@@ -4001,17 +4001,17 @@ msgstr "Aucun team memberships trouvé"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_patient_card
 msgid "No teams"
-msgstr ""
+msgstr msgstr "Aucune équipe"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_timesheets_list
 msgid "No timesheets found"
-msgstr ""
+msgstr msgstr "Aucune feuille de temps trouvée"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_detail
 msgid "No timesheets yet."
-msgstr ""
+msgstr msgstr "Aucune feuille de temps pour le moment."
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_treatment_notes
@@ -4022,7 +4022,7 @@ msgstr "Aucune note de traitement disponible"
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_events_list
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_timesheets_list
 msgid "None"
-msgstr ""
+msgstr msgstr "Aucun"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields.selection,name:bemade_sports_clinic.selection__sports_patient_injury__parental_consent__na
@@ -4035,7 +4035,7 @@ msgstr "S/O"
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_edit_activity
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_treatment_notes
 msgid "Note"
-msgstr ""
+msgstr msgstr "Note"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_treatment_note__note_type
@@ -4045,7 +4045,7 @@ msgstr "Type de note"
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_patient__team_info_notes
 msgid "Notes"
-msgstr ""
+msgstr msgstr "Notes"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event__message_needaction_counter
@@ -4091,12 +4091,12 @@ msgstr "Nombre de messages avec une erreur de livraison"
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,help:bemade_sports_clinic.field_sports_event__timesheet_count
 msgid "Number of timesheets recorded for this event"
-msgstr ""
+msgstr msgstr "Nombre de feuilles de temps enregistrées pour cet événement"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_recurrence_wizard__count
 msgid "Occurrences"
-msgstr ""
+msgstr msgstr "Occurrences"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_patient__odoo16_patient_id
@@ -4107,7 +4107,7 @@ msgstr "ID du patient Odoo 16"
 #. odoo-python
 #: code:addons/bemade_sports_clinic/models/res_config_settings.py:0
 msgid "Only administrators can run this maintenance action."
-msgstr ""
+msgstr msgstr "Seuls les administrateurs peuvent exécuter cette action de maintenance."
 
 #. module: bemade_sports_clinic
 #. odoo-python
@@ -4131,7 +4131,7 @@ msgstr "Seules les blessures non vérifiées peuvent être vérifiées."
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_patient_card
 msgid "Open player details"
-msgstr ""
+msgstr msgstr "Ouvrir les détails du joueur"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_player_injuries
@@ -4141,7 +4141,7 @@ msgstr "Description optionnelle"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_event_batch_invoicing_wizard
 msgid "Optional description applied to created SO lines"
-msgstr ""
+msgstr msgstr "Description optionnelle appliquée aux lignes de commande créées"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event__partner_id
@@ -4205,12 +4205,12 @@ msgstr "Équipe détenue"
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_timesheet__purchase_coverage_line_id
 msgid "PO Line (Coverage)"
-msgstr ""
+msgstr msgstr "Ligne de BC (couverture)"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_timesheet__purchase_travel_line_id
 msgid "PO Line (Travel)"
-msgstr ""
+msgstr msgstr "Ligne de BC (déplacement)"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_team__parent_id
@@ -4234,14 +4234,14 @@ msgstr "Consentement parental"
 #: model:ir.model.fields,help:bemade_sports_clinic.field_sports_event_timesheet__therapist_partner_id
 #: model:ir.model.fields,help:bemade_sports_clinic.field_team_role_mass_assign_wizard__partner_id
 msgid "Partner-related data of the user"
-msgstr ""
+msgstr msgstr "Données de partenaire associées à l'utilisateur"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_breadcrumbs_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_home
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_home_timesheet_override_url
 msgid "Past Timesheets"
-msgstr ""
+msgstr msgstr "Feuilles de temps passées"
 
 #. module: bemade_sports_clinic
 #: model:ir.model,name:bemade_sports_clinic.model_sports_patient
@@ -4261,7 +4261,7 @@ msgstr "Patient dans une clinique de médecine sportive."
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_attachments
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_messages
 msgid "Patient #"
-msgstr ""
+msgstr msgstr "Patient n°"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.sports_patient_view_form
@@ -4354,12 +4354,12 @@ msgstr "Contacts du patient"
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.sports_patient_view_list
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.sports_patient_view_list_embedded
 msgid "Patients"
-msgstr ""
+msgstr msgstr "Patients"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_sports_event_recurrence_wizard
 msgid "Pattern"
-msgstr ""
+msgstr msgstr "Modèle"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_patient__pending_removal
@@ -4417,7 +4417,7 @@ msgstr "Téléphone"
 msgid ""
 "Pick a role to apply to all selected teams (and as default for newly "
 "selected teams)."
-msgstr ""
+msgstr msgstr "Choisissez un rôle à appliquer à toutes les équipes sélectionnées (et comme rôle par défaut pour les équipes nouvellement sélectionnées)."
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_activities
@@ -4427,37 +4427,37 @@ msgstr "Planifié ("
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_invoicing_wizard__duration
 msgid "Planned Event Duration"
-msgstr ""
+msgstr msgstr "Durée prévue de l'événement"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_invoicing_wizard__event_date_end
 msgid "Planned Event End"
-msgstr ""
+msgstr msgstr "Fin prévue de l'événement"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_invoicing_wizard__event_date_start
 msgid "Planned Event Start"
-msgstr ""
+msgstr msgstr "Début prévu de l'événement"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_invoicing_wizard__therapist_duration
 msgid "Planned Therapist Duration"
-msgstr ""
+msgstr msgstr "Durée prévue du thérapeute"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_invoicing_wizard__therapist_end
 msgid "Planned Therapist End"
-msgstr ""
+msgstr msgstr "Fin prévue du thérapeute"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_invoicing_wizard__therapist_start
 msgid "Planned Therapist Start"
-msgstr ""
+msgstr msgstr "Début prévu du thérapeute"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_sports_event_invoicing_wizard_form
 msgid "Planned Times"
-msgstr ""
+msgstr msgstr "Horaires prévus"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields.selection,name:bemade_sports_clinic.selection__sports_patient__stage__healthy
@@ -4486,19 +4486,19 @@ msgstr "Nombre de joueurs"
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/team_management_portal.py:0
 msgid "Player Created"
-msgstr ""
+msgstr msgstr "Joueur créé"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_add_player
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_player_form_body
 msgid "Player Details"
-msgstr ""
+msgstr msgstr "Détails du joueur"
 
 #. module: bemade_sports_clinic
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/team_management_portal.py:0
 msgid "Player Linked"
-msgstr ""
+msgstr msgstr "Joueur associé"
 
 #. module: bemade_sports_clinic
 #. odoo-python
@@ -4602,7 +4602,7 @@ msgstr "Joueurs"
 #. odoo-python
 #: code:addons/bemade_sports_clinic/models/team_role_mass_assign_wizard.py:0
 msgid "Please choose a role for team '%s' or set a bulk role."
-msgstr ""
+msgstr msgstr "Veuillez choisir un rôle pour l'équipe '%s' ou définir un rôle en lot."
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_treatment_notes
@@ -4614,7 +4614,7 @@ msgstr "Veuillez enter a treatment note."
 #: code:addons/bemade_sports_clinic/controllers/player_management_portal.py:0
 #: code:addons/bemade_sports_clinic/controllers/team_management_portal.py:0
 msgid "Please enter a valid Date of Birth (YYYY-MM-DD)."
-msgstr ""
+msgstr msgstr "Veuillez entrer une date de naissance valide (AAAA-MM-JJ)."
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_edit_activity
@@ -4660,19 +4660,19 @@ msgstr "Veuillez select a file to upload."
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_create_injury
 msgid "Please select a team for this injury."
-msgstr ""
+msgstr msgstr "Veuillez sélectionner une équipe pour cette blessure."
 
 #. module: bemade_sports_clinic
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/player_management_portal.py:0
 msgid "Please select at least one team to assign to this player."
-msgstr ""
+msgstr msgstr "Veuillez sélectionner au moins une équipe à assigner à ce joueur."
 
 #. module: bemade_sports_clinic
 #. odoo-python
 #: code:addons/bemade_sports_clinic/models/patient_injury.py:0
 msgid "Please verify this injury and set the appropriate status."
-msgstr ""
+msgstr msgstr "Veuillez vérifier cette blessure et définir le statut approprié."
 
 #. module: bemade_sports_clinic
 #: model:res.groups,name:bemade_sports_clinic.group_portal_team_coach
@@ -4731,22 +4731,22 @@ msgstr "Date prévue de retour"
 #: model:ir.model.fields.selection,name:bemade_sports_clinic.selection__sports_injury_document__category__prescription
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_injury_documents
 msgid "Prescription"
-msgstr ""
+msgstr msgstr "Prescription"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_sports_event_recurrence_wizard
 msgid "Preview"
-msgstr ""
+msgstr msgstr "Aperçu"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_recurrence_wizard__preview_line_ids
 msgid "Preview Dates"
-msgstr ""
+msgstr msgstr "Aperçu des dates"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_player_form_body
 msgid "Primary Emergency Contact"
-msgstr ""
+msgstr msgstr "Contact d'urgence principal"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_project_task__priority
@@ -4756,12 +4756,12 @@ msgstr "Priorité"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_res_config_settings_bemade_sports_clinic
 msgid "Product used for clinic events on Customer Invoices/Quotations"
-msgstr ""
+msgstr msgstr "Produit utilisé pour les événements de clinique sur les factures/soumissions clients"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_res_config_settings_bemade_sports_clinic
 msgid "Product used for clinic events on Vendor Purchase Orders"
-msgstr ""
+msgstr msgstr "Produit utilisé pour les événements de clinique sur les bons de commande fournisseur"
 
 #. module: bemade_sports_clinic
 #: model:ir.model,name:bemade_sports_clinic.model_project_project
@@ -4799,30 +4799,30 @@ msgstr "Propriétés"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_edit_player
 msgid "Provide a clear reason for this request"
-msgstr ""
+msgstr msgstr "Fournissez une raison claire pour cette demande"
 
 #. module: bemade_sports_clinic
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/team_management_portal.py:0
 msgid "Provide at least a first or last name"
-msgstr ""
+msgstr msgstr "Fournissez au moins un prénom ou un nom de famille"
 
 #. module: bemade_sports_clinic
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/player_management_portal.py:0
 #: code:addons/bemade_sports_clinic/controllers/team_management_portal.py:0
 msgid "Provide at least a first or last name to search"
-msgstr ""
+msgstr msgstr "Fournissez au moins un prénom ou un nom de famille pour rechercher"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_player_form_body
 msgid "Province/Territory"
-msgstr ""
+msgstr msgstr "Province/Territoire"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,help:bemade_sports_clinic.field_sports_event_timesheet__vendor_purchase_order_id
 msgid "Purchase Order to which the therapist lines will be added."
-msgstr ""
+msgstr msgstr "Bon de commande auquel les lignes du thérapeute seront ajoutées."
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event__rating_ids
@@ -4836,23 +4836,23 @@ msgstr "Évaluations"
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_timesheet__vendor_ready_to_po
 msgid "Ready to Add to Vendor PO"
-msgstr ""
+msgstr msgstr "Prêt à ajouter au BC fournisseur"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_timesheet__customer_ready_to_invoice
 msgid "Ready to Invoice (Customer)"
-msgstr ""
+msgstr msgstr "Prêt à facturer (client)"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_player_injuries
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_team_players
 msgid "Reason"
-msgstr ""
+msgstr msgstr "Raison"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_edit_player
 msgid "Reason for removal <span class=\"text-danger\">*</span>"
-msgstr ""
+msgstr msgstr "Raison du retrait <span class=\>*</span>"
 
 #. module: bemade_sports_clinic
 #. odoo-python
@@ -4879,34 +4879,34 @@ msgstr "Réassigner cette activité à un autre professionnel de la santé :"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_res_config_settings_bemade_sports_clinic
 msgid "Recompute Followers & Groups"
-msgstr ""
+msgstr msgstr "Recalculer les abonnés et les groupes"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_res_config_settings_bemade_sports_clinic
 msgid "Recompute Groups Only"
-msgstr ""
+msgstr msgstr "Recalculer les groupes uniquement"
 
 #. module: bemade_sports_clinic
 #: model:ir.actions.server,name:bemade_sports_clinic.ir_cron_recompute_sports_followers_and_groups_ir_actions_server
 msgid "Recompute Sports Followers and Groups"
-msgstr ""
+msgstr msgstr "Recalculer les abonnés et les groupes sportifs"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_res_config_settings_bemade_sports_clinic
 msgid ""
 "Recompute followers and team staff group memberships for all sports clinic "
 "records."
-msgstr ""
+msgstr msgstr "Recalculer les abonnés et les appartenances de groupe du personnel d'équipe pour tous les enregistrements de clinique sportive."
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_res_config_settings_bemade_sports_clinic
 msgid "Recompute only team staff group memberships (no follower updates)."
-msgstr ""
+msgstr msgstr "Recalculer uniquement les appartenances de groupe du personnel d'équipe (sans mise à jour des abonnés)."
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_team_role_mass_assign_wizard__partner_id
 msgid "Related Partner"
-msgstr ""
+msgstr msgstr "Partenaire associé"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.activity_list_table
@@ -4926,7 +4926,7 @@ msgstr "Enregistré pour"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_player_form_body
 msgid "Relationship"
-msgstr ""
+msgstr msgstr "Relation"
 
 #. module: bemade_sports_clinic
 #. odoo-python
@@ -4968,12 +4968,12 @@ msgstr "Les professionnels de traitement suivants ont été supprimés : %s."
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_recurrence_wizard__interval_weeks
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_sports_event_recurrence_wizard
 msgid "Repeat every (weeks)"
-msgstr ""
+msgstr msgstr "Répéter toutes les (semaines)"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_sports_event_recurrence_wizard
 msgid "Repeat on"
-msgstr ""
+msgstr msgstr "Répéter le"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_player_injuries
@@ -4996,12 +4996,12 @@ msgstr "Signaler une blessure pour"
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/team_management_portal.py:0
 msgid "Request Failed"
-msgstr ""
+msgstr msgstr "Échec de la demande"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_team_players
 msgid "Request Player Addition"
-msgstr ""
+msgstr msgstr "Demander l'ajout d'un joueur"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_edit_player
@@ -5013,7 +5013,7 @@ msgstr "Demander le retrait d'un joueur"
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/team_management_portal.py:0
 msgid "Request Submitted"
-msgstr ""
+msgstr msgstr "Demande soumise"
 
 #. module: bemade_sports_clinic
 #. odoo-python
@@ -5031,7 +5031,7 @@ msgstr ""
 msgid ""
 "Requested player: %s %s%s\n"
 "Reason: %s"
-msgstr ""
+msgstr msgstr "Joueur demandé : %s %s%s\nRaison : %s"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.activity_list_table
@@ -5047,14 +5047,14 @@ msgstr "Reprogrammer l'activité"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.sports_event_view_form
 msgid "Reset Timesheets"
-msgstr ""
+msgstr msgstr "Réinitialiser les feuilles de temps"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.sports_event_view_form
 msgid ""
 "Reset timesheets to Submitted if they are no longer linked to any "
 "SO/PO/Invoice lines."
-msgstr ""
+msgstr msgstr "Réinitialiser les feuilles de temps à « Soumis » si elles ne sont plus liées à des lignes de commande/BC/facture."
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_patient_injury__resolution_date
@@ -5119,12 +5119,12 @@ msgstr "Erreur de livraison SMS"
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_timesheet__sale_coverage_line_id
 msgid "Sale Line (Coverage)"
-msgstr ""
+msgstr msgstr "Ligne de vente (couverture)"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_timesheet__sale_travel_line_id
 msgid "Sale Line (Travel)"
-msgstr ""
+msgstr msgstr "Ligne de vente (déplacement)"
 
 #. module: bemade_sports_clinic
 #: model:ir.model,name:bemade_sports_clinic.model_sale_order_line
@@ -5134,12 +5134,12 @@ msgstr "Ligne de commande"
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_recurrence_wizard__by_sa
 msgid "Sat"
-msgstr ""
+msgstr msgstr "Sam"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_detail
 msgid "Save"
-msgstr ""
+msgstr msgstr "Enregistrer"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_edit_contact
@@ -5152,17 +5152,17 @@ msgstr "Enregistrer les modifications"
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_create
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_edit
 msgid "Save Venue"
-msgstr ""
+msgstr msgstr "Enregistrer le lieu"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_timesheets_list
 msgid "Search (event / team / organization)"
-msgstr ""
+msgstr msgstr "Rechercher (événement / équipe / organisation)"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_add_link_player_page
 msgid "Search Results"
-msgstr ""
+msgstr msgstr "Résultats de la recherche"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_treatment_note_search
@@ -5173,12 +5173,12 @@ msgstr "Rechercher des notes de traitement"
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/team_management_portal.py:0
 msgid "Search failed. Please try again."
-msgstr ""
+msgstr msgstr "Échec de la recherche. Veuillez réessayer."
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.sports_event_view_form
 msgid "Select treatment professionals"
-msgstr ""
+msgstr msgstr "Sélectionner les professionnels de la santé"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_task_to_event_wizard__task_ids
@@ -5189,7 +5189,7 @@ msgstr "Tâches sélectionnées"
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,help:bemade_sports_clinic.field_sports_event_vendor_po_wizard__timesheet_ids
 msgid "Selected timesheets to add to a vendor purchase order."
-msgstr ""
+msgstr msgstr "Feuilles de temps sélectionnées à ajouter à un bon de commande fournisseur."
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_patient_contact__sequence
@@ -5200,12 +5200,12 @@ msgstr "Séquence"
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_team_role_mass_assign_wizard__bulk_role
 msgid "Set role for selected"
-msgstr ""
+msgstr msgstr "Définir le rôle pour la sélection"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_team_role_mass_assign_wizard_form
 msgid "Set role for selected teams"
-msgstr ""
+msgstr msgstr "Définir le rôle pour les équipes sélectionnées"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.sports_patient_view_form
@@ -5238,7 +5238,7 @@ msgstr "Taille"
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_events_list
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_timesheets_list
 msgid "Sort by"
-msgstr ""
+msgstr msgstr "Trier par"
 
 #. module: bemade_sports_clinic
 #: model:ir.ui.menu,name:bemade_sports_clinic.sports_clinic_root
@@ -5253,29 +5253,29 @@ msgstr "Droits d'accès clinique de médecine sportive"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_res_config_settings_bemade_sports_clinic
 msgid "Sports Clinic Group Maintenance"
-msgstr ""
+msgstr msgstr "Maintenance des groupes de la clinique sportive"
 
 #. module: bemade_sports_clinic
 #. odoo-python
 #: code:addons/bemade_sports_clinic/models/res_config_settings.py:0
 msgid "Sports Clinic Group Maintenance Completed"
-msgstr ""
+msgstr msgstr "Maintenance des groupes de la clinique sportive terminée"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_res_config_settings_bemade_sports_clinic
 msgid "Sports Clinic Invoicing"
-msgstr ""
+msgstr msgstr "Facturation de la clinique sportive"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_res_config_settings_bemade_sports_clinic
 msgid "Sports Clinic Maintenance"
-msgstr ""
+msgstr msgstr "Maintenance de la clinique sportive"
 
 #. module: bemade_sports_clinic
 #. odoo-python
 #: code:addons/bemade_sports_clinic/models/res_config_settings.py:0
 msgid "Sports Clinic Maintenance Completed"
-msgstr ""
+msgstr msgstr "Maintenance de la clinique sportive terminée"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_project_project__is_sports_clinic_project
@@ -5299,17 +5299,17 @@ msgstr "Événement sportif"
 #. module: bemade_sports_clinic
 #: model:ir.model,name:bemade_sports_clinic.model_sports_event_invoicing_wizard
 msgid "Sports Event Invoicing Wizard"
-msgstr ""
+msgstr msgstr "Assistant de facturation d'événement sportif"
 
 #. module: bemade_sports_clinic
 #: model:ir.model,name:bemade_sports_clinic.model_sports_event_recurrence_preview
 msgid "Sports Event Recurrence Preview Line"
-msgstr ""
+msgstr msgstr "Ligne d'aperçu de récurrence d'événement sportif"
 
 #. module: bemade_sports_clinic
 #: model:ir.model,name:bemade_sports_clinic.model_sports_event_timesheet
 msgid "Sports Event Timesheet"
-msgstr ""
+msgstr msgstr "Feuille de temps d'événement sportif"
 
 #. module: bemade_sports_clinic
 #: model:ir.actions.act_window,name:bemade_sports_clinic.sports_event_action
@@ -5354,7 +5354,7 @@ msgstr "Équipes sportives"
 msgid ""
 "Sports events help you manage games, practices, training sessions, and team meetings.\n"
 "                    Each event can be linked to a project task for internal management."
-msgstr ""
+msgstr msgstr "Les événements sportifs vous aident à gérer les matchs, pratiques, sessions d'entraînement et réunions d'équipe.\n                    Chaque événement peut être lié à une tâche de projet pour la gestion interne."
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_res_partner__staff_ids
@@ -5384,7 +5384,7 @@ msgstr "Étape"
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_recurrence_preview__date_start
 msgid "Start"
-msgstr ""
+msgstr msgstr "Début"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_project_task__date_start
@@ -5400,7 +5400,7 @@ msgstr "Statut"
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_recurrence_wizard__recurrence_state
 msgid "State for new events"
-msgstr ""
+msgstr msgstr "État pour les nouveaux événements"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event__state
@@ -5455,17 +5455,17 @@ msgstr "Rue"
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_create
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_edit
 msgid "Street 2"
-msgstr ""
+msgstr msgstr "Adresse 2"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_player_form_body
 msgid "Street Address"
-msgstr ""
+msgstr msgstr "Adresse"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_player_form_body
 msgid "Street Address 2"
-msgstr ""
+msgstr msgstr "Adresse 2"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_patient__street2
@@ -5485,12 +5485,12 @@ msgstr "Soumettre le rapport"
 #. module: bemade_sports_clinic
 #: model:ir.model.fields.selection,name:bemade_sports_clinic.selection__sports_event_timesheet__state__submitted
 msgid "Submitted"
-msgstr ""
+msgstr msgstr "Soumis"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,help:bemade_sports_clinic.field_sports_event_timesheet__state
 msgid "Submitted: editable; Invoiced: read-only"
-msgstr ""
+msgstr msgstr "Soumis : modifiable; Facturé : lecture seule"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.activity_list_table
@@ -5506,7 +5506,7 @@ msgstr "Résumé <span class=\"text-danger\">*</span>"
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_recurrence_wizard__by_su
 msgid "Sun"
-msgstr ""
+msgstr msgstr "Dim"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_project_task__tag_ids
@@ -5565,7 +5565,7 @@ msgstr "Équipe #"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.sports_event_view_search
 msgid "Team (by Organization)"
-msgstr ""
+msgstr msgstr "Équipe (par organisation)"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.sports_patient_view_form
@@ -5594,7 +5594,7 @@ msgstr "Notes d'équipe"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_team_players
 msgid "Team Players"
-msgstr ""
+msgstr msgstr "Joueurs de l'équipe"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_users_form_inherit
@@ -5618,7 +5618,7 @@ msgstr "Équipe non trouvée ou vous n'avez pas accès à elle"
 #: code:addons/bemade_sports_clinic/models/res_config_settings.py:0
 msgid ""
 "Team staff group memberships have been recomputed (no follower changes)."
-msgstr ""
+msgstr msgstr "Les appartenances de groupe du personnel d'équipe ont été recalculées (sans modification des abonnés)."
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,help:bemade_sports_clinic.field_task_to_event_wizard__team_id
@@ -5706,12 +5706,12 @@ msgstr "La blessure doit appartenir au patient sélectionné."
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_create_injury
 msgid "The selected team is not valid for this player."
-msgstr ""
+msgstr msgstr "L'équipe sélectionnée n'est pas valide pour ce joueur."
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,help:bemade_sports_clinic.field_sports_event__team_ids
 msgid "The sports teams this event involves"
-msgstr ""
+msgstr msgstr "Les équipes sportives concernées par cet événement"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,help:bemade_sports_clinic.field_sports_patient_injury__team_id
@@ -5753,7 +5753,7 @@ msgstr "Thérapeute"
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_vendor_po_wizard__therapist_partner_id
 msgid "Therapist (Vendor)"
-msgstr ""
+msgstr msgstr "Thérapeute (fournisseur)"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.sports_event_view_form
@@ -5769,7 +5769,7 @@ msgstr "Durée de la couverture du thérapeute (heures)"
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_res_config_settings__product_event_coverage_vendor_id
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_res_config_settings_bemade_sports_clinic
 msgid "Therapist Coverage Product (Vendor PO)"
-msgstr ""
+msgstr msgstr "Produit de couverture thérapeute (BC fournisseur)"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_create
@@ -5790,7 +5790,7 @@ msgstr "Fin de la couverture :"
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_timesheet__therapist_partner_id
 msgid "Therapist Partner"
-msgstr ""
+msgstr msgstr "Partenaire thérapeute"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_create
@@ -5806,7 +5806,7 @@ msgstr "Début de la couverture"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.sports_event_view_form
 msgid "Therapist Start/End"
-msgstr ""
+msgstr msgstr "Début/fin du thérapeute"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_detail
@@ -5817,7 +5817,7 @@ msgstr "Début de la couverture :"
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_res_config_settings__product_event_travel_vendor_id
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_res_config_settings_bemade_sports_clinic
 msgid "Therapist Travel Product (Vendor PO)"
-msgstr ""
+msgstr msgstr "Produit de déplacement thérapeute (BC fournisseur)"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,help:bemade_sports_clinic.field_sports_event__therapist_duration
@@ -5828,12 +5828,12 @@ msgstr "Durée de la couverture du thérapeute en heures"
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,help:bemade_sports_clinic.field_sports_event_timesheet__user_id
 msgid "Therapist entering this timesheet"
-msgstr ""
+msgstr msgstr "Thérapeute saisissant cette feuille de temps"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,help:bemade_sports_clinic.field_sports_event_vendor_po_wizard__therapist_partner_id
 msgid "Therapist partner inferred from selected timesheets."
-msgstr ""
+msgstr msgstr "Partenaire thérapeute déduit des feuilles de temps sélectionnées."
 
 #. module: bemade_sports_clinic
 #. odoo-python
@@ -5850,7 +5850,7 @@ msgstr "Aucun événement ne correspond à vos critères."
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_timesheets_list
 msgid "There are no timesheets matching your criteria."
-msgstr ""
+msgstr msgstr "Aucune feuille de temps ne correspond à vos critères."
 
 #. module: bemade_sports_clinic
 #. odoo-python
@@ -5858,7 +5858,7 @@ msgstr ""
 msgid ""
 "There was an error creating the player. Please review your inputs and try "
 "again."
-msgstr ""
+msgstr msgstr "Une erreur s'est produite lors de la création du joueur. Veuillez vérifier vos entrées et réessayer."
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.sports_event_view_search
@@ -5881,17 +5881,17 @@ msgstr "Cette équipe n'a pu être trouvée."
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/timesheets_portal.py:0
 msgid "This timesheet is invoiced and cannot be edited."
-msgstr ""
+msgstr msgstr "Cette feuille de temps est facturée et ne peut pas être modifiée."
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_recurrence_wizard__by_th
 msgid "Thu"
-msgstr ""
+msgstr msgstr "Jeu"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event__timesheet_count
 msgid "Timesheet Count"
-msgstr ""
+msgstr msgstr "Nombre de feuilles de temps"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event__timesheet_ids
@@ -5903,27 +5903,27 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_sports_event_invoicing_wizard_form
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_timesheet_tree_for_invoicing_wizard
 msgid "Timesheets"
-msgstr ""
+msgstr msgstr "Feuilles de temps"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,help:bemade_sports_clinic.field_sports_event__timesheet_ids
 msgid "Timesheets logged by assigned therapists for this event"
-msgstr ""
+msgstr msgstr "Feuilles de temps saisies par les thérapeutes assignés à cet événement"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_invoicing_wizard__timesheet_ids
 msgid "Timesheets to Invoice"
-msgstr ""
+msgstr msgstr "Feuilles de temps à facturer"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_recurrence_wizard__timezone
 msgid "Timezone"
-msgstr ""
+msgstr msgstr "Fuseau horaire"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,help:bemade_sports_clinic.field_sports_event_recurrence_wizard__timezone
 msgid "Timezone used to compute occurrences at a fixed local wall time."
-msgstr ""
+msgstr msgstr "Fuseau horaire utilisé pour calculer les occurrences à une heure locale fixe."
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_project_task__name
@@ -5941,12 +5941,12 @@ msgstr "Date de fin"
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.sports_event_timesheet_search
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.sports_event_view_search
 msgid "To Invoice"
-msgstr ""
+msgstr msgstr "À facturer"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.sports_event_timesheet_search
 msgid "To Vendor PO"
-msgstr ""
+msgstr msgstr "À ajouter au BC fournisseur"
 
 #. module: bemade_sports_clinic
 #. odoo-python
@@ -5976,7 +5976,7 @@ msgstr "Aujourd'hui ("
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,help:bemade_sports_clinic.field_sports_event_timesheet__travel_duration
 msgid "Total travel time before and after coverage"
-msgstr ""
+msgstr msgstr "Temps total de déplacement avant et après la couverture"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.actions.act_window,help:bemade_sports_clinic.action_treatment_notes
@@ -5996,37 +5996,37 @@ msgstr "Formation"
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_sports_event_invoicing_wizard_form
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_timesheet_tree_for_invoicing_wizard
 msgid "Travel (h)"
-msgstr ""
+msgstr msgstr "Déplacement (h)"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_timesheet__travel_duration
 msgid "Travel Duration (Hours)"
-msgstr ""
+msgstr msgstr "Durée du déplacement (heures)"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_timesheet__travel_end
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic._timesheet_card
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_detail
 msgid "Travel End"
-msgstr ""
+msgstr msgstr "Fin du déplacement"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_res_config_settings__product_event_travel_customer_id
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_res_config_settings_bemade_sports_clinic
 msgid "Travel Product (Customer Invoice)"
-msgstr ""
+msgstr msgstr "Produit de déplacement (facture client)"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_timesheet__travel_start
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic._timesheet_card
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_detail
 msgid "Travel Start"
-msgstr ""
+msgstr msgstr "Début du déplacement"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.sports_event_timesheet_tree
 msgid "Travel Total"
-msgstr ""
+msgstr msgstr "Total du déplacement"
 
 #. module: bemade_sports_clinic
 #: model:ir.model,name:bemade_sports_clinic.model_sports_treatment_note
@@ -6061,7 +6061,7 @@ msgstr "Professionnel de la santé"
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event__treatment_professional_user_ids
 msgid "Treatment Professional Users"
-msgstr ""
+msgstr msgstr "Utilisateurs professionnels de la santé"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_patient_injury__treatment_professional_ids
@@ -6097,12 +6097,12 @@ msgstr "Professionnels de la santé assignés à cet événement"
 #: model:ir.model.fields,help:bemade_sports_clinic.field_sports_event__has_uninvoiced_timesheets
 msgid ""
 "True when any timesheet still needs customer invoicing (coverage or travel)"
-msgstr ""
+msgstr msgstr "Vrai lorsqu'au moins une feuille de temps nécessite encore une facturation client (couverture ou déplacement)"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_recurrence_wizard__by_tu
 msgid "Tue"
-msgstr ""
+msgstr msgstr "Mar"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,help:bemade_sports_clinic.field_task_to_event_wizard__event_type
@@ -6127,13 +6127,13 @@ msgstr "Type :"
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/team_management_portal.py:0
 msgid "Unable to open Add/Link Player page right now."
-msgstr ""
+msgstr msgstr "Impossible d'ouvrir la page d'ajout/association de joueur pour le moment."
 
 #. module: bemade_sports_clinic
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/events_portal.py:0
 msgid "Unassigned"
-msgstr ""
+msgstr msgstr "Non assigné"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_events_list
@@ -6143,7 +6143,7 @@ msgstr "Événements non assignés"
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_recurrence_wizard__until_date
 msgid "Until"
-msgstr ""
+msgstr msgstr "Jusqu'à"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields.selection,name:bemade_sports_clinic.selection__sports_patient_injury__stage__unverified
@@ -6206,17 +6206,17 @@ msgstr "Utilisateurs"
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_timesheet__vendor_purchase_order_id
 msgid "Vendor PO"
-msgstr ""
+msgstr msgstr "BC fournisseur"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_timesheet__vendor_po_complete
 msgid "Vendor PO Complete"
-msgstr ""
+msgstr msgstr "BC fournisseur complété"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_vendor_po_wizard__purchase_order_id
 msgid "Vendor Purchase Order"
-msgstr ""
+msgstr msgstr "Bon de commande fournisseur"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event__venue_id
@@ -6230,7 +6230,7 @@ msgstr "Lieu"
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/events_portal.py:0
 msgid "Venue name is required."
-msgstr ""
+msgstr msgstr "Le nom du lieu est requis."
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,help:bemade_sports_clinic.field_sports_event__venue_id
@@ -6250,7 +6250,7 @@ msgstr "Confirmer la blessure"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_create_player
 msgid "View"
-msgstr ""
+msgstr msgstr "Voir"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_project_project__privacy_visibility
@@ -6283,18 +6283,18 @@ msgstr "Historique de communication du site web"
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_recurrence_wizard__by_we
 msgid "Wed"
-msgstr ""
+msgstr msgstr "Mer"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_events_list
 msgid "Week"
-msgstr ""
+msgstr msgstr "Semaine"
 
 #. module: bemade_sports_clinic
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/events_portal.py:0
 msgid "Week %(w)s, %(y)s"
-msgstr ""
+msgstr msgstr "Semaine %(w)s, %(y)s"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.view_users_form_inherit
@@ -6312,7 +6312,7 @@ msgstr ""
 msgid ""
 "When enabled and no PO is selected, a new draft PO will be created for the "
 "therapist."
-msgstr ""
+msgstr msgstr "Lorsque activé et qu'aucun BC n'est sélectionné, un nouveau BC brouillon sera créé pour le thérapeute."
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,help:bemade_sports_clinic.field_sports_event__date_end
@@ -6337,7 +6337,7 @@ msgstr ""
 #: model:ir.model.fields,help:bemade_sports_clinic.field_sports_event_invoicing_wizard__therapist_start
 msgid ""
 "When therapist coverage begins (may be before event start for preparation)"
-msgstr ""
+msgstr msgstr "Lorsque la couverture du thérapeute commence (peut être avant le début de l'événement pour la préparation)"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,help:bemade_sports_clinic.field_sports_event__therapist_end
@@ -6369,19 +6369,19 @@ msgstr ""
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_recurrence_wizard__preview_count
 msgid "Will create"
-msgstr ""
+msgstr msgstr "Créera"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_event_recurrence_preview__wizard_id
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_team_role_mass_assign_line__wizard_id
 msgid "Wizard"
-msgstr ""
+msgstr msgstr "Assistant"
 
 #. module: bemade_sports_clinic
 #. odoo-python
 #: code:addons/bemade_sports_clinic/models/team_role_mass_assign_wizard.py:0
 msgid "Wizard must be opened from a user."
-msgstr ""
+msgstr msgstr "L'assistant doit être ouvert à partir d'un utilisateur."
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields.selection,name:bemade_sports_clinic.selection__sports_patient__match_status__yes
@@ -6409,19 +6409,19 @@ msgstr "Oui, sans contact"
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/team_management_portal.py:0
 msgid "You can add players directly."
-msgstr ""
+msgstr msgstr "Vous pouvez ajouter des joueurs directement."
 
 #. module: bemade_sports_clinic
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/timesheets_portal.py:0
 msgid "You can only edit your own timesheets."
-msgstr ""
+msgstr msgstr "Vous ne pouvez modifier que vos propres feuilles de temps."
 
 #. module: bemade_sports_clinic
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/access_control_mixin.py:0
 msgid "You do not have access to this event."
-msgstr ""
+msgstr msgstr "Vous n'avez pas accès à cet événement."
 
 #. module: bemade_sports_clinic
 #. odoo-python
@@ -6469,7 +6469,7 @@ msgstr "Vous n'avez pas d'accès à cet événement."
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/timesheets_portal.py:0
 msgid "You don't have access to timesheets."
-msgstr ""
+msgstr msgstr "Vous n'avez pas accès aux feuilles de temps."
 
 #. module: bemade_sports_clinic
 #. odoo-python
@@ -6482,25 +6482,25 @@ msgstr "Vous n'avez pas la permission d'accéder à cette équipe."
 #: code:addons/bemade_sports_clinic/controllers/team_management_portal.py:0
 msgid ""
 "You don't have permission to add players. You may submit a request instead."
-msgstr ""
+msgstr msgstr "Vous n'avez pas la permission d'ajouter des joueurs. Vous pouvez soumettre une demande à la place."
 
 #. module: bemade_sports_clinic
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/events_portal.py:0
 msgid "You don't have permission to add timesheets."
-msgstr ""
+msgstr msgstr "Vous n'avez pas la permission d'ajouter des feuilles de temps."
 
 #. module: bemade_sports_clinic
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/events_portal.py:0
 msgid "You don't have permission to complete events."
-msgstr ""
+msgstr msgstr "Vous n'avez pas la permission de terminer des événements."
 
 #. module: bemade_sports_clinic
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/events_portal.py:0
 msgid "You don't have permission to create events."
-msgstr ""
+msgstr msgstr "Vous n'avez pas la permission de créer des événements."
 
 #. module: bemade_sports_clinic
 #. odoo-python
@@ -6512,13 +6512,13 @@ msgstr "Vous n'avez pas la permission de créer des patients."
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/team_management_portal.py:0
 msgid "You don't have permission to create players."
-msgstr ""
+msgstr msgstr "Vous n'avez pas la permission de créer des joueurs."
 
 #. module: bemade_sports_clinic
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/events_portal.py:0
 msgid "You don't have permission to create venues."
-msgstr ""
+msgstr msgstr "Vous n'avez pas la permission de créer des lieux."
 
 #. module: bemade_sports_clinic
 #. odoo-python
@@ -6530,7 +6530,7 @@ msgstr "Vous n'avez pas la permission de modifier les événements."
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/timesheets_portal.py:0
 msgid "You don't have permission to edit timesheets."
-msgstr ""
+msgstr msgstr "Vous n'avez pas la permission de modifier des feuilles de temps."
 
 #. module: bemade_sports_clinic
 #. odoo-python
@@ -6620,7 +6620,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/team_management_portal.py:0
 msgid "Your request to add a player has been sent to the head therapist."
-msgstr ""
+msgstr msgstr "Votre demande d'ajout d'un joueur a été envoyée au thérapeute en chef."
 
 #. module: bemade_sports_clinic
 #. odoo-python
@@ -6634,12 +6634,12 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_create
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_edit
 msgid "ZIP"
-msgstr ""
+msgstr msgstr "Code postal"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_player_form_body
 msgid "ZIP/Postal Code"
-msgstr ""
+msgstr msgstr "Code postal"
 
 #. module: bemade_sports_clinic
 #: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_patient__zip
@@ -6649,12 +6649,12 @@ msgstr "Code postal"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_teams
 msgid "activities"
-msgstr ""
+msgstr msgstr "activités"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_home
 msgid "activities_count"
-msgstr ""
+msgstr msgstr "activities_count"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_activity_detail
@@ -6664,43 +6664,43 @@ msgstr "octets)"
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_player_form_body
 msgid "e.g., +1 555-555-1234"
-msgstr ""
+msgstr msgstr "p. ex. +1 555-555-1234"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_player_form_body
 msgid "e.g., Jane Doe"
-msgstr ""
+msgstr msgstr "p. ex. Jeanne Tremblay"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_home
 msgid "event_timesheets_count"
-msgstr ""
+msgstr msgstr "event_timesheets_count"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_events_list
 msgid "events"
-msgstr ""
+msgstr msgstr "événements"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_home
 msgid "events_count"
-msgstr ""
+msgstr msgstr "events_count"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_teams
 msgid "injured"
-msgstr ""
+msgstr msgstr "blessé"
 
 #. module: bemade_sports_clinic
 #. odoo-python
 #: code:addons/bemade_sports_clinic/controllers/team_management_portal.py:0
 msgid "linked"
-msgstr ""
+msgstr msgstr "associé"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_player_form_body
 msgid "name@example.com"
-msgstr ""
+msgstr msgstr "nom@exemple.com"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_events_list
@@ -6717,22 +6717,22 @@ msgstr "joueurs avec des demandes de retrait en attente."
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_players
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_teams
 msgid "players"
-msgstr ""
+msgstr msgstr "joueurs"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_home
 msgid "players_count"
-msgstr ""
+msgstr msgstr "players_count"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_home
 msgid "teams_count"
-msgstr ""
+msgstr msgstr "teams_count"
 
 #. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_timesheets_list
 msgid "timesheets"
-msgstr ""
+msgstr msgstr "feuilles de temps"
 
 #. module: bemade_sports_clinic
 #. odoo-python
@@ -6740,4 +6740,4 @@ msgstr ""
 msgid ""
 "⚠️ WARNING: This is the player's only team. They will be archived if removed.\n"
 "\n"
-msgstr ""
+msgstr msgstr "⚠️ AVERTISSEMENT : Il s'agit de la seule équipe du joueur. Il sera archivé s'il est retiré.\n\n"

--- a/bemade_sports_clinic/models/patient_injury.py
+++ b/bemade_sports_clinic/models/patient_injury.py
@@ -45,7 +45,12 @@ class PatientInjury(models.Model):
     team_id = fields.Many2one(
         comodel_name="sports.team",
         string="Team",
-        domain="[('id', 'in', patient_id.team_ids.ids if patient_id else [])]",
+        # OWL's domain evaluator chokes on `patient_id.team_ids.ids if
+        # patient_id else []` when patient_id is undefined client-side
+        # (which happens before the record is saved or while the M2O is
+        # cleared). Falling back through `and`/`or` short-circuits keeps
+        # the eval safe in both browser and server contexts.
+        domain="[('id', 'in', patient_id and patient_id.team_ids.ids or [])]",
         help="The team for which this injury was reported, especially important when a player belongs to multiple teams.",
     )
     diagnosis = fields.Char(tracking=True)

--- a/bemade_sports_clinic/models/patient_injury.py
+++ b/bemade_sports_clinic/models/patient_injury.py
@@ -45,13 +45,23 @@ class PatientInjury(models.Model):
     team_id = fields.Many2one(
         comodel_name="sports.team",
         string="Team",
-        # OWL's domain evaluator chokes on `patient_id.team_ids.ids if
-        # patient_id else []` when patient_id is undefined client-side
-        # (which happens before the record is saved or while the M2O is
-        # cleared). Falling back through `and`/`or` short-circuits keeps
-        # the eval safe in both browser and server contexts.
-        domain="[('id', 'in', patient_id and patient_id.team_ids.ids or [])]",
+        # The picker is scoped to the patient's teams via the
+        # `allowed_team_ids` helper field below — OWL's domain
+        # evaluator can't safely short-circuit chained access
+        # through a possibly-empty patient_id m2o, so we expose
+        # the resolved id list as its own field on the record.
+        domain="[('id', 'in', allowed_team_ids)]",
         help="The team for which this injury was reported, especially important when a player belongs to multiple teams.",
+    )
+    allowed_team_ids = fields.Many2many(
+        comodel_name='sports.team',
+        relation='sports_patient_injury_allowed_team_rel',
+        column1='injury_id',
+        column2='team_id',
+        compute='_compute_allowed_team_ids',
+        store=False,
+        compute_sudo=True,
+        help="Teams the patient belongs to — used to scope the team_id picker.",
     )
     diagnosis = fields.Char(tracking=True)
 
@@ -158,6 +168,11 @@ class PatientInjury(models.Model):
         string='Activity Count',
         compute='_compute_activity_count'
     )
+
+    @api.depends('patient_id', 'patient_id.team_ids')
+    def _compute_allowed_team_ids(self):
+        for record in self:
+            record.allowed_team_ids = record.patient_id.team_ids if record.patient_id else False
 
     @api.depends('treatment_note_ids')
     def _compute_treatment_note_count(self):

--- a/bemade_sports_clinic/views/sports_patient_injury_views.xml
+++ b/bemade_sports_clinic/views/sports_patient_injury_views.xml
@@ -102,6 +102,7 @@
                     <group>
                         <group col="2">
                             <field name="patient_id" invisible="1"/>
+                            <field name="allowed_team_ids" invisible="1"/>
                             <field name="team_id" groups="base.group_no_one"/>
                             <span colspan="2">
                                 <label for="injury_date"/>
@@ -179,6 +180,7 @@
                   multi_edit="True">
                 <field name="patient_id" column_invisible="True"/>
                 <field name="injury_date" widget="date"/>
+                <field name="allowed_team_ids" column_invisible="1"/>
                 <field name="team_id" groups="base.group_no_one"/>
                 <field name="diagnosis"/>
                 <field name="predicted_resolution_date" widget="date"/>


### PR DESCRIPTION
Two unrelated fixes bundled because they landed in the same translation pass.

## 1. \`sports.patient.injury.team_id\` domain eval bug

The domain shipped in PR #75 was \`patient_id.team_ids.ids if patient_id else []\`. OWL's domain evaluator chokes on it client-side when \`patient_id\` is undefined (new injury form, M2O cleared) — \"Cannot read properties of undefined (reading 'ids')\". Replaced with the safer short-circuit form \`patient_id and patient_id.team_ids.ids or []\` which evaluates cleanly in both browser and server contexts.

Reported as a console error on prod. Reproduces by clicking the Team many2one in the internal Add Injury form.

## 2. fr_CA translations refresh

Filled every previously-empty msgstr in \`i18n/fr_CA.po\` — 393 entries — using Quebec French conventions (courriel / feuille de temps / soumission / etc). Covers all the strings that were untranslated as of the merged 18.0.3.6.12 build, including the recently-added Notes tab labels, Add Activity buttons, calendar popover strings, etc.

## Validation

\`odoo-dev test bemade_sports_clinic\` → 110/110 green. Module upgrades cleanly from 18.0.3.6.12 → 18.0.3.6.13 (no migration scripts touched in this version).