### PR TITLE
test(account_credit_hold): seed active_model for manual_reminder wizard test

### DIFF
--- a/account_credit_hold/__manifest__.py
+++ b/account_credit_hold/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Account Credit Hold",
-    "version": "18.0.1.1.8",
+    "version": "18.0.1.1.9",
     "summary": "Allows setting clients on credit hold, blocking the ability confirm a new sales order.",
     "category": "Accounting/Accounting",
     "author": "Bemade Inc.",

--- a/account_credit_hold/tests/test_account_credit_hold_email_integration.py
+++ b/account_credit_hold/tests/test_account_credit_hold_email_integration.py
@@ -257,19 +257,22 @@ class TestAccountCreditHoldEmailIntegration(common.TransactionCase):
         self.assertEqual(attachment_count, len(followup_lines))
 
     def test_manual_followup_wizard_shows_credit_hold_status(self):
-        """Test that manual followup wizard shows credit hold status"""
-        # Place partner on credit hold
+        """Test that manual followup wizard shows credit hold status."""
         self.partner.action_credit_hold()
         self.assertTrue(self.partner.on_hold)
 
-        # Create manual reminder
-        wizard = self.env["account_followup.manual_reminder"].create({
+        # account_followup.manual_reminder.default_get asserts
+        # active_model == 'res.partner' and reads active_ids, so we have
+        # to seed both in the context — that's how the wizard is launched
+        # from the partner form in the UI.
+        wizard = self.env["account_followup.manual_reminder"].with_context(
+            active_model='res.partner',
+            active_ids=self.partner.ids,
+            active_id=self.partner.id,
+        ).create({
             "partner_id": self.partner.id,
-            "followup_line_id": self.followup_line_hold.id,
         })
 
-        # Check that wizard form shows credit hold warning
-        # This would be tested in the UI, but we can check the context
         self.assertTrue(wizard.partner_id.on_hold)
 
     def test_credit_hold_field_deprecated_but_functional(self):


### PR DESCRIPTION
## Summary
\`account_followup.manual_reminder.default_get\` asserte \`active_model == 'res.partner'\` et lit \`active_ids\` — c'est ainsi que le wizard est lancé depuis le formulaire partner. Le test ne seedait ni l'un ni l'autre dans le context → \`KeyError: 'active_model'\`.

Fix : \`with_context(active_model='res.partner', active_ids=...)\` au create du wizard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)