### PR TITLE
test(account_credit_hold): re-establish credit hold each loop iteration

### DIFF
--- a/account_credit_hold/__manifest__.py
+++ b/account_credit_hold/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Account Credit Hold",
-    "version": "18.0.1.1.7",
+    "version": "18.0.1.1.8",
     "summary": "Allows setting clients on credit hold, blocking the ability confirm a new sales order.",
     "category": "Accounting/Accounting",
     "author": "Bemade Inc.",

--- a/account_credit_hold/tests/test_account_credit_hold_email_integration.py
+++ b/account_credit_hold/tests/test_account_credit_hold_email_integration.py
@@ -86,13 +86,14 @@ class TestAccountCreditHoldEmailIntegration(common.TransactionCase):
         
         for i, followup_line in enumerate(followup_lines):
             with self.subTest(followup_line=followup_line):
-                # Clear pre-existing credit hold attachments. We search by
-                # name only — ``message_post`` re-parents attachments to
-                # the posted message, so filtering by res_partner alone
-                # would miss any leftover from a previous iteration.
+                # Clear pre-existing credit hold attachments.
                 self.env["ir.attachment"].search(
                     [("name", "like", "Credit_Hold_Report%")]
                 ).unlink()
+                # Re-establish the hold each iteration: super()._send_email
+                # triggers _compute_followup_status which lifts the hold
+                # once the followup has been sent (correct business logic).
+                self.partner.action_credit_hold()
 
                 # Send followup email
                 options = {
@@ -228,11 +229,12 @@ class TestAccountCreditHoldEmailIntegration(common.TransactionCase):
         attachment_count = 0
 
         for i, followup_line in enumerate(followup_lines):
-            # Clear pre-existing credit hold attachments — search by name
-            # only (see other test for the message_post re-parenting note).
+            # Clear pre-existing credit hold attachments.
             self.env["ir.attachment"].search(
                 [("name", "like", "Credit_Hold_Report%")]
             ).unlink()
+            # Re-establish the hold each iteration (see other test).
+            self.partner.action_credit_hold()
 
             # Send followup email
             options = {

--- a/account_credit_hold/tests/test_credit_hold_email_simple.py
+++ b/account_credit_hold/tests/test_credit_hold_email_simple.py
@@ -212,13 +212,14 @@ class TestAccountCreditHoldEmailSimple(common.TransactionCase):
         followup_lines = [self.followup_line_no_hold, self.followup_line_hold]
         
         for followup_line in followup_lines:
-            # Clear pre-existing credit hold attachments — search by name
-            # only because ``message_post`` re-parents attachments to the
-            # posted ``mail.message``, so filtering by res_partner alone
-            # would miss them.
+            # Clear pre-existing credit hold attachments.
             self.env["ir.attachment"].search(
                 [("name", "like", "Credit_Hold_Report%")]
             ).unlink()
+            # Re-establish the hold each iteration: super()._send_email
+            # triggers _compute_followup_status which lifts the hold once
+            # the followup has just been sent (correct business logic).
+            self.partner.action_credit_hold()
 
             options = {
                 "partner_id": self.partner.id,


### PR DESCRIPTION
## Summary
3 tests bouclent sur les followup_lines et appellent \`_send_email\` à chaque iteration. Après le 1er appel, \`_compute_followup_status\` (déclenché via \`super()._send_email\` qui lit \`partner.followup_line_id\`) lift le hold — comportement business correct, le followup vient d'être envoyé.

Les tests supposaient que le hold restait set entre iterations, ce qui crashait silencieusement avec le bug \`_render_qweb_pdf\` (le test n'allait jamais aussi loin). Maintenant ça FAIL au 2ème iteration avec 0 attachments.

Fix : ré-appeler \`action_credit_hold()\` au début de chaque iteration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)