### PR TITLE
feat(bemade_mail_author_visibility): migration 18.0 → 19.0

### DIFF
--- a/bemade_mail_author_visibility/__init__.py
+++ b/bemade_mail_author_visibility/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2026 Bemade Inc.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).

--- a/bemade_mail_author_visibility/__manifest__.py
+++ b/bemade_mail_author_visibility/__manifest__.py
@@ -1,0 +1,21 @@
+# Copyright 2026 Bemade Inc.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+{
+    "name": "Mail Author Visibility",
+    "version": "19.0.1.0.0",
+    "category": "Discuss",
+    "summary": (
+        "Injects a 'Posted by:' author header block into chatter notification "
+        "emails so recipients immediately know who posted each message."
+    ),
+    "author": "Bemade Inc.",
+    "maintainers": ["mdurepos"],
+    "website": "https://www.bemade.org",
+    "depends": ["mail"],
+    "data": [
+        "views/mail_notification_layout.xml",
+    ],
+    "auto_install": ["mail"],
+    "installable": True,
+    "license": "LGPL-3",
+}

--- a/bemade_mail_author_visibility/i18n/bemade_mail_author_visibility.pot
+++ b/bemade_mail_author_visibility/i18n/bemade_mail_author_visibility.pot
@@ -1,0 +1,26 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* bemade_mail_author_visibility
+#
+# Copyright (C) 2026 Bemade Inc. (<https://www.bemade.org>).
+# This file is distributed under the same license as the bemade_mail_author_visibility package.
+# Bemade Inc. <marc@bemade.org>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-22 00:00+0000\n"
+"PO-Revision-Date: 2026-04-22 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: bemade_mail_author_visibility
+#: model_terms:ir.ui.view,arch_db:bemade_mail_author_visibility.mail_notification_layout
+#: model_terms:ir.ui.view,arch_db:bemade_mail_author_visibility.mail_notification_light
+msgid "<strong>Posted by:</strong>"
+msgstr ""

--- a/bemade_mail_author_visibility/i18n/fr_CA.po
+++ b/bemade_mail_author_visibility/i18n/fr_CA.po
@@ -1,0 +1,27 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* bemade_mail_author_visibility
+#
+# Copyright (C) 2026 Bemade Inc. (<https://www.bemade.org>).
+# This file is distributed under the same license as the bemade_mail_author_visibility package.
+# Bemade Inc. <marc@bemade.org>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-22 00:00+0000\n"
+"PO-Revision-Date: 2026-04-22 00:00+0000\n"
+"Last-Translator: Bemade Inc. <marc@bemade.org>\n"
+"Language-Team: fr_CA <marc@bemade.org>\n"
+"Language: fr_CA\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. module: bemade_mail_author_visibility
+#: model_terms:ir.ui.view,arch_db:bemade_mail_author_visibility.mail_notification_layout
+#: model_terms:ir.ui.view,arch_db:bemade_mail_author_visibility.mail_notification_light
+msgid "<strong>Posted by:</strong>"
+msgstr "<strong>Publié par :</strong>"

--- a/bemade_mail_author_visibility/tests/__init__.py
+++ b/bemade_mail_author_visibility/tests/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2026 Bemade Inc.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+from . import test_author_header
+from . import test_po_loading

--- a/bemade_mail_author_visibility/tests/test_author_header.py
+++ b/bemade_mail_author_visibility/tests/test_author_header.py
@@ -1,0 +1,392 @@
+# Copyright 2026 Bemade Inc.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+#
+# Acceptance criteria tested here
+# --------------------------------
+# 1. Author is an internal user — notification body_html contains "Posted by:",
+#    author name and email (mailto: link) above the message body.
+# 3. Author has name but no email (name-only partner) — name shown, no dangling
+#    <> brackets, no broken mailto.
+# 6. Layout regression — mail_notification_layout_with_responsible_signature
+#    primary inherit still renders without xpath collision on o_signature.
+# 7. Empty author suppression — when author_id=False and email_from is blank,
+#    the "Posted by:" block is absent from the rendered output.
+# 8. French (fr_CA) rendering — follower whose lang is fr_CA receives "Publié
+#    par :" instead of "Posted by:".
+#
+# Tests 2 (incoming email gateway), 4 (light layout staging), and
+# 5 (plain-text html2plaintext) are documented below but require a staging
+# server for full integration verification — they are skipped with a note.
+
+from odoo.addons.mail.tests.common import MailCommon, mail_new_test_user
+from odoo.tests import tagged
+from odoo.tools import mute_logger
+
+
+@tagged("post_install", "-at_install", "bemade_mail_author_visibility")
+class TestAuthorHeader(MailCommon):
+    """Tests for bemade_mail_author_visibility: author header in notifications."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # Internal user / author — posts messages.
+        cls.user_author = mail_new_test_user(
+            cls.env,
+            login="test_mav_author",
+            name="Jane Doe",
+            email="jane@test.example.com",
+            groups="base.group_user,base.group_partner_manager",
+            notification_type="email",
+        )
+        cls.partner_author = cls.user_author.partner_id
+
+        # Follower who will receive notifications (English default).
+        cls.user_follower = mail_new_test_user(
+            cls.env,
+            login="test_mav_follower",
+            name="Follower User",
+            email="follower@test.example.com",
+            groups="base.group_user,base.group_partner_manager",
+            notification_type="email",
+        )
+        cls.partner_follower = cls.user_follower.partner_id
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _make_record(self, name="Test MAV Thread"):
+        """Return a minimal mail.thread record (res.partner) for posting."""
+        return self.env["res.partner"].create({
+            "name": name,
+            "email": "thread@test.example.com",
+        })
+
+    def _post_and_get_mails(self, record, author_user, extra_followers=None):
+        """Subscribe followers, post, return (message, mail.mail recordset)."""
+        partner_ids = [self.partner_follower.id]
+        if extra_followers:
+            partner_ids += [p.id for p in extra_followers]
+        record.message_subscribe(partner_ids=partner_ids)
+        msg = record.with_user(author_user).message_post(
+            body="<p>Hello, this is a test message.</p>",
+            message_type="comment",
+            subtype_xmlid="mail.mt_comment",
+            mail_auto_delete=False,
+        )
+        mail_mails = self.env["mail.mail"].sudo().search(
+            [("mail_message_id", "=", msg.id)]
+        )
+        return msg, mail_mails
+
+    # ------------------------------------------------------------------
+    # Test 1 — Internal user author: name + email in notification
+    # ------------------------------------------------------------------
+
+    @mute_logger("odoo.addons.mail.models.mail_mail", "odoo.models.unlink")
+    def test_01_internal_user_author_shows_name_and_email(self):
+        """body_html contains 'Posted by:', author name and mailto email link."""
+        record = self._make_record()
+        _msg, mail_mails = self._post_and_get_mails(record, self.user_author)
+
+        self.assertTrue(mail_mails, "Expected mail.mail records to be created")
+        for mail in mail_mails:
+            with self.subTest(mail=mail):
+                self.assertIn(
+                    "Posted by:",
+                    mail.body_html,
+                    "Expected 'Posted by:' label in notification HTML",
+                )
+                self.assertIn(
+                    self.user_author.name,
+                    mail.body_html,
+                    "Expected author name in notification HTML",
+                )
+                self.assertIn(
+                    "mailto:%s" % self.user_author.email,
+                    mail.body_html,
+                    "Expected mailto: link for author email in notification HTML",
+                )
+                self.assertIn(
+                    self.user_author.email,
+                    mail.body_html,
+                    "Expected author email address in notification HTML",
+                )
+
+    # ------------------------------------------------------------------
+    # Test 3 — Author has name but no email
+    # ------------------------------------------------------------------
+
+    @mute_logger("odoo.addons.mail.models.mail_mail", "odoo.models.unlink")
+    def test_03_author_name_only_no_dangling_brackets(self):
+        """When author has name but no email: name shown, no <> brackets, no mailto."""
+        # Create a partner with no email and post as that partner (no user).
+        # We post directly with sudo + author_id override via context.
+        no_email_partner = self.env["res.partner"].create({
+            "name": "NoEmail Bot",
+            "email": False,
+        })
+        record = self._make_record("Name-Only Test Record")
+        record.message_subscribe(partner_ids=[self.partner_follower.id])
+
+        # Post with sudo, specifying author explicitly via kwarg.
+        msg = record.sudo().message_post(
+            body="<p>Message from no-email partner.</p>",
+            message_type="comment",
+            subtype_xmlid="mail.mt_comment",
+            author_id=no_email_partner.id,
+            mail_auto_delete=False,
+        )
+        mail_mails = self.env["mail.mail"].sudo().search(
+            [("mail_message_id", "=", msg.id)]
+        )
+
+        self.assertTrue(mail_mails, "Expected mail.mail records to be created")
+        for mail in mail_mails:
+            with self.subTest(mail=mail):
+                self.assertIn(
+                    "Posted by:",
+                    mail.body_html,
+                    "Expected 'Posted by:' label even for name-only author",
+                )
+                self.assertIn(
+                    "NoEmail Bot",
+                    mail.body_html,
+                    "Expected author name in notification HTML",
+                )
+                # No mailto link and no <> brackets around empty address
+                self.assertNotIn(
+                    "mailto:",
+                    mail.body_html,
+                    "Unexpected mailto: link when author has no email",
+                )
+                # The ">" character from &gt; may appear in other places, but
+                # the combination of bare "<" + ">" wrapping nothing should not.
+                # A simple guard: check there's no empty angle bracket pair.
+                self.assertNotIn(
+                    "<>",
+                    mail.body_html,
+                    "Unexpected empty angle brackets in notification HTML",
+                )
+
+    # ------------------------------------------------------------------
+    # Test 6 — No xpath collision with mail_notification_layout_with_responsible_signature
+    # ------------------------------------------------------------------
+
+    @mute_logger("odoo.addons.mail.models.mail_mail", "odoo.models.unlink")
+    def test_06_no_xpath_collision_with_responsible_signature(self):
+        """mail_notification_layout_with_responsible_signature still renders; no crash."""
+        # Use a sale.order-style model that uses the responsible signature layout.
+        # res.partner uses the base layout. We test the base layout renders and
+        # the o_signature class node is still present (not broken by our xpath).
+        # Since we don't depend on sale, we render the template directly.
+        message_template = self.env.ref(
+            "mail.mail_notification_layout_with_responsible_signature",
+            raise_if_not_found=False,
+        )
+        if not message_template:
+            self.skipTest("mail_notification_layout_with_responsible_signature not found")
+
+        # Build a minimal render context mimicking what _notify_by_email_render_layout
+        # passes, then call ir.qweb._render directly.
+        record = self._make_record("Signature Collision Test")
+        msg = record.sudo().message_post(
+            body="<p>Test for responsible signature layout.</p>",
+            message_type="comment",
+            subtype_xmlid="mail.mt_comment",
+            author_id=self.partner_author.id,
+            mail_auto_delete=False,
+        )
+        # Direct qweb render with the primary inherit template.
+        from odoo.tools.mail import is_html_empty
+
+        render_ctx = {
+            "message": msg,
+            "record": record,
+            "record_name": record.display_name,
+            "company": self.env.company,
+            "model_description": "Contact",
+            "is_discussion": True,
+            "tracking_values": [],
+            "subtype": msg.subtype_id,
+            "author_user": False,
+            "signature": "",
+            "email_add_signature": False,
+            "lang": "en_US",
+            "website_url": False,
+            "subtitles": [record.display_name],
+            "is_html_empty": is_html_empty,
+            "has_button_access": False,
+            "button_access": {},
+            "actions": [],
+            "recipients": [],
+            "email_notification_force_header": False,
+            "email_notification_force_footer": False,
+            "email_notification_allow_header": True,
+            "email_notification_allow_footer": False,
+        }
+        rendered = self.env["ir.qweb"]._render(
+            "mail.mail_notification_layout_with_responsible_signature",
+            render_ctx,
+            minimal_qcontext=True,
+        )
+        self.assertTrue(rendered, "Expected non-empty render output")
+        self.assertIn(
+            "Posted by:",
+            rendered,
+            "Expected 'Posted by:' block in primary-inherit layout",
+        )
+
+    # ------------------------------------------------------------------
+    # Test 7 — Empty author: block suppressed
+    # ------------------------------------------------------------------
+
+    @mute_logger("odoo.addons.mail.models.mail_mail", "odoo.models.unlink")
+    def test_07_empty_author_block_suppressed(self):
+        """When author_id=False and email_from is blank, 'Posted by:' is absent."""
+        from odoo.tools.mail import is_html_empty
+
+        record = self._make_record("Empty Author Test")
+        # Build a synthetic mail.message with no author and no email_from.
+        msg = self.env["mail.message"].sudo().create({
+            "body": "<p>System message.</p>",
+            "message_type": "comment",
+            "subtype_id": self.env.ref("mail.mt_comment").id,
+            "model": "res.partner",
+            "res_id": record.id,
+            "author_id": False,
+            "email_from": False,
+        })
+        render_ctx = {
+            "message": msg,
+            "record": record,
+            "record_name": record.display_name,
+            "company": self.env.company,
+            "model_description": "Contact",
+            "is_discussion": True,
+            "tracking_values": [],
+            "subtype": msg.subtype_id,
+            "author_user": False,
+            "signature": "",
+            "email_add_signature": False,
+            "lang": "en_US",
+            "website_url": False,
+            "subtitles": [record.display_name],
+            "is_html_empty": is_html_empty,
+            "has_button_access": False,
+            "button_access": {},
+            "actions": [],
+            "recipients": [],
+            "email_notification_force_header": False,
+            "email_notification_force_footer": False,
+            "email_notification_allow_header": True,
+            "email_notification_allow_footer": False,
+        }
+        rendered = self.env["ir.qweb"]._render(
+            "mail.mail_notification_layout",
+            render_ctx,
+            minimal_qcontext=True,
+        )
+        self.assertTrue(rendered, "Expected non-empty render output")
+        self.assertNotIn(
+            "Posted by:",
+            rendered,
+            "Expected 'Posted by:' block to be suppressed when author is absent",
+        )
+
+    # ------------------------------------------------------------------
+    # Test 8 — French (fr_CA) rendering
+    # ------------------------------------------------------------------
+
+    @mute_logger("odoo.addons.mail.models.mail_mail", "odoo.models.unlink")
+    def test_08_french_rendering(self):
+        """Follower with lang=fr_CA receives 'Publié par :' instead of 'Posted by:'."""
+        # Activate fr_CA language.
+        self.env["res.lang"]._activate_lang("fr_CA")
+
+        # Load module translations for fr_CA so our .po is active.
+        self.env["ir.module.module"]._load_module_terms(
+            ["bemade_mail_author_visibility"], ["fr_CA"]
+        )
+
+        # Create a fr_CA follower user.
+        user_fr = mail_new_test_user(
+            self.env,
+            login="test_mav_fr_follower",
+            name="Utilisateur Francophone",
+            email="fr.follower@test.example.com",
+            groups="base.group_user,base.group_partner_manager",
+            notification_type="email",
+            lang="fr_CA",
+        )
+        partner_fr = user_fr.partner_id
+
+        record = self._make_record("French Rendering Test")
+        record.message_subscribe(partner_ids=[partner_fr.id])
+
+        msg = record.with_user(self.user_author).message_post(
+            body="<p>Message for fr_CA follower.</p>",
+            message_type="comment",
+            subtype_xmlid="mail.mt_comment",
+            mail_auto_delete=False,
+        )
+        mail_mails = self.env["mail.mail"].sudo().search(
+            [("mail_message_id", "=", msg.id)]
+        )
+        self.assertTrue(mail_mails, "Expected mail.mail records")
+
+        # Find the mail.mail entry addressed to our fr_CA follower.
+        fr_mail = mail_mails.filtered(
+            lambda m: partner_fr in m.recipient_ids
+        )
+        self.assertTrue(
+            fr_mail,
+            "Expected a mail.mail record addressed to the fr_CA follower",
+        )
+        for mail in fr_mail:
+            with self.subTest(mail=mail):
+                self.assertIn(
+                    "Publié par :",
+                    mail.body_html,
+                    "Expected French translation 'Publié par :' in fr_CA notification",
+                )
+                self.assertNotIn(
+                    "Posted by:",
+                    mail.body_html,
+                    "Unexpected English 'Posted by:' in fr_CA notification",
+                )
+
+    # ------------------------------------------------------------------
+    # Skipped / staging-only tests (documented)
+    # ------------------------------------------------------------------
+
+    def test_02_incoming_email_gateway_skip(self):
+        """Test 2: external author (email gateway) — requires staging verification.
+
+        Simulating message_process with a real .eml and verifying the rendered
+        notification HTML contains the From-header name/email requires a
+        configured mail gateway and outgoing SMTP mock.  Verified on
+        staging.pneumac.qc.ca as part of the production rollout.
+        """
+        self.skipTest("Requires staging verification (email gateway integration)")
+
+    def test_04_light_layout_skip(self):
+        """Test 4: mail_notification_light render — requires staging verification.
+
+        Templates using mail.mail_notification_light (e.g. portal invoice share)
+        are only triggered via specific workflows not easily reproducible in unit
+        tests without depending on account/sale.  Verified on staging.
+        """
+        self.skipTest("Requires staging verification (portal invoice share workflow)")
+
+    def test_05_plain_text_fallback_skip(self):
+        """Test 5: plain-text html2plaintext — requires staging verification.
+
+        The body (plaintext) field of mail.mail is generated lazily by
+        html2plaintext in _send_prepare_body / _send.  Inspecting it requires
+        triggering actual send logic which diverges from unit-test isolation.
+        Verified on staging by checking raw MIME source of a sent notification.
+        """
+        self.skipTest("Requires staging verification (plain-text MIME inspection)")

--- a/bemade_mail_author_visibility/tests/test_po_loading.py
+++ b/bemade_mail_author_visibility/tests/test_po_loading.py
@@ -1,0 +1,87 @@
+# Copyright 2026 Bemade Inc.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+#
+# Acceptance criteria tested here
+# --------------------------------
+# 9. PO loading — both i18n/fr_CA.po and i18n/bemade_mail_author_visibility.pot
+#    parse without any ERROR log from odoo.tools.translate, and the reader
+#    yields at least one entry with type == 'model_terms', imd_model ==
+#    'ir.ui.view', name == 'ir.ui.view,arch_db', imd_name in
+#    {'mail_notification_layout', 'mail_notification_light'}, and source
+#    '<strong>Posted by:</strong>'.
+
+import os
+
+from odoo.tests import TransactionCase, tagged
+from odoo.tools.translate import TranslationFileReader
+
+
+def _i18n_dir():
+    """Return the absolute path to bemade_mail_author_visibility/i18n/."""
+    here = os.path.dirname(__file__)  # …/tests/
+    return os.path.join(here, "..", "i18n")
+
+
+@tagged("post_install", "-at_install", "bemade_mail_author_visibility")
+class TestPoLoading(TransactionCase):
+    """Test that the fr_CA .po and .pot files load cleanly via TranslationFileReader."""
+
+    def _assert_clean_load(self, po_path):
+        """Parse *po_path* and assert no ERROR logs; return list of yielded dicts."""
+        entries = []
+        with self.assertNoLogs("odoo.tools.translate", level="ERROR"):
+            for entry in TranslationFileReader(po_path, fileformat="po"):
+                entries.append(entry)
+        return entries
+
+    def _find_posted_by_entry(self, entries):
+        """Return all entries whose source is the canonical 'Posted by:' msgid."""
+        return [
+            e for e in entries
+            if e.get("src") == "<strong>Posted by:</strong>"
+        ]
+
+    def test_09_po_loads_without_malformed_warning(self):
+        """fr_CA.po and .pot parse cleanly and yield the expected arch_db entries."""
+        i18n = _i18n_dir()
+        fr_ca_path = os.path.join(i18n, "fr_CA.po")
+        pot_path = os.path.join(i18n, "bemade_mail_author_visibility.pot")
+
+        for label, path in [("fr_CA.po", fr_ca_path), (".pot", pot_path)]:
+            with self.subTest(file=label):
+                entries = self._assert_clean_load(path)
+                posted_by = self._find_posted_by_entry(entries)
+                self.assertTrue(
+                    posted_by,
+                    f"{label}: expected at least one entry with "
+                    "src='<strong>Posted by:</strong>'",
+                )
+                matched_xmlids = {e["imd_name"] for e in posted_by}
+                expected_xmlids = {"mail_notification_layout", "mail_notification_light"}
+                self.assertTrue(
+                    matched_xmlids & expected_xmlids,
+                    f"{label}: expected imd_name in {expected_xmlids!r}, "
+                    f"got {matched_xmlids!r}",
+                )
+                for entry in posted_by:
+                    if entry["imd_name"] not in expected_xmlids:
+                        continue
+                    with self.subTest(imd_name=entry["imd_name"]):
+                        self.assertEqual(
+                            entry["type"],
+                            "model_terms",
+                            f"{label}: expected type='model_terms', "
+                            f"got {entry['type']!r}",
+                        )
+                        self.assertEqual(
+                            entry["imd_model"],
+                            "ir.ui.view",
+                            f"{label}: expected imd_model='ir.ui.view', "
+                            f"got {entry['imd_model']!r}",
+                        )
+                        self.assertEqual(
+                            entry["name"],
+                            "ir.ui.view,arch_db",
+                            f"{label}: expected name='ir.ui.view,arch_db', "
+                            f"got {entry['name']!r}",
+                        )

--- a/bemade_mail_author_visibility/views/mail_notification_layout.xml
+++ b/bemade_mail_author_visibility/views/mail_notification_layout.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2026 Bemade Inc. -->
+<!-- License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl). -->
+<odoo>
+    <data>
+
+        <!--
+            Inject "Posted by:" author block into mail.mail_notification_layout
+            just above the message body.
+
+            author_display_name: partner name for internal authors; raw
+            email_from string for inbound emails without a matched partner.
+            author_display_email: partner email (clean address) for internal
+            authors; empty when no author_id (to avoid parsing email_from).
+        -->
+        <template id="mail_notification_layout"
+                  inherit_id="mail.mail_notification_layout">
+            <xpath expr="//div[@t-out='message.body']" position="before">
+                <t t-set="author_display_name"
+                   t-value="message.author_id.name or message.email_from or ''"/>
+                <t t-set="author_display_email"
+                   t-value="message.author_id.email or ''"/>
+                <div t-if="author_display_name or author_display_email"
+                     style="font-size: 12px; color: #555555; margin: 4px 0 8px 0; padding: 6px 8px; border-left: 3px solid #cccccc; background: #f7f7f7;">
+                    <strong>Posted by:</strong>&#160;<t t-if="author_display_name"><span t-out="author_display_name"/></t>
+                    <t t-if="author_display_email">
+                        &#160;&lt;<a t-att-href="'mailto:%s' % author_display_email"
+                               style="color: #555555; text-decoration: none;"
+                               t-out="author_display_email"/>&gt;
+                    </t>
+                </div>
+            </xpath>
+        </template>
+
+        <!--
+            Inject "Posted by:" author block into mail.mail_notification_light
+            just above the message body (the <t t-out="message.body"/> node
+            lives inside a <td>).
+        -->
+        <template id="mail_notification_light"
+                  inherit_id="mail.mail_notification_light">
+            <xpath expr="//td/t[@t-out='message.body']" position="before">
+                <t t-set="author_display_name"
+                   t-value="message.author_id.name or message.email_from or ''"/>
+                <t t-set="author_display_email"
+                   t-value="message.author_id.email or ''"/>
+                <div t-if="author_display_name or author_display_email"
+                     style="font-size: 12px; color: #555555; margin: 4px 0 8px 0; padding: 6px 8px; border-left: 3px solid #cccccc; background: #f7f7f7;">
+                    <strong>Posted by:</strong>&#160;<t t-if="author_display_name"><span t-out="author_display_name"/></t>
+                    <t t-if="author_display_email">
+                        &#160;&lt;<a t-att-href="'mailto:%s' % author_display_email"
+                               style="color: #555555; text-decoration: none;"
+                               t-out="author_display_email"/>&gt;
+                    </t>
+                </div>
+            </xpath>
+        </template>
+
+    </data>
+</odoo>


### PR DESCRIPTION
Aucun changement de logique — les deux xpath ciblant message.body sont identiques en 19.0. Mise à jour de la version et des métadonnées i18n.