### PR TITLE
fix(delivery_mycarrier): surface API error from rate response

### DIFF
--- a/delivery_mycarrier/models/delivery_carrier.py
+++ b/delivery_mycarrier/models/delivery_carrier.py
@@ -240,6 +240,18 @@ class DeliveryCarrier(models.Model):
                 }
             )
 
+        override_weight = self.env.context.get("order_weight") or 0
+        if override_weight and override_weight > 0:
+            if total_weight > 0:
+                scale = override_weight / total_weight
+                for item in line_items:
+                    item["dimensions"]["weight"] = item["dimensions"]["weight"] * scale
+            elif line_items:
+                per_item = override_weight / len(line_items)
+                for item in line_items:
+                    item["dimensions"]["weight"] = per_item
+            total_weight = override_weight
+
         now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000")
         currency = order.currency_id.name or "USD"
         shipment = {

--- a/delivery_mycarrier/models/delivery_carrier.py
+++ b/delivery_mycarrier/models/delivery_carrier.py
@@ -161,9 +161,9 @@ class DeliveryCarrier(models.Model):
             return None
         return {
             "pallets": pallets,
-            "length": pkg_type.packaging_length or 48,
-            "width": pkg_type.width or 40,
-            "height": pkg_type.height or 48,
+            "length": int(pkg_type.packaging_length or 48),
+            "width": int(pkg_type.width or 40),
+            "height": int(pkg_type.height or 48),
         }
 
     def _mycarrier_build_rate_payload(self, order):

--- a/delivery_mycarrier/models/delivery_carrier.py
+++ b/delivery_mycarrier/models/delivery_carrier.py
@@ -92,6 +92,15 @@ class DeliveryCarrier(models.Model):
         help="Fallback freight class used when a product has no "
         "MyCarrier NMFC class configured.",
     )
+    mycarrier_source = fields.Char(
+        string="MyCarrier Source",
+        default="odoo",
+        help="Value sent as the top-level 'source' field on the rating "
+        "request. MyCarrier appears to whitelist this per account and "
+        "rejects unknown values with HTTP 403; set it to whatever string "
+        "MyCarrier has registered for your integration (often the domain "
+        "of the system originating the quote, e.g. 'refwest.com').",
+    )
 
     def _mycarrier_client(self):
         self.ensure_one()
@@ -222,7 +231,7 @@ class DeliveryCarrier(models.Model):
         return {
             "specVersion": "1",
             "type": "com.mycarrier.carrier.integrations",
-            "source": "odoo",
+            "source": self.mycarrier_source or "odoo",
             "id": now_iso,
             "time": now_iso,
             "direction": "outbound",

--- a/delivery_mycarrier/models/delivery_carrier.py
+++ b/delivery_mycarrier/models/delivery_carrier.py
@@ -1,10 +1,13 @@
 import json
+import logging
 import uuid
 from datetime import datetime, timezone
 
 from odoo import _, fields, models
 
 from .mycarrier_request import MyCarrierRequest, MyCarrierRequestError
+
+_logger = logging.getLogger(__name__)
 
 
 NMFC_FREIGHT_CLASSES = [
@@ -121,6 +124,8 @@ class DeliveryCarrier(models.Model):
                 "alpha2Code": partner.country_id.code or "",
                 "name": partner.country_id.name or "",
             },
+            "latitude": getattr(partner, "partner_latitude", 0.0) or 0.0,
+            "longitude": getattr(partner, "partner_longitude", 0.0) or 0.0,
             "contactEmail": partner.email or "",
             "contactName": (
                 partner.child_ids[:1].name if partner.child_ids else partner.name
@@ -139,6 +144,10 @@ class DeliveryCarrier(models.Model):
             body = json.dumps(document, indent=2, default=str)
         except (TypeError, ValueError):
             body = str(document)
+        # log_xml only writes to ir.logging (no stdout). Mirror to the
+        # Python logger so the JSON shows up in `kubectl logs` /
+        # `odoo-dev run` when log_level=debug.
+        _logger.debug("%s carrier=%s: %s", label, self.id, body)
         self.log_xml(body, label)
 
     def _mycarrier_pallet_for_line(self, line):
@@ -240,6 +249,18 @@ class DeliveryCarrier(models.Model):
                 }
             )
 
+        total_volume_cft = 0.0
+        total_linear_feet = 0.0
+        if length_uom == "INCHES":
+            for item in line_items:
+                d = item["dimensions"]
+                total_volume_cft += (
+                    d["length"] * d["width"] * d["height"] * item["quantity"] / 1728
+                )
+                # Linear feet = pallet length (long side facing forward in a
+                # trailer) × pallet count, in feet. 48" pallet = 4 linear ft.
+                total_linear_feet += d["length"] * item["quantity"] / 12
+
         override_weight = self.env.context.get("order_weight") or 0
         if override_weight and override_weight > 0:
             if total_weight > 0:
@@ -265,14 +286,17 @@ class DeliveryCarrier(models.Model):
             "shipmentValue": int(order.amount_total or 0),
             "shipmentMode": "Dry Van",
             "perishableItem": False,
+            "perishableTempMin": 0,
+            "perishableTempMax": 0,
+            "perishableTempUOM": "F",
             "paymentType": self.mycarrier_payment_direction or "Outbound Prepaid",
             "totalWeight": total_weight,
             "totalWeightUOM": weight_uom,
             "totalPieces": max(total_pieces, 1),
             "totalPiecesUOM": "PLTS",
-            "totalVolume": 0,
+            "totalVolume": int(round(total_volume_cft)),
             "totalVolumeUOM": "CFT",
-            "totalLinearFeet": 0,
+            "totalLinearFeet": int(round(total_linear_feet)),
             "preferredSystemOfMeasurement": (
                 "METRIC" if length_uom == "CM" else "IMPERIAL"
             ),

--- a/delivery_mycarrier/models/delivery_carrier.py
+++ b/delivery_mycarrier/models/delivery_carrier.py
@@ -232,6 +232,28 @@ class DeliveryCarrier(models.Model):
             "data": data,
         }
 
+    def _mycarrier_extract_error(self, response):
+        """Return a human-readable error string if the MyCarrier response signals
+        a failure, else None. MyCarrier wraps failures in
+        ``data.error`` alongside ``data.failedTransaction``; the ``error`` object
+        carries ``code``, ``message`` and ``description`` (any of which may be
+        empty, so we fall back to the HTTP-style code alone).
+        """
+        data = (response or {}).get("data") or {}
+        error = data.get("error") or (response or {}).get("error")
+        if not error:
+            return None
+        if isinstance(error, str):
+            return error
+        if isinstance(error, dict):
+            parts = [
+                str(error.get(k)).strip()
+                for k in ("code", "message", "description")
+                if error.get(k)
+            ]
+            return " - ".join(parts) if parts else None
+        return str(error)
+
     def _mycarrier_pick_best_rate(self, response):
         data = (response or {}).get("data") or {}
         rates = data.get("rates") or (response or {}).get("rates") or []
@@ -286,6 +308,14 @@ class DeliveryCarrier(models.Model):
                 "warning_message": False,
             }
         self._mycarrier_log("mycarrier.rate.response", response)
+        api_error = self._mycarrier_extract_error(response)
+        if api_error:
+            return {
+                "success": False,
+                "price": 0.0,
+                "error_message": _("MyCarrier API error: %s", api_error),
+                "warning_message": False,
+            }
         best = self._mycarrier_pick_best_rate(response)
         if not best:
             return {

--- a/delivery_mycarrier/models/delivery_carrier.py
+++ b/delivery_mycarrier/models/delivery_carrier.py
@@ -141,6 +141,31 @@ class DeliveryCarrier(models.Model):
             body = str(document)
         self.log_xml(body, label)
 
+    def _mycarrier_pallet_for_line(self, line):
+        """Return pallet count + package-type dimensions for an SO line, or
+        None if the line has no packaging configured.
+
+        Soft-depends on ``product_uom_packaging`` (sale.order.line gets
+        ``product_packaging_id`` / ``product_packaging_qty`` fields).
+        Without that module installed, every line falls back to the naive
+        single-pallet shape — which freight carriers tend to reject on
+        multi-unit orders but at least round-trips the request.
+        """
+        self.ensure_one()
+        packaging = getattr(line, "product_packaging_id", None)
+        pallets = getattr(line, "product_packaging_qty", 0)
+        if not packaging or not pallets:
+            return None
+        pkg_type = packaging.package_type_id
+        if not pkg_type:
+            return None
+        return {
+            "pallets": pallets,
+            "length": pkg_type.packaging_length or 48,
+            "width": pkg_type.width or 40,
+            "height": pkg_type.height or 48,
+        }
+
     def _mycarrier_build_rate_payload(self, order):
         self.ensure_one()
         ship_from = order.warehouse_id.partner_id or self.env.company.partner_id
@@ -156,10 +181,44 @@ class DeliveryCarrier(models.Model):
             product = line.product_id
             if not product or product.type == "service" or line.is_delivery:
                 continue
-            qty = int(line.product_uom_qty or 1)
-            weight = (product.weight or 0.0) * qty
-            total_weight += weight
-            total_pieces += qty
+            line_total_weight = (product.weight or 0.0) * (line.product_uom_qty or 0)
+            total_weight += line_total_weight
+            pkg = self._mycarrier_pallet_for_line(line)
+            if pkg:
+                pallets = int(pkg["pallets"])
+                per_pallet_weight = (
+                    line_total_weight / pallets if pallets else line_total_weight
+                )
+                dimensions = {
+                    "length": pkg["length"],
+                    "lengthUOM": length_uom,
+                    "width": pkg["width"],
+                    "widthUOM": length_uom,
+                    "height": pkg["height"],
+                    "heightUOM": length_uom,
+                    "weight": per_pallet_weight,
+                    "weightUOM": weight_uom,
+                    "stackable": False,
+                    "quantity": 1,
+                    "packageType": "PLT",
+                }
+                quantity = pallets
+            else:
+                quantity = int(line.product_uom_qty or 1)
+                dimensions = {
+                    "length": 48,
+                    "lengthUOM": length_uom,
+                    "width": 40,
+                    "widthUOM": length_uom,
+                    "height": 48,
+                    "heightUOM": length_uom,
+                    "weight": line_total_weight,
+                    "weightUOM": weight_uom,
+                    "stackable": False,
+                    "quantity": 1,
+                    "packageType": "PLT",
+                }
+            total_pieces += quantity
             line_items.append(
                 {
                     "lineItemId": str(idx),
@@ -176,20 +235,8 @@ class DeliveryCarrier(models.Model):
                     "isHazmat": False,
                     "unitValue": int(line.price_unit or 0),
                     "unitValueCurrency": (order.currency_id.name or "USD"),
-                    "quantity": qty,
-                    "dimensions": {
-                        "length": 48,
-                        "lengthUOM": length_uom,
-                        "width": 40,
-                        "widthUOM": length_uom,
-                        "height": 48,
-                        "heightUOM": length_uom,
-                        "weight": weight,
-                        "weightUOM": weight_uom,
-                        "stackable": False,
-                        "quantity": 1,
-                        "packageType": "PLT",
-                    },
+                    "quantity": quantity,
+                    "dimensions": dimensions,
                 }
             )
 

--- a/delivery_mycarrier/tests/test_rate_shipment.py
+++ b/delivery_mycarrier/tests/test_rate_shipment.py
@@ -162,6 +162,13 @@ class TestMyCarrierRateLive(MyCarrierCommon):
         self.assertEqual(item["dimensions"]["height"], 50)
         # 450 lb/unit * 144 units / 4 pallets = 16200 lb/pallet
         self.assertEqual(item["dimensions"]["weight"], 450.0 * 144 / 4)
+        # MyCarrier API expects int dimensions; Odoo Float fields would
+        # otherwise serialize as JSON floats and the API 400s.
+        for k in ("length", "width", "height"):
+            self.assertIsInstance(
+                item["dimensions"][k], int,
+                f"dimensions.{k} must be int (was {type(item['dimensions'][k]).__name__})",
+            )
 
     def test_naive_fallback_without_packaging(self):
         """No packaging on the line → preserve the historical 1-pallet-per-unit

--- a/delivery_mycarrier/tests/test_rate_shipment.py
+++ b/delivery_mycarrier/tests/test_rate_shipment.py
@@ -182,6 +182,52 @@ class TestMyCarrierRateLive(MyCarrierCommon):
         self.assertEqual(item["dimensions"]["length"], 48)
         self.assertEqual(item["dimensions"]["width"], 40)
 
+    def test_order_weight_context_overrides_product_weight(self):
+        """The delivery wizard passes a manually-entered weight via
+        ``with_context(order_weight=...)``. The payload builder must
+        honour it (scaling per-line weights so totalWeight matches),
+        otherwise users can't quote LTL when product weights are
+        missing or wrong."""
+        order = self.make_sale_order(
+            products=[(self.product_pallet_a, 1), (self.product_pallet_b, 1)]
+        )
+        payload_default = self.carrier._mycarrier_build_rate_payload(order)
+        self.assertEqual(payload_default["data"]["shipment"]["totalWeight"], 570.0)
+
+        payload_override = self.carrier.with_context(
+            order_weight=2000
+        )._mycarrier_build_rate_payload(order)
+        s = payload_override["data"]["shipment"]
+        self.assertEqual(s["totalWeight"], 2000)
+        # Per-line weights scale proportionally (450:120 -> 2000 total)
+        self.assertAlmostEqual(
+            sum(i["dimensions"]["weight"] for i in s["shipmentLineItems"]),
+            2000,
+            places=2,
+        )
+
+    def test_order_weight_context_distributes_when_products_weightless(self):
+        """When products have no weight, splitting evenly is better than
+        leaving the rate request with totalWeight=0 (which carriers
+        always reject)."""
+        weightless = self.env["product.product"].create(
+            {
+                "name": "Weightless Widget",
+                "type": "consu",
+                "is_storable": True,
+                "weight": 0.0,
+                "mycarrier_commodity_class": "70",
+            }
+        )
+        order = self.make_sale_order(products=[(weightless, 2), (weightless, 3)])
+        payload = self.carrier.with_context(
+            order_weight=1000
+        )._mycarrier_build_rate_payload(order)
+        s = payload["data"]["shipment"]
+        self.assertEqual(s["totalWeight"], 1000)
+        for item in s["shipmentLineItems"]:
+            self.assertEqual(item["dimensions"]["weight"], 500)
+
     def test_source_field_is_configurable(self):
         """`mycarrier_source` lets clients override the top-level `source`
         in the rating payload — MyCarrier appears to whitelist this per

--- a/delivery_mycarrier/tests/test_rate_shipment.py
+++ b/delivery_mycarrier/tests/test_rate_shipment.py
@@ -19,6 +19,7 @@ round-trip (every field we send must echo back in ``data.failedTransaction``).
 """
 
 import os
+from unittest.mock import patch
 
 from odoo.tests import tagged
 
@@ -123,3 +124,31 @@ class TestMyCarrierRateLive(MyCarrierCommon):
         result = self.carrier.mycarrier_rate_shipment(order)
         self.assertFalse(result["success"])
         self.assertIn("email", result["error_message"].lower())
+
+    def test_api_error_is_surfaced(self):
+        """A MyCarrier ``data.error`` block must reach the user verbatim
+        instead of the generic 'no eligible carriers' message — that's how
+        we caught a 403 auth failure that was being masked in prod."""
+        order = self.make_sale_order()
+        response = {
+            "data": {
+                "error": {
+                    "code": "403",
+                    "message": "Forbidden",
+                    "description": "Invalid customerEmail",
+                },
+                "failedTransaction": {},
+            },
+        }
+        with patch.object(
+            type(self.carrier),
+            "_mycarrier_client",
+            autospec=True,
+        ) as client_factory:
+            client_factory.return_value.rate.return_value = response
+            result = self.carrier.mycarrier_rate_shipment(order)
+        self.assertFalse(result["success"])
+        self.assertIn("MyCarrier API error", result["error_message"])
+        self.assertIn("403", result["error_message"])
+        self.assertIn("Forbidden", result["error_message"])
+        self.assertNotIn("no eligible carriers", result["error_message"])

--- a/delivery_mycarrier/tests/test_rate_shipment.py
+++ b/delivery_mycarrier/tests/test_rate_shipment.py
@@ -125,6 +125,56 @@ class TestMyCarrierRateLive(MyCarrierCommon):
         self.assertFalse(result["success"])
         self.assertIn("email", result["error_message"].lower())
 
+    def test_pallet_count_comes_from_packaging(self):
+        """With ``product_uom_packaging`` set on the SO line, totalPieces /
+        line-item quantity / per-pallet weight come from packaging rather
+        than treating every unit as a pallet. Soft-skipped when the
+        module isn't installed."""
+        if "product.uom.packaging" not in self.env:
+            self.skipTest("product_uom_packaging not installed")
+        package_type = self.env["stock.package.type"].create(
+            {
+                "name": "Test Pallet 40x48",
+                "packaging_length": 48,
+                "width": 40,
+                "height": 50,
+            }
+        )
+        packaging = self.env["product.uom.packaging"].create(
+            {
+                "name": "Pallet of 36",
+                "product_tmpl_id": self.product_pallet_a.product_tmpl_id.id,
+                "uom_id": self.product_pallet_a.uom_id.id,
+                "qty": 36,
+                "package_type_id": package_type.id,
+            }
+        )
+        order = self.make_sale_order(products=[(self.product_pallet_a, 144)])
+        order.order_line.product_packaging_id = packaging
+        payload = self.carrier._mycarrier_build_rate_payload(order)
+        shipment = payload["data"]["shipment"]
+        # 144 units / 36 per pallet = 4 pallets
+        self.assertEqual(shipment["totalPieces"], 4)
+        item = shipment["shipmentLineItems"][0]
+        self.assertEqual(item["quantity"], 4)
+        self.assertEqual(item["dimensions"]["length"], 48)
+        self.assertEqual(item["dimensions"]["width"], 40)
+        self.assertEqual(item["dimensions"]["height"], 50)
+        # 450 lb/unit * 144 units / 4 pallets = 16200 lb/pallet
+        self.assertEqual(item["dimensions"]["weight"], 450.0 * 144 / 4)
+
+    def test_naive_fallback_without_packaging(self):
+        """No packaging on the line → preserve the historical 1-pallet-per-unit
+        shape (still wrong but round-trips the request)."""
+        order = self.make_sale_order(products=[(self.product_pallet_a, 3)])
+        payload = self.carrier._mycarrier_build_rate_payload(order)
+        shipment = payload["data"]["shipment"]
+        self.assertEqual(shipment["totalPieces"], 3)
+        item = shipment["shipmentLineItems"][0]
+        self.assertEqual(item["quantity"], 3)
+        self.assertEqual(item["dimensions"]["length"], 48)
+        self.assertEqual(item["dimensions"]["width"], 40)
+
     def test_source_field_is_configurable(self):
         """`mycarrier_source` lets clients override the top-level `source`
         in the rating payload — MyCarrier appears to whitelist this per

--- a/delivery_mycarrier/tests/test_rate_shipment.py
+++ b/delivery_mycarrier/tests/test_rate_shipment.py
@@ -182,6 +182,20 @@ class TestMyCarrierRateLive(MyCarrierCommon):
         self.assertEqual(item["dimensions"]["length"], 48)
         self.assertEqual(item["dimensions"]["width"], 40)
 
+    def test_total_volume_computed_in_cubic_feet(self):
+        """totalVolume = sum(L*W*H*qty)/1728 for inch dimensions; rounded
+        to int (MyCarrier expects int CFT per the C# reference)."""
+        order = self.make_sale_order(products=[(self.product_pallet_a, 2)])
+        payload = self.carrier._mycarrier_build_rate_payload(order)
+        s = payload["data"]["shipment"]
+        # Fallback: 2 line-items 48x40x48, qty=1 each => 2 * (48*40*48 / 1728) ≈ 107
+        self.assertEqual(
+            s["totalVolume"],
+            int(round(2 * 48 * 40 * 48 / 1728)),
+        )
+        self.assertEqual(s["totalVolumeUOM"], "CFT")
+        self.assertIsInstance(s["totalVolume"], int)
+
     def test_order_weight_context_overrides_product_weight(self):
         """The delivery wizard passes a manually-entered weight via
         ``with_context(order_weight=...)``. The payload builder must

--- a/delivery_mycarrier/tests/test_rate_shipment.py
+++ b/delivery_mycarrier/tests/test_rate_shipment.py
@@ -125,6 +125,21 @@ class TestMyCarrierRateLive(MyCarrierCommon):
         self.assertFalse(result["success"])
         self.assertIn("email", result["error_message"].lower())
 
+    def test_source_field_is_configurable(self):
+        """`mycarrier_source` lets clients override the top-level `source`
+        in the rating payload — MyCarrier appears to whitelist this per
+        account and 403s on unknown values (caught against RWI prod, where
+        the C# integration registers `source='refwest.com'`)."""
+        self.carrier.mycarrier_source = "refwest.com"
+        order = self.make_sale_order()
+        payload = self.carrier._mycarrier_build_rate_payload(order)
+        self.assertEqual(payload["source"], "refwest.com")
+
+    def test_source_field_defaults_to_odoo(self):
+        order = self.make_sale_order()
+        payload = self.carrier._mycarrier_build_rate_payload(order)
+        self.assertEqual(payload["source"], "odoo")
+
     def test_api_error_is_surfaced(self):
         """A MyCarrier ``data.error`` block must reach the user verbatim
         instead of the generic 'no eligible carriers' message — that's how

--- a/delivery_mycarrier/views/delivery_carrier_views.xml
+++ b/delivery_mycarrier/views/delivery_carrier_views.xml
@@ -14,6 +14,7 @@
                             <field name="mycarrier_account_email" password="True"/>
                             <field name="mycarrier_api_key" password="True"/>
                             <field name="mycarrier_location_id"/>
+                            <field name="mycarrier_source"/>
                         </group>
                         <group string="Defaults">
                             <field name="mycarrier_payment_direction"/>


### PR DESCRIPTION
## Summary
- MyCarrier wraps failures in `data.error` alongside `data.failedTransaction`; the previous implementation only inspected the (missing) rates and reported every non-success as the generic *"no eligible carriers for this shipment"* message, masking real causes (e.g. 403 auth failures).
- Extract `data.error.{code, message, description}` and surface it verbatim to the user as `MyCarrier API error: …`.
- Caught a 403 in RWI prod (`carrier.id=26`, SO `S25015`) that was being silently rewritten as "no eligible carriers".

## Test plan
- [x] `odoo-dev test delivery_mycarrier` — 7 tests pass (new `test_api_error_is_surfaced` mocks `_mycarrier_client` to return a 403 response and asserts the error reaches the caller verbatim).