### PR TITLE
[FIX] bemade_sports_clinic: portal mail.activity 403 + calendar 4-hour TZ shift

### DIFF
--- a/bemade_sports_clinic/__manifest__.py
+++ b/bemade_sports_clinic/__manifest__.py
@@ -18,7 +18,7 @@
 #
 {
     'name': 'Sports Clinic Management',
-    'version': '18.0.3.6.16',
+    'version': '18.0.3.6.17',
     'summary': 'Comprehensive sports medicine clinic management with portal access and activity tracking.',
     'description': """
 Sports Clinic Management System

--- a/bemade_sports_clinic/__manifest__.py
+++ b/bemade_sports_clinic/__manifest__.py
@@ -18,7 +18,7 @@
 #
 {
     'name': 'Sports Clinic Management',
-    'version': '18.0.3.6.15',
+    'version': '18.0.3.6.16',
     'summary': 'Comprehensive sports medicine clinic management with portal access and activity tracking.',
     'description': """
 Sports Clinic Management System

--- a/bemade_sports_clinic/controllers/events_portal.py
+++ b/bemade_sports_clinic/controllers/events_portal.py
@@ -445,16 +445,23 @@ class EventsPortal(CustomerPortal, AccessControlMixin):
             return http.request.make_response('[]', headers=[('Content-Type', 'application/json')])
 
         domain = self._prepare_events_domain('all')
-        # FullCalendar passes ISO datetimes (with or without tz). Use them
-        # to bound the query so we don't return the entire history.
+        # FullCalendar passes ISO datetimes (with or without tz). Normalize
+        # to naive UTC so the comparison against Odoo's UTC-stored
+        # date_start / date_end fields is correct regardless of the
+        # offset the client sent.
         def _parse(dt_str):
             if not dt_str:
                 return None
             try:
-                # FullCalendar typically sends e.g. "2026-05-01T00:00:00-04:00"
                 if dt_str.endswith('Z'):
+                    # Trailing 'Z' is valid ISO-8601 but not accepted by
+                    # fromisoformat on older Pythons — drop it; the value
+                    # is already UTC.
                     return datetime.fromisoformat(dt_str[:-1])
-                return datetime.fromisoformat(dt_str)
+                dt = datetime.fromisoformat(dt_str)
+                if dt.tzinfo is not None:
+                    return dt.astimezone(pytz.UTC).replace(tzinfo=None)
+                return dt
             except Exception:
                 return None
 
@@ -474,11 +481,16 @@ class EventsPortal(CustomerPortal, AccessControlMixin):
         events_sudo_by_id = {ev.id: ev for ev in events.sudo()}
         for ev in events:
             ev_sudo = events_sudo_by_id.get(ev.id, ev)
+            # date_start / date_end are stored as naive UTC. Emit ISO 8601
+            # with an explicit UTC offset so FullCalendar localizes to the
+            # browser's time zone instead of treating the wall-clock string
+            # as already-local (which previously shifted every event by the
+            # client's UTC offset — e.g. 11 AM EDT → 3 PM in the calendar).
             payload.append({
                 'id': ev.id,
                 'title': ev.name or '',
-                'start': fields.Datetime.to_string(ev.date_start) if ev.date_start else None,
-                'end': fields.Datetime.to_string(ev.date_end) if ev.date_end else None,
+                'start': pytz.UTC.localize(ev.date_start).isoformat() if ev.date_start else None,
+                'end': pytz.UTC.localize(ev.date_end).isoformat() if ev.date_end else None,
                 'url': f'/my/event?event_id={ev.id}',
                 'extendedProps': {
                     'teams': ev_sudo.team_ids.mapped('name'),

--- a/bemade_sports_clinic/controllers/task_management_portal.py
+++ b/bemade_sports_clinic/controllers/task_management_portal.py
@@ -52,34 +52,21 @@ class TaskManagementPortal(CustomerPortal, AccessControlMixin):
             ('res_id', 'in', team_staff_rels.mapped('team_id.event_ids.id') or [0])
         ]
         
-        # Context-sensitive filtering:
-        # - General "My Activities" view: show activities assigned to the current user
-        #   (for sports clinic models) OR any activity accessible via team relationships.
-        # - Specific record activities: show activities for that record that are either
-        #   assigned to the current user OR accessible via team relationships.
-        
-        allowed_models = ['sports.patient', 'sports.patient.injury', 'sports.team', 'sports.event']
-        assigned_sports_domain = [
-            '&',
-            ('user_id', '=', user.id),
-            ('res_model', 'in', allowed_models),
-        ]
+        # Activities are scoped strictly by the team-based access domain. We used to
+        # OR-in `(user_id == self) AND res_model in [...]` so a portal user could see
+        # activities personally assigned to them, but that left orphan assignee
+        # activities (e.g. cron-created "Verify injury" tasks left over after a TP
+        # was unstaffed from a team) visible while their related record was no
+        # longer readable, causing 403s when the template browsed the related
+        # injury for display. Aligning with the ir.rule keeps the listing
+        # consistent with what the user can actually open.
 
         if model:
-            domain = [
-                '&',
-                ('res_model', '=', model),
-                '|',
-            ] + assigned_sports_domain + team_access_domain
-
+            domain = ['&', ('res_model', '=', model)] + team_access_domain
             if res_id:
-                domain = [
-                    '&',
-                    ('res_id', '=', int(res_id)),
-                ] + domain
-
+                domain = ['&', ('res_id', '=', int(res_id))] + domain
         else:
-            domain = ['|'] + assigned_sports_domain + team_access_domain
+            domain = team_access_domain
         
         # Search for activities with both assignment and team-based access control
         activities = request.env['mail.activity'].search(domain, order='date_deadline asc')

--- a/bemade_sports_clinic/migrations/18.0.3.6.16/post-migration.py
+++ b/bemade_sports_clinic/migrations/18.0.3.6.16/post-migration.py
@@ -1,0 +1,31 @@
+"""Reconcile stale mail.activity assignments on existing data.
+
+The 18.0.3.6.16 release tightens the portal mail.activity rule to drop the
+"(user_id == self) AND res_model in [...]" OR-branch. Activities still
+assigned to a user who is no longer on staff for any of the related
+patient's teams would otherwise become silently invisible in the portal.
+
+This post-migration runs the new cleanup helper across every active
+sports.patient.injury so existing stale assignments are reassigned (or
+unlinked when there's no current team therapist to take them over).
+"""
+import logging
+
+from odoo import api, SUPERUSER_ID
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    if not version:
+        return
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    injuries = env['sports.patient.injury'].sudo().search([])
+    if not injuries:
+        return
+    _logger.info(
+        "[bemade_sports_clinic 18.0.3.6.16] reconciling mail.activity "
+        "assignments across %d injuries",
+        len(injuries),
+    )
+    injuries._cleanup_stale_mail_activities()

--- a/bemade_sports_clinic/models/patient_injury.py
+++ b/bemade_sports_clinic/models/patient_injury.py
@@ -346,6 +346,49 @@ class PatientInjury(models.Model):
                     'treatment_professional_ids': [(3, u.id) for u in stale],
                 })
 
+    def _cleanup_stale_mail_activities(self):
+        """Reassign or close mail.activity records on injuries in self that
+        are still assigned to users who no longer have staff access to the
+        patient. Without this, tightening the portal mail.activity rule
+        would silently hide stale assignee activities — leaving them
+        invisible to the original assignee while still cluttering the
+        backend.
+
+        Strategy: prefer reassigning to a current head therapist on the
+        patient's teams (then any therapist), so the work follows the
+        team. If no replacement is available, drop the activity
+        entirely — the verification cron will re-create what it needs.
+        """
+        Activity = self.env['mail.activity'].sudo()
+        model_rec = self.env['ir.model']._get('sports.patient.injury')
+        for injury in self.sudo():
+            patient = injury.patient_id
+            if not patient:
+                continue
+            current_user_ids = set(patient.team_ids.mapped('staff_ids.user_ids').ids)
+            activities = Activity.search([
+                ('res_model_id', '=', model_rec.id),
+                ('res_id', '=', injury.id),
+            ])
+            stale = activities.filtered(
+                lambda a: a.user_id and a.user_id.id not in current_user_ids
+            )
+            if not stale:
+                continue
+            # Pick replacement assignee from the patient's current teams.
+            therapist_staff = patient.team_ids.mapped('staff_ids').filtered(
+                lambda s: s.role in ('head_therapist', 'therapist')
+            )
+            head = therapist_staff.filtered(lambda s: s.role == 'head_therapist')
+            replacement_user = (
+                (head.mapped('user_ids')[:1])
+                or (therapist_staff.mapped('user_ids')[:1])
+            )
+            if replacement_user:
+                stale.write({'user_id': replacement_user.id})
+            else:
+                stale.unlink()
+
     def _manage_treatment_professional_subscriptions(self):
         """Subscribe treatment professionals to both regular and internal note updates
         while ensuring non-treatment professionals only subscribe to external updates."""

--- a/bemade_sports_clinic/models/sports_team.py
+++ b/bemade_sports_clinic/models/sports_team.py
@@ -367,8 +367,14 @@ class TeamStaff(models.Model):
         # access via any of the patient's other teams. Without this a
         # therapist removed from a team stays assigned to the team's
         # injuries (and as a follower) until manually scrubbed.
+        # Same logic for mail.activity records pointing at those
+        # injuries — the activity rule won't grant access to the
+        # ex-staff user anymore, so leaving the activity assigned to
+        # them produces a 403 in the portal next time they open
+        # /my/activities. Reassign to a current team therapist or drop.
         if patients:
             patients.injury_ids.sudo()._cleanup_stale_treatment_professionals()
+            patients.injury_ids.sudo()._cleanup_stale_mail_activities()
 
         # After deletion, update group memberships for all affected users
         # Use a new empty recordset to avoid using the deleted recordset
@@ -650,5 +656,6 @@ class TeamStaff(models.Model):
             # changes don't affect access to the patient itself.)
             if 'team_id' in values and previous_patients:
                 previous_patients.injury_ids.sudo()._cleanup_stale_treatment_professionals()
+                previous_patients.injury_ids.sudo()._cleanup_stale_mail_activities()
 
         return result

--- a/bemade_sports_clinic/security/mail_activity_portal_rules.xml
+++ b/bemade_sports_clinic/security/mail_activity_portal_rules.xml
@@ -50,16 +50,16 @@
 <odoo>
     <data noupdate="0">
         
-        <!-- Record rule for portal treatment professionals to access mail.activity records -->
-        <!-- BROAD ACL ACCESS: Full CRUD on sports-related activities - controller enforces team filtering -->
+        <!-- Record rule for portal treatment professionals to access mail.activity records.
+             Activities are only visible when the related sports record is currently in the
+             user's team-staff scope. The previous OR branch granting visibility purely on
+             user_id == self left orphan assignee activities readable while their related
+             record was not — causing 403s on portal pages that browse the related record
+             (e.g. /my/activities rendering injury.display_name). -->
         <record id="mail_activity_portal_treatment_professional_rule" model="ir.rule">
             <field name="name">Portal Treatment Professional: Mail Activity Access</field>
             <field name="model_id" ref="mail.model_mail_activity"/>
-            <field name="domain_force">[  
-                '|',
-                '&amp;',
-                ('user_id', '=', user.id),
-                ('res_model', 'in', ['sports.patient', 'sports.patient.injury', 'sports.team', 'sports.event']),
+            <field name="domain_force">[
                 '|', '|', '|',
                 '&amp;', '&amp;',
                 ('res_model', '=', 'sports.patient'),
@@ -89,10 +89,6 @@
             <field name="name">Portal Team Coach: Mail Activity Read Access</field>
             <field name="model_id" ref="mail.model_mail_activity"/>
             <field name="domain_force">[
-                '|',
-                '&amp;',
-                ('user_id', '=', user.id),
-                ('res_model', 'in', ['sports.patient', 'sports.patient.injury', 'sports.team', 'sports.event']),
                 '|', '|', '|',
                 '&amp;', '&amp;',
                 ('res_model', '=', 'sports.patient'),

--- a/bemade_sports_clinic/tests/test_events_calendar_portal.py
+++ b/bemade_sports_clinic/tests/test_events_calendar_portal.py
@@ -149,3 +149,37 @@ class TestEventsCalendarPortal(HttpCase):
         for k in ("id", "title", "start", "end", "url"):
             self.assertIn(k, e)
         self.assertIn("teams", e.get("extendedProps", {}))
+
+    def test_event_payload_start_end_are_explicit_utc(self):
+        """Payload start/end must be ISO-8601 with an explicit UTC offset
+        (or trailing 'Z'). Emitting Odoo's bare 'YYYY-MM-DD HH:MM:SS'
+        leads FullCalendar to treat the wall-clock as already-local,
+        shifting every event by the client's UTC offset (the 11 AM →
+        3 PM bug Stephanie reported in EDT)."""
+        self.authenticate("cal.coach.611@example.com", "cal-coach")
+        start = datetime.now() - timedelta(days=30)
+        end = datetime.now() + timedelta(days=30)
+        events = self._get_data(start, end).json()
+        e = next(e for e in events if e["id"] == self.future_a.id)
+        # ISO-8601 UTC marker check: '+00:00' (what isoformat emits for
+        # a pytz.UTC-localized datetime) or 'Z' both qualify.
+        self.assertTrue(
+            e["start"].endswith("+00:00") or e["start"].endswith("Z"),
+            f"start should carry an explicit UTC marker, got {e['start']!r}",
+        )
+        self.assertTrue(
+            e["end"].endswith("+00:00") or e["end"].endswith("Z"),
+            f"end should carry an explicit UTC marker, got {e['end']!r}",
+        )
+        # Round-trip: parsed start should match the UTC datetime stored
+        # on the event, regardless of any client-side offset rendering.
+        parsed = datetime.fromisoformat(e["start"].replace("Z", "+00:00"))
+        self.assertEqual(
+            parsed.utcoffset().total_seconds(), 0,
+            "Parsed payload datetime must be UTC.",
+        )
+        # Strip tz to compare with Odoo's naive-UTC stored value.
+        self.assertEqual(
+            parsed.replace(tzinfo=None).replace(microsecond=0),
+            self.future_a.date_start.replace(microsecond=0),
+        )

--- a/bemade_sports_clinic/tests/test_therapist_access_revoke.py
+++ b/bemade_sports_clinic/tests/test_therapist_access_revoke.py
@@ -154,6 +154,84 @@ class TestTherapistAccessRevoke(TransactionCase):
             self.portal_tp.partner_id, self.player_a.message_partner_ids,
         )
 
+    # --- Stale mail.activity cleanup ----------------------------------
+
+    def _injury(self, patient, team):
+        return self.env["sports.patient.injury"].create({
+            "patient_id": patient.id,
+            "team_id": team.id,
+            "diagnosis": "Test injury",
+            "stage": "active",
+        })
+
+    def _activity_on(self, injury, user):
+        return self.env["mail.activity"].create({
+            "res_model_id": self.env["ir.model"]._get_id("sports.patient.injury"),
+            "res_id": injury.id,
+            "summary": "Verify injury",
+            "user_id": user.id,
+            "date_deadline": "2026-05-15",
+        })
+
+    def test_portal_tp_stale_activity_reassigned_on_unlink(self):
+        """When a portal TP is removed from one team but still on another,
+        mail.activity records on the ex-team's injuries should follow the
+        team — reassigned to the team's head therapist — not stay
+        assigned to a user whose record-rule scope no longer covers the
+        related injury (which would trigger a 403 on /my/activities when
+        the template browses the related injury)."""
+        head_tp = self.env["res.users"].create({
+            "name": "Head TP",
+            "login": "head.tp@example.com",
+            "groups_id": [(6, 0, [self.env.ref("base.group_portal").id])],
+        })
+        self._staff(head_tp, self.team_a, role="head_therapist")
+        ex_staff = self._staff(self.portal_tp, self.team_a)
+        # Portal TP also staffs team_b — keeps her portal-TP group + ACL on
+        # mail.activity after the team_a removal.
+        self._staff(self.portal_tp, self.team_b)
+        injury = self._injury(self.player_a, self.team_a)
+        activity = self._activity_on(injury, self.portal_tp)
+
+        ex_staff.unlink()
+
+        activity.invalidate_recordset(["user_id"])
+        self.assertEqual(
+            activity.user_id, head_tp,
+            "Stale activity should be reassigned to the team's head therapist.",
+        )
+        # Ex-TP can still query mail.activity (other teams remain), but
+        # this orphan one is filtered out by the rule.
+        self.portal_tp.invalidate_recordset(["groups_id"])
+        visible = (
+            self.env["mail.activity"]
+            .with_user(self.portal_tp)
+            .search([("id", "=", activity.id)])
+        )
+        self.assertFalse(
+            visible,
+            "Ex-TP must not see activities for injuries off her teams "
+            "(prevents 403 in /my/activities when the template browses "
+            "the related injury).",
+        )
+
+    def test_portal_tp_stale_activity_dropped_when_no_replacement(self):
+        """If no current team therapist exists to take over, the stale
+        activity is unlinked rather than left assigned to a user who
+        can no longer act on it."""
+        ex_staff = self._staff(self.portal_tp, self.team_a)
+        injury = self._injury(self.player_a, self.team_a)
+        activity = self._activity_on(injury, self.portal_tp)
+        activity_id = activity.id
+
+        ex_staff.unlink()
+
+        self.assertFalse(
+            self.env["mail.activity"].browse(activity_id).exists(),
+            "Activity should be unlinked when there's no current team "
+            "therapist to take it over.",
+        )
+
     # --- Self-healing path --------------------------------------------
 
     def test_orphan_tp_group_cleared_by_nightly_recompute(self):


### PR DESCRIPTION
## Summary
Two production fixes reported on 18.0 staging by Stephanie (portal therapist):

### 1. Portal mail.activity 403 on stale TP injuries (`6820503` — 18.0.3.6.16)
- The portal mail.activity rule had a `(user_id == self) AND res_model in [...]` OR-branch that let through assignee activities even when the related record was no longer in the user's team-staff scope (e.g. cron-created "Verify injury" tasks left over after a TP was unstaffed).
- The portal `/my/activities` template then 403'd browsing the now-unreadable `sports.patient.injury`.
- Drops the offending OR-branch from the TP and coach mail.activity rules and aligns the controller domain.
- Adds `_cleanup_stale_mail_activities` (mirrors the existing `_cleanup_stale_treatment_professionals` pattern) — wired into `TeamStaff.unlink` + `write` (when `team_id` changes) — that reassigns activities to a current head therapist (then any team therapist), or unlinks if no replacement.
- Post-migration `migrations/18.0.3.6.16/post-migration.py` reconciles existing data on upgrade.

### 2. Portal events calendar 4-hour TZ shift (`c0d2f71` — 18.0.3.6.17)
- `/my/events/calendar/data` was emitting Odoo's bare `YYYY-MM-DD HH:MM:SS` strings (via `fields.Datetime.to_string`); FullCalendar parsed those as already-local wall-clock — but Odoo stores naive UTC, so every event rendered shifted by the client's UTC offset (an 11 AM EDT clinic showed up at 3 PM in the calendar).
- Emits ISO-8601 with explicit UTC offset (`pytz.UTC.localize(...).isoformat()`).
- Also tightens the `start`/`end` window parser so tz-aware ISO datetimes from FullCalendar (e.g. `2026-05-01T00:00:00-04:00`) are converted to UTC before being compared against the stored fields, avoiding boundary off-by-offset misses.

## Test plan
- [x] `TestTherapistAccessRevoke` (14 tests, includes 2 new regressions: stale-activity reassignment + unlink-when-no-replacement) — pass
- [x] `TestMailActivityPortalAccess` (16 tests) — pass
- [x] `TestMailActivityPortalIntegration` (16 tests) — pass
- [x] `TestEventsCalendarPortal` (6 tests, includes 1 new regression asserting payload start/end carry an explicit UTC marker and round-trip back to the stored UTC time) — pass
- [x] Validated on fitcrew 18.0-staging by Stephanie — both reports confirmed fixed

## Forward-port
Will cherry-pick onto `19.0-mig-bemade_sports_clinic` once 19.0 stabilizes. Should apply cleanly since 19.0-mig was seeded from `3bbb012`.