### PR TITLE
[FIX] bemade_mail_gateway: restore logger state in test_security_redaction

### DIFF
--- a/bemade_mail_gateway/tests/test_security_redaction.py
+++ b/bemade_mail_gateway/tests/test_security_redaction.py
@@ -37,8 +37,12 @@ class TestNoTokenInLogs(HttpCase):
         cls.env["ir.config_parameter"].sudo().set_param("bemade_mail_gateway.allow_http", "True")
 
     def _capture(self):
-        """Context manager-ish handler that captures every LogRecord on
-        the relevant loggers. Returns (handler, captured_messages)."""
+        """Attach a capturing handler to the relevant loggers and force them
+        to DEBUG so a real `_logger.debug("token=%s", raw)` leak would land
+        in the handler. Prior level + propagate are snapshotted and restored
+        via ``addCleanup`` so we don't taint global logging state for the
+        rest of the test run (which previously pinned root/`odoo` at DEBUG
+        and flooded CI logs)."""
         handler = _ListHandler()
         handler.setLevel(logging.DEBUG)
         loggers = [
@@ -49,14 +53,23 @@ class TestNoTokenInLogs(HttpCase):
             logging.getLogger("odoo.addons.bemade_mail_gateway.controllers.mail_gateway"),
             logging.getLogger("odoo.addons.bemade_mail_gateway.wizards.token_create_wizard"),
         ]
+        prior = [(lg, lg.level, lg.propagate) for lg in loggers]
         for lg in loggers:
             lg.addHandler(handler)
             lg.setLevel(logging.DEBUG)
+            # Keep captured DEBUG records out of the console: emission to
+            # the parent chain happens via propagation, so cutting that off
+            # while the test runs prevents stdout pollution.
+            lg.propagate = False
+        self.addCleanup(self._release, handler, prior)
         return handler, loggers
 
-    def _release(self, handler, loggers):
-        for lg in loggers:
+    @staticmethod
+    def _release(handler, prior):
+        for lg, level, propagate in prior:
             lg.removeHandler(handler)
+            lg.setLevel(level)
+            lg.propagate = propagate
 
     def _assert_no_leak(self, handler, raw, label_for_msg=""):
         for record in handler.records:
@@ -72,77 +85,59 @@ class TestNoTokenInLogs(HttpCase):
     # ---- Generation path --------------------------------------------------
 
     def test_generate_does_not_log_raw(self):
-        handler, loggers = self._capture()
-        try:
-            _, raw = self.Token.action_generate("redact-gen")
-        finally:
-            self._release(handler, loggers)
+        handler, _ = self._capture()
+        _, raw = self.Token.action_generate("redact-gen")
         self._assert_no_leak(handler, raw, "action_generate")
 
     # ---- Validation paths -------------------------------------------------
 
     def test_validate_success_does_not_log_raw(self):
         _, raw = self.Token.action_generate("redact-val-ok")
-        handler, loggers = self._capture()
-        try:
-            self.Token.validate_token(raw, ip="127.0.0.1")
-        finally:
-            self._release(handler, loggers)
+        handler, _ = self._capture()
+        self.Token.validate_token(raw, ip="127.0.0.1")
         self._assert_no_leak(handler, raw, "validate_token (success)")
 
     def test_validate_failure_does_not_log_attempted_token(self):
         attempted = "evil-attempted-token-shouldn't-appear-anywhere-XYZ123"
-        handler, loggers = self._capture()
-        try:
-            self.Token.validate_token(attempted)
-        finally:
-            self._release(handler, loggers)
+        handler, _ = self._capture()
+        self.Token.validate_token(attempted)
         self._assert_no_leak(handler, attempted, "validate_token (failure)")
 
     # ---- Controller paths -------------------------------------------------
 
     def test_controller_check_success_does_not_log_raw(self):
         _, raw = self.Token.action_generate("redact-ctl-check")
-        handler, loggers = self._capture()
-        try:
-            self.opener.post(
-                self.base_url() + "/bemade/mail-gateway/check",
-                headers={"X-Bemade-Token": raw},
-                timeout=10,
-            )
-        finally:
-            self._release(handler, loggers)
+        handler, _ = self._capture()
+        self.opener.post(
+            self.base_url() + "/bemade/mail-gateway/check",
+            headers={"X-Bemade-Token": raw},
+            timeout=10,
+        )
         self._assert_no_leak(handler, raw, "controller /check (200)")
 
     def test_controller_check_failure_does_not_log_attempted(self):
         attempted = "evil-controller-token-X9Y8Z7"
-        handler, loggers = self._capture()
-        try:
-            self.opener.post(
-                self.base_url() + "/bemade/mail-gateway/check",
-                headers={"X-Bemade-Token": attempted},
-                timeout=10,
-            )
-        finally:
-            self._release(handler, loggers)
+        handler, _ = self._capture()
+        self.opener.post(
+            self.base_url() + "/bemade/mail-gateway/check",
+            headers={"X-Bemade-Token": attempted},
+            timeout=10,
+        )
         self._assert_no_leak(handler, attempted, "controller /check (401)")
 
     @mute_logger("odoo.addons.mail.models.mail_thread")
     def test_controller_process_does_not_log_raw(self):
         _, raw = self.Token.action_generate("redact-ctl-process")
-        handler, loggers = self._capture()
-        try:
-            self.opener.post(
-                self.base_url() + "/bemade/mail-gateway/process",
-                data=(
-                    b"From: a@b\r\nTo: nope@example.org\r\n"
-                    b"Subject: x\r\nMessage-Id: <r@x>\r\n\r\nbody\r\n"
-                ),
-                headers={"X-Bemade-Token": raw},
-                timeout=10,
-            )
-        finally:
-            self._release(handler, loggers)
+        handler, _ = self._capture()
+        self.opener.post(
+            self.base_url() + "/bemade/mail-gateway/process",
+            data=(
+                b"From: a@b\r\nTo: nope@example.org\r\n"
+                b"Subject: x\r\nMessage-Id: <r@x>\r\n\r\nbody\r\n"
+            ),
+            headers={"X-Bemade-Token": raw},
+            timeout=10,
+        )
         self._assert_no_leak(handler, raw, "controller /process")
 
     # ---- Read API doesn't echo the hash to non-admins --------------------


### PR DESCRIPTION
## Summary
- `TestNoTokenInLogs._capture()` forced root, `odoo` and several `bemade_mail_gateway` child loggers to `DEBUG` so a real leak at `_logger.debug(\"token=%s\", raw)` would land in the test's `_ListHandler`. `_release()` removed the handler but never restored the prior `level` / `propagate`, so once the first test in the class ran, root + `odoo` stayed at `DEBUG` for the rest of the Odoo process.
- On CI (`odoo --log-level=warn`) this neutralized the level cap partway through the test stage and produced a sudden DEBUG flood (`odoo.sql_db`, `urllib3.connectionpool`, website routing, …) that overran GitLab's job-log cap and failed downstream jobs in durpro.
- Snapshot `(level, propagate)` per logger, restore via `self.addCleanup(...)` so unittest teardown puts things back even if a test errors mid-flight. Drop the per-test `try/finally` blocks.
- Also set `propagate=False` on the captured loggers while the test runs, so the DEBUG records we want to capture don't bubble to the parent console handler and pollute stdout during the test itself. Capture still works — `_ListHandler` is attached directly to each logger in the list.
- No behaviour change for the security assertion: the handler still sees every record at DEBUG and a real raw-token leak would still be caught.

## Test plan
- [x] `odoo-dev test bemade_mail_gateway --test-tags bemade_mail_gateway` → 64 tests, 0 failed, 0 errors locally.
- [x] `grep -c "DEBUG odoo " /tmp/test.log` → 0 (no DEBUG pollution during or after `TestNoTokenInLogs`).
- [ ] CI test stage runs at warn-level throughout (no DEBUG flood after `TestNoTokenInLogs`).