### PR TITLE
test(fsm_visit_confirmation): valider timezone partenaire dans courriel de confirmation

### DIFF
--- a/fsm_visit_confirmation/data/mail_templates.xml
+++ b/fsm_visit_confirmation/data/mail_templates.xml
@@ -26,7 +26,7 @@
                         <td style="padding:10px;background-color:#f8f9fa;border-bottom:1px solid #e7e7e7;">Technician Arrival</td>
                         <td style="padding:10px;border-bottom:1px solid #e7e7e7;">
                             <t t-set="partner" t-value="object.work_order_contacts and object.work_order_contacts[0] or object.partner_id"/>
-                            <t t-set="partner_tz" t-value="user.tz or object.company_id.partner_id.tz or 'America/Toronto'"/>
+                            <t t-set="partner_tz" t-value="partner.tz or object.company_id.partner_id.tz or 'America/Toronto'"/>
                             <span t-field="object.planned_date_begin" t-options="{'widget': 'datetime', 'timezone': partner_tz}"/>
                             <div style="font-size: 12px; color: #666;">
                                 (Timezone: <t t-out="partner_tz"/>)

--- a/fsm_visit_confirmation/tests/test_fsm_visit_confirmation.py
+++ b/fsm_visit_confirmation/tests/test_fsm_visit_confirmation.py
@@ -310,3 +310,32 @@ class TestFSMVisitConfirmation(HttpCase):
         self.assertIn("Power Shutdown Required", new_mail.body_html, "Email should contain second requirement")
         self.assertIn("Water will be off for 2 hours", new_mail.body_html, "Email should contain first requirement description")
         self.assertIn("Power will be interrupted briefly", new_mail.body_html, "Email should contain second requirement description")
+
+    def test_07_confirmation_email_uses_partner_timezone(self):
+        """Le courriel doit afficher l'heure dans le fuseau du partenaire,
+        pas celui de l'utilisateur (odoo-bot a souvent UTC, ce qui causait
+        un décalage de 4-5h dans les confirmations envoyées aux clients)."""
+        from datetime import datetime
+
+        # Partenaire dans le fuseau EST; utilisateur simulé en UTC (odoo-bot)
+        self.customer.write({"tz": "America/Toronto"})
+        self.env.user.write({"tz": "UTC"})
+
+        self.task.write({
+            "planned_date_begin": datetime(2026, 6, 15, 14, 0, 0),  # 14h UTC = 10h EDT
+        })
+
+        template = self.env.ref(
+            "fsm_visit_confirmation.fsm_visit_confirmation_email_template"
+        )
+        self.stage_approved.approval_template_id = template
+        self.task.write({"stage_id": self.stage_approved.id})
+
+        new_mail = self.env["mail.mail"].search([], order="id desc", limit=1)
+
+        # Le fuseau affiché doit être celui du partenaire (America/Toronto)
+        self.assertIn(
+            "America/Toronto",
+            new_mail.body_html,
+            "Le courriel doit afficher le fuseau du partenaire (America/Toronto), pas UTC",
+        )


### PR DESCRIPTION
Test de régression pour le bug où `user.tz` (UTC pour odoo-bot) était utilisé au lieu de `partner.tz`, causant un décalage d'heure dans les courriels de confirmation de visite FSM.