### PR TITLE
fix(product_supplierinfo_tracking): fix log message

### DIFF
--- a/product_supplierinfo_tracking/models/product_supplier_info.py
+++ b/product_supplierinfo_tracking/models/product_supplier_info.py
@@ -35,10 +35,11 @@ class ProductSupplierInfo(models.Model):
 
     def _generate_chatter(self, vals, operation):
         if len(self) == 1 and self.product_tmpl_id:
+            name = self.product_id.name or self.product_tmpl_id.name
             msg = ""
             headmsg = (
                 f"<a href='#' data-oe-model='product.supplierinfo' data-oe-id='{self.id}'>"
-                f"Price {operation} for {self.product_id.name} : <br /></a>"
+                f"Price {operation} for {name} : <br /></a>"
             )
             if self.min_qty > 0:
                 msg += f"<li>Minimum qty : {self.min_qty}</li>"
@@ -63,7 +64,7 @@ class ProductSupplierInfo(models.Model):
 
     def write(self, vals):
         res = super(ProductSupplierInfo, self).write(vals)
-        self._generate_chatter(vals, "modify")
+        self._generate_chatter(vals, "modified")
         return res
 
     def supplierinfo_show_details(self):

--- a/product_supplierinfo_tracking/tests/test_product_supplierinfo_tracking.py
+++ b/product_supplierinfo_tracking/tests/test_product_supplierinfo_tracking.py
@@ -121,7 +121,7 @@ class TestProductSupplierinfoTracking(TransactionCase):
 
         # Verify message content contains the changes
         message_body = template_messages[0].body
-        self.assertIn("Price modify", message_body)
+        self.assertIn("Price modified", message_body)
         self.assertIn("min_qty", message_body)
 
     def test_chatter_message_content_structure(self):
@@ -159,7 +159,7 @@ class TestProductSupplierinfoTracking(TransactionCase):
 
             # Verify message content structure
             message_body = template_messages[0].body
-            self.assertIn("Price modify", message_body)
+            self.assertIn("Price modified", message_body)
             self.assertIn("price --&gt; 80.0", message_body)
             self.assertIn("min_qty --&gt; 10.0", message_body)
 
@@ -191,7 +191,7 @@ class TestProductSupplierinfoTracking(TransactionCase):
 
             # Verify message content
             message_body = template_messages[0].body
-            self.assertIn("Price modify", message_body)
+            self.assertIn("Price modified", message_body)
             self.assertIn("price --&gt; 60.0", message_body)
 
     def test_supplierinfo_show_details_action(self):
@@ -292,7 +292,7 @@ class TestProductSupplierinfoTracking(TransactionCase):
             self.assertTrue(len(template_messages) > 0, "Should have posted message")
 
             message_body = template_messages[0].body
-            self.assertIn("Price modify", message_body)
+            self.assertIn("Price modified", message_body)
             self.assertIn("price --&gt; 30.0", message_body)
             # Should not contain qty, dates since they weren't set
             self.assertNotIn("Minimum qty", message_body)


### PR DESCRIPTION
- Fix the English syntax in the message that previously read `Price modify for ...` for `Price modified for ...`.
- Adjust tests for new wording
- Fall back to product template name when product_id.name is falsy.