### PR TITLE
fix(account_credit_hold): corriger incompatibilité avec durpro_sale_bemade_fsm

### DIFF
--- a/account_credit_hold/__manifest__.py
+++ b/account_credit_hold/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Account Credit Hold",
-    "version": "18.0.1.1.2",
+    "version": "18.0.1.1.3",
     "summary": "Allows setting clients on credit hold, blocking the ability confirm a new sales order.",
     "category": "Accounting/Accounting",
     "author": "Bemade Inc.",

--- a/account_credit_hold/__manifest__.py
+++ b/account_credit_hold/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Account Credit Hold",
-    "version": "18.0.1.1.4",
+    "version": "18.0.1.1.5",
     "summary": "Allows setting clients on credit hold, blocking the ability confirm a new sales order.",
     "category": "Accounting/Accounting",
     "author": "Bemade Inc.",

--- a/account_credit_hold/__manifest__.py
+++ b/account_credit_hold/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Account Credit Hold",
-    "version": "18.0.1.1.3",
+    "version": "18.0.1.1.4",
     "summary": "Allows setting clients on credit hold, blocking the ability confirm a new sales order.",
     "category": "Accounting/Accounting",
     "author": "Bemade Inc.",

--- a/account_credit_hold/models/account_followup_report.py
+++ b/account_credit_hold/models/account_followup_report.py
@@ -24,8 +24,10 @@ class FollowUpReport(models.AbstractModel):
             return None
             
         # Generate the PDF report
-        report = self.env.ref('account_credit_hold.account_credit_hold_report_action')
-        pdf_content, _ = report._render_qweb_pdf([partner.id])
+        pdf_content, _ = self.env['ir.actions.report']._render_qweb_pdf(
+            'account_credit_hold.account_credit_hold_report_action',
+            [partner.id],
+        )
         
         # Create attachment
         attachment = self.env['ir.attachment'].create({
@@ -58,15 +60,20 @@ class FollowUpReport(models.AbstractModel):
         # Call the original method
         return super()._send_email(options)
 
+    @api.model
     def _get_main_body(self, options):
         """
         Override to add credit hold information to email body.
         """
         partner = self.env['res.partner'].browse(options.get('partner_id'))
+        # Capture on_hold before super() — super reads followup_line_id which
+        # triggers _compute_followup_status, which may lift the hold for
+        # partners without unreconciled amls.
+        was_on_hold = partner.on_hold
         body = super()._get_main_body(options)
-        
+
         # Add credit hold notice if partner is on hold
-        if partner.on_hold:
+        if was_on_hold:
             credit_hold_notice = _(
                 "<div style='background-color: #fff3cd; border: 1px solid #ffeaa7; padding: 10px; margin: 10px 0; border-radius: 4px;'>"
                 "<strong style='color: #856404;'>⚠️ Credit Hold Notice:</strong> "

--- a/account_credit_hold/models/account_followup_report.py
+++ b/account_credit_hold/models/account_followup_report.py
@@ -52,11 +52,13 @@ class FollowUpReport(models.AbstractModel):
         if partner.on_hold:
             attachment = self._generate_credit_hold_attachment(partner)
             if attachment:
-                # Add attachment to options
-                attachment_ids = options.get('attachment_ids', [])
-                attachment_ids.append((4, attachment.id))
+                # account_followup forwards options['attachment_ids'] to
+                # message_post, which in Odoo 18 requires a flat list of IDs
+                # (no (4, id) commands).
+                attachment_ids = list(options.get('attachment_ids') or [])
+                attachment_ids.append(attachment.id)
                 options['attachment_ids'] = attachment_ids
-        
+
         # Call the original method
         return super()._send_email(options)
 

--- a/account_credit_hold/tests/__init__.py
+++ b/account_credit_hold/tests/__init__.py
@@ -3,3 +3,4 @@ from . import test_credit_hold_views
 from . import test_res_partner
 from . import test_account_credit_hold_email_integration
 from . import test_credit_hold_email_simple
+from . import test_followup_report_regression

--- a/account_credit_hold/tests/test_account_credit_hold_email_integration.py
+++ b/account_credit_hold/tests/test_account_credit_hold_email_integration.py
@@ -193,8 +193,10 @@ class TestAccountCreditHoldEmailIntegration(common.TransactionCase):
         self.assertTrue(self.partner.on_hold)
 
         # Generate PDF
-        report = self.env.ref('account_credit_hold.account_credit_hold_report_action')
-        pdf_content, _ = report._render_qweb_pdf([self.partner.id])
+        pdf_content, _ = self.env['ir.actions.report']._render_qweb_pdf(
+            'account_credit_hold.account_credit_hold_report_action',
+            [self.partner.id],
+        )
 
         # Check that PDF is generated (non-empty content)
         self.assertTrue(len(pdf_content) > 0, "PDF should be generated")

--- a/account_credit_hold/tests/test_credit_hold_email_simple.py
+++ b/account_credit_hold/tests/test_credit_hold_email_simple.py
@@ -179,8 +179,10 @@ class TestAccountCreditHoldEmailSimple(common.TransactionCase):
         self.assertTrue(self.partner.on_hold)
 
         # Generate PDF
-        report = self.env.ref('account_credit_hold.account_credit_hold_report_action')
-        pdf_content, _ = report._render_qweb_pdf([self.partner.id])
+        pdf_content, _ = self.env['ir.actions.report']._render_qweb_pdf(
+            'account_credit_hold.account_credit_hold_report_action',
+            [self.partner.id],
+        )
 
         # Check that PDF is generated (non-empty content)
         self.assertTrue(len(pdf_content) > 0, "PDF should be generated")

--- a/account_credit_hold/tests/test_followup_report_regression.py
+++ b/account_credit_hold/tests/test_followup_report_regression.py
@@ -1,0 +1,218 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for bugs found during the Durpro18 CI integration.
+
+Each test targets a specific bug fixed in 18.0.1.1.3 / 18.0.1.1.4:
+
+  1. ``_render_qweb_pdf`` signature mismatch (must be called on
+     ``ir.actions.report`` with a ``report_ref`` argument).
+  2. ``_get_main_body`` must capture ``partner.on_hold`` *before*
+     calling ``super()``, since the super reads ``followup_line_id``
+     which triggers ``_compute_followup_status``, which may itself
+     lift the hold.
+  3. ``_send_email`` must push raw attachment IDs (not ``(4, id)``
+     ORM commands) into ``options['attachment_ids']`` because
+     ``account_followup`` forwards that dict straight to
+     ``message_post``, which in Odoo 18 rejects ORM commands there.
+"""
+
+from datetime import timedelta
+from unittest.mock import patch
+
+from odoo import Command, fields
+from odoo.tests import common, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestFollowupReportRegression(common.TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.report = cls.env["account.followup.report"]
+
+        cls.partner = cls.env["res.partner"].create({
+            "name": "Regression Customer",
+            "is_company": True,
+            "customer_rank": 1,
+            "email": "regression@example.com",
+        })
+
+        cls.env["account_followup.followup.line"].search([]).unlink()
+        cls.followup_hold = cls.env["account_followup.followup.line"].create({
+            "company_id": cls.env.company.id,
+            "name": "Hold Reminder",
+            "delay": 30,
+            "account_hold": True,
+            "send_email": True,
+        })
+        cls.followup_no_hold = cls.env["account_followup.followup.line"].create({
+            "company_id": cls.env.company.id,
+            "name": "Soft Reminder",
+            "delay": 15,
+            "account_hold": False,
+            "send_email": True,
+        })
+
+    def _create_overdue_invoice(self, partner, amount=1000.0, days_overdue=30):
+        due_date = fields.Date.today() - timedelta(days=days_overdue)
+        invoice = self.env["account.move"].create({
+            "partner_id": partner.id,
+            "move_type": "out_invoice",
+            "invoice_date": due_date,
+            "invoice_date_due": due_date,
+            "invoice_line_ids": [Command.create({
+                "name": "Service",
+                "quantity": 1.0,
+                "price_unit": amount,
+            })],
+        })
+        invoice.action_post()
+        return invoice
+
+    # ------------------------------------------------------------------
+    # Bug 1: _render_qweb_pdf signature
+    # ------------------------------------------------------------------
+
+    def test_generate_credit_hold_attachment_uses_correct_render_signature(self):
+        """``_generate_credit_hold_attachment`` must use the Odoo 18
+        signature ``ir.actions.report._render_qweb_pdf(report_ref, ids)``.
+
+        Previously the code called ``report._render_qweb_pdf([ids])`` on
+        the report record itself, which silently broke in 18.0.
+        """
+        self.partner.action_credit_hold()
+        attachment = self.report._generate_credit_hold_attachment(self.partner)
+        self.assertIsNotNone(attachment)
+        self.assertTrue(attachment.datas)
+        # Decoded payload must be a real PDF.
+        import base64
+        self.assertTrue(base64.b64decode(attachment.datas).startswith(b"%PDF"))
+
+    # ------------------------------------------------------------------
+    # Bug 2: _get_main_body must capture on_hold before super()
+    # ------------------------------------------------------------------
+
+    def test_get_main_body_keeps_notice_when_super_clears_on_hold(self):
+        """``_get_main_body`` must use the on_hold value captured before
+        ``super()``. ``super()._get_main_body`` reads ``followup_line_id``
+        which triggers ``_compute_followup_status``, and if the partner
+        has no unreconciled amls (or a non-hold followup line) that
+        compute will call ``action_lift_credit_hold`` and flip
+        ``on_hold`` to False mid-call. Without the capture the notice
+        would silently disappear.
+        """
+        # Partner with no overdue invoices — _compute_followup_status
+        # returns 'no_action_needed' and clears the hold during super().
+        self.partner.action_credit_hold()
+        self.assertTrue(self.partner.on_hold)
+
+        body = self.report._get_main_body({
+            "partner_id": self.partner.id,
+            "followup_line": self.followup_hold,
+        })
+
+        self.assertIn("Credit Hold Notice", body)
+        # And the compute did fire — confirm the hold is now gone, which
+        # is precisely the condition the ``was_on_hold`` capture defends
+        # against.
+        self.assertFalse(self.partner.on_hold)
+
+    def test_get_main_body_no_notice_when_partner_never_on_hold(self):
+        """Sanity counterpart: when the partner was never on hold, no
+        notice is added even if super() doesn't change anything."""
+        self.partner.action_lift_credit_hold()
+        self.assertFalse(self.partner.on_hold)
+
+        body = self.report._get_main_body({
+            "partner_id": self.partner.id,
+            "followup_line": self.followup_no_hold,
+        })
+        self.assertNotIn("Credit Hold Notice", body)
+
+    # ------------------------------------------------------------------
+    # Bug 3: attachment_ids must be a flat list of IDs
+    # ------------------------------------------------------------------
+
+    def test_send_email_pushes_flat_attachment_ids(self):
+        """``_send_email`` must push raw IDs into
+        ``options['attachment_ids']``. In Odoo 18 ``message_post``
+        explicitly rejects ``(4, id)`` ORM commands here with::
+
+            ValueError: Posting a message should receive attachments
+            records as a list of IDs
+
+        We patch the parent ``_send_email`` to inspect what our
+        override hands up the chain, so the test pins the contract
+        regardless of whether the upstream call later succeeds or not.
+        """
+        self.partner.action_credit_hold()
+        self.assertTrue(self.partner.on_hold)
+
+        captured = {}
+
+        def fake_super_send_email(self_inner, options):
+            captured["attachment_ids"] = list(options.get("attachment_ids") or [])
+            return True
+
+        # Patch the parent class (account_followup) directly so we
+        # intercept after our override has populated attachment_ids.
+        from odoo.addons.account_followup.models.account_followup_report import (
+            AccountFollowupReport,
+        )
+        with patch.object(
+            AccountFollowupReport, "_send_email", fake_super_send_email
+        ):
+            self.report._send_email({
+                "partner_id": self.partner.id,
+                "followup_line": self.followup_hold,
+                "send_email": True,
+            })
+
+        self.assertIn("attachment_ids", captured)
+        self.assertTrue(captured["attachment_ids"],
+                        "An attachment ID should have been added for an on-hold partner")
+        for item in captured["attachment_ids"]:
+            self.assertIsInstance(
+                item, int,
+                f"attachment_ids must contain raw IDs, got {item!r} "
+                f"(probably a (4, id) ORM command — that raises ValueError "
+                f"in message_post in Odoo 18)",
+            )
+
+    def test_send_email_preserves_existing_attachment_ids(self):
+        """If the caller already pre-populated ``attachment_ids`` with
+        raw IDs, our override must append to that list rather than
+        replacing it or wrapping the new entry in a tuple."""
+        self.partner.action_credit_hold()
+        existing_attachment = self.env["ir.attachment"].create({
+            "name": "pre-existing.txt",
+            "type": "binary",
+            "datas": b"aGVsbG8=",  # 'hello' base64
+            "res_model": "res.partner",
+            "res_id": self.partner.id,
+        })
+
+        captured = {}
+
+        def fake_super_send_email(self_inner, options):
+            captured["attachment_ids"] = list(options.get("attachment_ids") or [])
+            return True
+
+        from odoo.addons.account_followup.models.account_followup_report import (
+            AccountFollowupReport,
+        )
+        with patch.object(
+            AccountFollowupReport, "_send_email", fake_super_send_email
+        ):
+            self.report._send_email({
+                "partner_id": self.partner.id,
+                "followup_line": self.followup_hold,
+                "send_email": True,
+                "attachment_ids": [existing_attachment.id],
+            })
+
+        self.assertIn(existing_attachment.id, captured["attachment_ids"])
+        self.assertGreaterEqual(len(captured["attachment_ids"]), 2,
+                                "Override should append, not replace")
+        for item in captured["attachment_ids"]:
+            self.assertIsInstance(item, int)

--- a/account_credit_hold/tests/test_res_partner.py
+++ b/account_credit_hold/tests/test_res_partner.py
@@ -185,12 +185,15 @@ class TestResPartnerCreditHold(common.TransactionCase):
         self.assertAlmostEqual(partner.total_due, 500.0, places=2)
 
     def _force_followup_line(self, partner, followup_line_id):
-        """Write followup_line_id directly in SQL to bypass computed field readonly checks."""
-        self.env.cr.execute(
-            "UPDATE res_partner SET followup_line_id = %s WHERE id = %s",
-            (followup_line_id, partner.id),
-        )
-        partner.invalidate_recordset(['followup_line_id'])
+        """Set followup_line_id via direct assignment.
+
+        followup_line_id is a non-stored computed field with an inverse method,
+        so direct assignment caches the value (the inverse is a no-op for
+        partners with no unreconciled amls, which is the case in these tests).
+        """
+        line = self.env['account_followup.followup.line'].browse(followup_line_id) \
+            if followup_line_id else self.env['account_followup.followup.line']
+        partner.followup_line_id = line
 
     # ------------------------------------------------------------------
     # _should_hold


### PR DESCRIPTION
## Summary

Trois bugs dans `account_credit_hold` détectés via la CI Durpro18 mais masqués par la CI bemade-addons isolée (qui ne charge pas `durpro_sale_bemade_fsm`).

## Bugs corrigés

### 1. `_render_qweb_pdf` signature Odoo 18 (3 sites)
Le code appelait `report._render_qweb_pdf([partner.id])` en passant la liste comme `report_ref`. L'override `durpro_sale_bemade_fsm/models/ir_actions_report.py:_get_report(report_ref)` échouait avec `'list' object has no attribute 'split'`.

**Fix** : signature standard `_render_qweb_pdf('xml.id', [ids])`.

Fichiers : `models/account_followup_report.py:28`, `tests/test_credit_hold_email_simple.py:183`, `tests/test_account_credit_hold_email_integration.py:197`.

### 2. `_get_main_body` perdait `on_hold` avant le check
`super()._get_main_body(options)` lit `partner.followup_line_id` qui déclenche `_compute_followup_status`, lequel appelle `action_lift_credit_hold` pour les partenaires sans `unreconciled_aml_ids`, effaçant `on_hold`. La notice « Credit Hold Notice » n'était jamais ajoutée au body.

**Fix** : capturer `was_on_hold = partner.on_hold` AVANT le `super()`.

### 3. `_force_followup_line` via SQL UPDATE
`followup_line_id` est un champ **computed non-stored** dans `account_followup` enterprise — il n'y a pas de colonne SQL `followup_line_id`. Le `UPDATE res_partner SET followup_line_id = ...` échouait avec `UndefinedColumn`.

**Fix** : assignation directe `partner.followup_line_id = line` (le field a un inverse qui est no-op pour partenaires sans unreconciled amls).

## Test plan
- [ ] CI verte (`Test Repo Addons With Odoo`)
- [ ] Vérifier que les ~20 tests `account_credit_hold` passent côté Durpro18

🤖 Generated with [Claude Code](https://claude.com/claude-code)