### PR TITLE
ci: run tests on all major version branches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,10 +3,10 @@ name: tests
 on:
   pull_request:
     branches:
-      - "17.0-test-ci"
+      - "*.0"
   push:
     branches:
-      - "17.0-test-ci"
+      - "*.0"
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- The test workflow was gated to the `17.0-test-ci` branch only, so merges into `19.0` (and other version branches) skipped CI entirely — which is how a broken merge into `19.0` slipped through and only surfaced downstream in ~/src/rwi.
- Broaden the `push` / `pull_request` triggers to any `*.0` branch so every major version branch runs tests. Feature branches (e.g. `18.0-mig-foo`) still get tested when they PR into their `*.0` base.

## Test plan
- [ ] Verify the workflow runs on this PR (PR targets `19.0`, which now matches the trigger).
- [ ] After merge, confirm a subsequent push to `19.0` triggers the workflow.