### PR TITLE
Fix: stale TP injury assignments + scrub HTML residue from text notes (18.0.3.6.15)

### DIFF
--- a/bemade_sports_clinic/__manifest__.py
+++ b/bemade_sports_clinic/__manifest__.py
@@ -18,7 +18,7 @@
 #
 {
     'name': 'Sports Clinic Management',
-    'version': '18.0.3.6.14',
+    'version': '18.0.3.6.15',
     'summary': 'Comprehensive sports medicine clinic management with portal access and activity tracking.',
     'description': """
 Sports Clinic Management System

--- a/bemade_sports_clinic/migrations/18.0.3.6.15/pre-migration.py
+++ b/bemade_sports_clinic/migrations/18.0.3.6.15/pre-migration.py
@@ -1,0 +1,111 @@
+"""Scrub stray HTML markup from text-typed note fields.
+
+Background
+----------
+sports.patient.injury.internal_notes / .external_notes,
+sports.patient.team_info_notes / .allergies were modeled as fields.Html
+in early iterations and are now fields.Text. Existing rows on installs
+that went through the Html era retain the markup (<p>...</p>, <br/>,
+&nbsp;, etc.), and since the fields are now plain text the markup is
+shown literally — visible to portal users and during chatter logging.
+
+This pre-migration walks each affected column and rewrites any value
+that looks HTML-ish to plain text by:
+
+1. Stripping HTML tags via Python's HTMLParser.
+2. Decoding common HTML entities (&nbsp;, &amp;, &lt;, &gt;, &quot;,
+   &#39;).
+3. Collapsing the result and trimming surrounding whitespace.
+
+Idempotent: rows that don't contain '<' or '&' are left untouched.
+"""
+
+import html
+import logging
+from html.parser import HTMLParser
+
+_logger = logging.getLogger(__name__)
+
+
+class _TextExtractor(HTMLParser):
+    def __init__(self):
+        super().__init__(convert_charrefs=True)
+        self._chunks = []
+
+    def handle_data(self, data):
+        self._chunks.append(data)
+
+    def handle_starttag(self, tag, attrs):
+        if tag in ('p', 'br', 'div', 'li', 'tr'):
+            self._chunks.append('\n')
+
+    def handle_endtag(self, tag):
+        if tag in ('p', 'div', 'li', 'tr'):
+            self._chunks.append('\n')
+
+    def get_text(self):
+        return ''.join(self._chunks)
+
+
+def _strip(value):
+    if not value:
+        return value
+    if '<' not in value and '&' not in value:
+        return value
+    parser = _TextExtractor()
+    try:
+        parser.feed(value)
+        parser.close()
+    except Exception:
+        # On malformed HTML, fall back to a best-effort entity decode.
+        return html.unescape(value).strip()
+    text = html.unescape(parser.get_text())
+    # Collapse consecutive blank lines and trim ends.
+    lines = [line.rstrip() for line in text.splitlines()]
+    out = []
+    blank = False
+    for line in lines:
+        if not line.strip():
+            if not blank and out:
+                out.append('')
+            blank = True
+        else:
+            out.append(line)
+            blank = False
+    return '\n'.join(out).strip()
+
+
+TARGETS = (
+    ('sports_patient_injury', 'internal_notes'),
+    ('sports_patient_injury', 'external_notes'),
+    ('sports_patient', 'team_info_notes'),
+    ('sports_patient', 'allergies'),
+)
+
+
+def migrate(cr, version):
+    for table, column in TARGETS:
+        cr.execute(
+            f"""
+            SELECT id, {column}
+            FROM {table}
+            WHERE {column} IS NOT NULL
+              AND ({column} LIKE '%<%' OR {column} LIKE '%&%')
+            """
+        )
+        rows = cr.fetchall()
+        if not rows:
+            continue
+        updated = 0
+        for row_id, raw in rows:
+            cleaned = _strip(raw)
+            if cleaned != raw:
+                cr.execute(
+                    f"UPDATE {table} SET {column} = %s WHERE id = %s",
+                    (cleaned, row_id),
+                )
+                updated += 1
+        _logger.info(
+            "Scrubbed HTML residue from %s.%s on %d rows.",
+            table, column, updated,
+        )

--- a/bemade_sports_clinic/models/patient_injury.py
+++ b/bemade_sports_clinic/models/patient_injury.py
@@ -323,6 +323,29 @@ class PatientInjury(models.Model):
                 
         return res
         
+    def _cleanup_stale_treatment_professionals(self):
+        """For each injury in self, drop from treatment_professional_ids
+        any user who no longer has staff access to the patient (i.e. is
+        not on staff of any team the patient belongs to). Used by the
+        team-staff unlink/write hooks to keep injury TP assignments in
+        sync with the team-staff source of truth."""
+        for injury in self:
+            if not injury.treatment_professional_ids:
+                continue
+            patient = injury.patient_id
+            accessible_user_ids = set(patient.team_ids.mapped('staff_ids.user_ids').ids)
+            stale = injury.treatment_professional_ids.filtered(
+                lambda u: u.id not in accessible_user_ids
+            )
+            if stale:
+                injury.with_context(
+                    mail_notrack=True,
+                    mail_create_nolog=True,
+                    mail_create_nosubscribe=True,
+                ).write({
+                    'treatment_professional_ids': [(3, u.id) for u in stale],
+                })
+
     def _manage_treatment_professional_subscriptions(self):
         """Subscribe treatment professionals to both regular and internal note updates
         while ensuring non-treatment professionals only subscribe to external updates."""

--- a/bemade_sports_clinic/models/sports_team.py
+++ b/bemade_sports_clinic/models/sports_team.py
@@ -356,12 +356,20 @@ class TeamStaff(models.Model):
         # Store affected partners and users before deletion
         affected_partners = self.mapped('partner_id')
         affected_users = self.mapped('user_ids')
-        
+
         # Standard processing for follower recomputation
         patients = self.team_id.mapped("patient_ids")
         res = super().unlink()
         patients.recompute_followers()
-        
+
+        # Drop ex-staff users from any treatment_professional_ids on the
+        # affected patients' injuries when they no longer have staff
+        # access via any of the patient's other teams. Without this a
+        # therapist removed from a team stays assigned to the team's
+        # injuries (and as a follower) until manually scrubbed.
+        if patients:
+            patients.injury_ids.sudo()._cleanup_stale_treatment_professionals()
+
         # After deletion, update group memberships for all affected users
         # Use a new empty recordset to avoid using the deleted recordset
         empty_staff = self.env['sports.team.staff']
@@ -369,7 +377,7 @@ class TeamStaff(models.Model):
             for user in affected_users.sudo():
                 # Use the comprehensive group update method for each affected user
                 empty_staff._update_all_portal_groups(user)
-        
+
         return res
 
     def _has_therapist_role(self):
@@ -634,6 +642,13 @@ class TeamStaff(models.Model):
             self._update_all_portal_groups()
 
         if 'team_id' in values or 'silent_notifications' in values or 'role' in values:
-            (self.team_id.patient_ids | previous_patients).recompute_followers()
+            affected_patients = self.team_id.patient_ids | previous_patients
+            affected_patients.recompute_followers()
+            # If team_id moved a staff member to a different team, the
+            # patients on the *previous* team may have stale TP injury
+            # assignments to clean up. (silent_notifications and role
+            # changes don't affect access to the patient itself.)
+            if 'team_id' in values and previous_patients:
+                previous_patients.injury_ids.sudo()._cleanup_stale_treatment_professionals()
 
         return result

--- a/bemade_sports_clinic/views/sports_clinic_portal_views.xml
+++ b/bemade_sports_clinic/views/sports_clinic_portal_views.xml
@@ -1530,7 +1530,7 @@
                                             <h5 class="mt-4">Team Notes</h5>
                                             <div class="card border-info">
                                                 <div class="card-body">
-                                                    <div t-raw="player.team_info_notes" class="mb-0 oe_no_empty"/>
+                                                    <div t-out="player.team_info_notes" class="mb-0 oe_no_empty" style="white-space: pre-wrap;"/>
                                                 </div>
                                             </div>
                                         </t>


### PR DESCRIPTION
Two related housekeeping fixes uncovered while auditing follower management.

## 1. Stale TP assignments on injuries

When a therapist was removed from a team's staff, they kept any injury-level assignments on \`sports.patient.injury.treatment_professional_ids\` and stayed as followers of those injuries. The patient-side \`recompute_followers\` scrubbed them from the patient's follower list but the injury-level M2M was never reconciled.

- New helper \`sports.patient.injury._cleanup_stale_treatment_professionals\` drops users from the M2M when they no longer have staff access via any of the patient's teams.
- Wired into \`TeamStaff.unlink\` (always) and \`TeamStaff.write\` when \`team_id\` changes — those are the only paths that actually change patient access for a staff member.

## 2. HTML residue in text-typed notes

\`internal_notes\` / \`external_notes\` on \`sports.patient.injury\` and \`team_info_notes\` / \`allergies\` on \`sports.patient\` were modeled as \`fields.Html\` in early iterations and are now \`fields.Text\`. Existing rows still hold the markup (\`<p>...</p>\`, \`&nbsp;\`, etc.), which renders literally in chatter and portal views. The portal \"Team Notes\" section was also using \`t-raw\`, so the residue was being interpreted as HTML.

- \`migrations/18.0.3.6.15/pre-migration.py\` walks the four columns and rewrites any value containing \`<\` or \`&\` to plain text (HTMLParser tag strip + entity decode + line collapse). Idempotent — rows without HTML markers are left alone.
- \`sports_clinic_portal_views.xml\` swaps \`t-raw\` → \`t-out\` for the Team Notes block (auto-escapes any future stray markup) and adds \`white-space: pre-wrap\` so the text renders with line breaks intact.

Bumps manifest to **18.0.3.6.15**. 110/110 module tests still green.