### PR TITLE
fix(fsm_visit_confirmation): utiliser le timezone du partenaire dans le courriel de confirmation

### DIFF
--- a/fsm_visit_confirmation/data/mail_templates.xml
+++ b/fsm_visit_confirmation/data/mail_templates.xml
@@ -26,7 +26,7 @@
                         <td style="padding:10px;background-color:#f8f9fa;border-bottom:1px solid #e7e7e7;">Technician Arrival</td>
                         <td style="padding:10px;border-bottom:1px solid #e7e7e7;">
                             <t t-set="partner" t-value="object.work_order_contacts and object.work_order_contacts[0] or object.partner_id"/>
-                            <t t-set="partner_tz" t-value="user.tz or object.company_id.partner_id.tz or 'America/Toronto'"/>
+                            <t t-set="partner_tz" t-value="partner.tz or object.company_id.partner_id.tz or 'America/Toronto'"/>
                             <span t-field="object.planned_date_begin" t-options="{'widget': 'datetime', 'timezone': partner_tz}"/>
                             <div style="font-size: 12px; color: #666;">
                                 (Timezone: <t t-out="partner_tz"/>)


### PR DESCRIPTION
Remplace `user.tz` par `partner.tz` dans le template de confirmation de visite FSM. `user.tz` (souvent UTC pour odoo-bot) causait un décalage d'heure dans les courriels envoyés aux clients.