### PR TITLE
fix(account_credit_hold): stop redeclaring followup_status Selection

### DIFF
--- a/account_credit_hold/__manifest__.py
+++ b/account_credit_hold/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Account Credit Hold",
-    "version": "18.0.1.1.10",
+    "version": "18.0.1.1.11",
     "summary": "Allows setting clients on credit hold, blocking the ability confirm a new sales order.",
     "category": "Accounting/Accounting",
     "author": "Bemade Inc.",

--- a/account_credit_hold/models/res_partner.py
+++ b/account_credit_hold/models/res_partner.py
@@ -24,11 +24,15 @@ class ResPartner(models.Model):
         string="Postpone Hold Until",
         help="Temporarily postpone credit hold until this date.",
     )
-    followup_status = fields.Selection([
-        ('no_action_needed', 'No Action Needed'),
-        ('in_need_of_action', 'In Need of Action'),
-        ('overdue', 'Overdue'),
-    ], string="Followup Status", compute="_compute_followup_status", store=True)
+    # NOTE: do NOT redeclare followup_status here. Odoo Enterprise 18
+    # defines it as a non-stored Selection with values
+    # ('in_need_of_action', 'with_overdue_invoices', 'no_action_needed').
+    # Redeclaring it as stored with a different value set caused
+    #   ValueError: Wrong value for res.partner.followup_status: 'with_overdue_invoices'
+    # at upgrade time, when the parent _compute_followup_status wrote
+    # 'with_overdue_invoices' into our cached Selection that didn't
+    # know that value. Use the parent field as-is — we only ever read
+    # 'no_action_needed' from it in _compute_hold_bg.
     total_due = fields.Float(
         string="Total Due",
         compute="_compute_total_due",


### PR DESCRIPTION
## Bug
Sur l'étape \`upgrade-modules\` du pipeline Durpro18 #3433 (durpro-staging) :

\`\`\`
ValueError: Wrong value for res.partner.followup_status: 'with_overdue_invoices'
File "account_credit_hold/models/res_partner.py", line 123, in _compute_followup_status
    super()._compute_followup_status()
File "enterprise/account_followup/models/res_partner.py", line 120
    partner.followup_status = partner_data['followup_status']
\`\`\`

## Cause
Odoo Enterprise 18 définit \`res.partner.followup_status\` avec les valeurs :
\`('in_need_of_action', 'with_overdue_invoices', 'no_action_needed')\`

\`account_credit_hold\` redéfinissait le field avec :
\`('no_action_needed', 'in_need_of_action', 'overdue')\` + \`store=True\`

Le parent compute écrit \`'with_overdue_invoices'\` dans notre cache → ValueError. Source aussi du warning \`selection overrides existing selection; use selection_add instead\`.

## Fix
Retirer la redéclaration. On ne lit que \`'no_action_needed'\` (dans \`_compute_hold_bg\`), valeur qui existe dans le parent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)