### PR TITLE
fix(mail_manual_routing_ux): supprimer symlinks internes cassés en CI

### DIFF
--- a/mail_manual_routing_ux/mail_manual_routing_fix
+++ b/mail_manual_routing_ux/mail_manual_routing_fix
@@ -1,1 +1,0 @@
-../.repos/bemade-addons/mail_manual_routing_fix

--- a/mail_manual_routing_ux/mail_manual_routing_helpdesk
+++ b/mail_manual_routing_ux/mail_manual_routing_helpdesk
@@ -1,1 +1,0 @@
-../.repos/bemade-addons/mail_manual_routing_helpdesk


### PR DESCRIPTION
Le CI échoue lors du cp -RL depuis bemade-addons — les symlinks internes ../.repos/bemade-addons/* ne se résolvent pas depuis l'intérieur du submodule. mail_manual_routing_fix et mail_manual_routing_helpdesk sont déjà exposés séparément dans addons/.