### PR TITLE
fix(bemade_mail_gateway): retourner 422 quand message_process retourne False

### DIFF
--- a/bemade_mail_gateway/__manifest__.py
+++ b/bemade_mail_gateway/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 {
     "name": "Bemade Mail Gateway Endpoint",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.0.1",
     "category": "Tools",
     "summary": (
         "Token-authenticated HTTP endpoint to push raw mail into Odoo "

--- a/bemade_mail_gateway/controllers/mail_gateway.py
+++ b/bemade_mail_gateway/controllers/mail_gateway.py
@@ -202,6 +202,22 @@ class MailGatewayController(http.Controller):
                 status=500,
             )
 
+        # message_process returns False when no route was found but a module
+        # (e.g. mail_manual_routing) silently swallowed the message instead of
+        # raising ValueError. Treat it the same as the ValueError no-route path
+        # so the LMTP sidecar knows the delivery did not land on a real thread.
+        if not result:
+            _logger.info(
+                "mail_gateway_no_route token=%s message_id=%s ip=%s",
+                log_ctx["token_label"],
+                log_ctx["message_id"],
+                log_ctx["ip"],
+            )
+            return _json_response(
+                {"ok": False, "error": "no_route", "detail": "message_process returned no result"},
+                status=422,
+            )
+
         _logger.info(
             "mail_gateway_delivered token=%s message_id=%s result=%s ip=%s",
             log_ctx["token_label"],


### PR DESCRIPTION
## Summary

- Quand `mail_manual_routing` est installé, les messages non routés sont silencieusement placés dans les *lost messages* sans lever de `ValueError`
- Le contrôleur retournait alors HTTP 200 avec `result=False`, trompant le sidecar LMTP qui croyait la livraison réussie
- On vérifie maintenant que `result` est truthy avant de retourner 200; sinon on retourne 422 `no_route`

## Test plan

- [ ] `TestMailGatewayController.test_process_with_no_alias_returns_422` passe avec tous les modules installés (incluant `mail_manual_routing`)
- [ ] `TestMailGatewayController.test_process_with_valid_alias_returns_200_and_creates_message` continue de passer (result truthy → 200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)