### PR TITLE
feat(bemade_product_pricelist_preview): show computed prices on all sales pricelists

### DIFF
--- a/bemade_product_pricelist_preview/__init__.py
+++ b/bemade_product_pricelist_preview/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import models

--- a/bemade_product_pricelist_preview/__manifest__.py
+++ b/bemade_product_pricelist_preview/__manifest__.py
@@ -38,7 +38,7 @@ surface there. Open the variant form to see variant-only rules.
 (never in list/kanban context). Each pricelist triggers one database search
 (``_get_applicable_rules``), so worst-case latency scales with the number of
 active pricelists but remains sub-second at typical volume (< 50 pricelists).
-    """,
+""",
     "author": "Bemade Inc.",
     "website": "https://www.bemade.org",
     "depends": ["product"],

--- a/bemade_product_pricelist_preview/__manifest__.py
+++ b/bemade_product_pricelist_preview/__manifest__.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "Bemade Product Pricelist Preview",
+    "version": "19.0.1.0.0",
+    "category": "Product",
+    "summary": "Show computed prices across all pricelists on the product Prices tab",
+    "description": """
+Bemade Product Pricelist Preview
+=================================
+
+Extends the **Prices** tab on the product template and product variant forms to
+show a second, read-only list of every active sales-channel pricelist that
+returns a computed price for the product at qty = 1.0 in its base unit of
+measure.
+
+Unlike the standard ``pricelist_rule_ids`` list (which only shows rules that are
+explicitly linked to the product), this section includes prices derived from:
+
+- Global fallback rules
+- Product-category rules
+- Formula-based rules
+- Direct product/variant rules
+
+A cap of 100 pricelists per load is applied for performance. If more than 100
+active pricelists match, the first 100 (ordered by sequence, then name) are
+shown and a warning is logged once per request.
+
+**Sales-channel filter heuristic:** The MVP includes *all* active pricelists
+visible to the current company (own-company or shared). Purchase-only filtering
+can be opted in by overriding ``_bemade_get_preview_pricelists`` in a downstream
+module.
+
+**Variant vs template:** The template form computes prices by passing the
+template record to ``_compute_price_rule``; variant-targeted rules may not
+surface there. Open the variant form to see variant-only rules.
+
+**Performance note:** Computation runs only when the product form is opened
+(never in list/kanban context). Each pricelist triggers one database search
+(``_get_applicable_rules``), so worst-case latency scales with the number of
+active pricelists but remains sub-second at typical volume (< 50 pricelists).
+    """,
+    "author": "Bemade Inc.",
+    "website": "https://www.bemade.org",
+    "depends": ["product"],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/product_views.xml",
+    ],
+    "auto_install": False,
+    "installable": True,
+    "license": "LGPL-3",
+}

--- a/bemade_product_pricelist_preview/models/__init__.py
+++ b/bemade_product_pricelist_preview/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+from . import bemade_product_pricelist_preview
+from . import product_template
+from . import product_product

--- a/bemade_product_pricelist_preview/models/bemade_product_pricelist_preview.py
+++ b/bemade_product_pricelist_preview/models/bemade_product_pricelist_preview.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+from odoo import fields, models
+
+
+class BemadeProductPricelistPreview(models.TransientModel):
+    """Transient row holding the computed price for one product/pricelist pair.
+
+    Rows are created on demand by
+    ``product.template._compute_computed_pricelist_ids`` (and the
+    ``product.product`` variant equivalent) every time the product form is
+    opened.  They are vacuumed automatically by Odoo's standard transient-table
+    GC (``_transient_max_hours``).
+    """
+
+    _name = "bemade.product.pricelist.preview"
+    _description = "Product Pricelist Price Preview"
+    _order = "sequence, pricelist_id"
+
+    product_tmpl_id = fields.Many2one(
+        comodel_name="product.template",
+        string="Product Template",
+        ondelete="cascade",
+    )
+    product_id = fields.Many2one(
+        comodel_name="product.product",
+        string="Product Variant",
+        ondelete="cascade",
+    )
+    pricelist_id = fields.Many2one(
+        comodel_name="product.pricelist",
+        string="Pricelist",
+        required=True,
+        ondelete="cascade",
+    )
+    price = fields.Monetary(
+        string="Price",
+        currency_field="currency_id",
+    )
+    currency_id = fields.Many2one(
+        comodel_name="res.currency",
+        string="Currency",
+        required=True,
+    )
+    rule_id = fields.Many2one(
+        comodel_name="product.pricelist.item",
+        string="Matched Rule",
+        ondelete="set null",
+    )
+    rule_source = fields.Selection(
+        selection=[
+            ("variant", "Variant Rule"),
+            ("template", "Template Rule"),
+            ("category", "Category Rule"),
+            ("global", "Global Rule"),
+            ("formula", "Formula Rule"),
+        ],
+        string="Rule Type",
+    )
+    min_quantity = fields.Float(
+        string="Min. Qty",
+        digits="Product Unit of Measure",
+    )
+    date_start = fields.Datetime(string="Start Date")
+    date_end = fields.Datetime(string="End Date")
+    sequence = fields.Integer(
+        string="Sequence",
+        help="Pricelist sequence used for ordering preview rows.",
+    )

--- a/bemade_product_pricelist_preview/models/product_product.py
+++ b/bemade_product_pricelist_preview/models/product_product.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models
+from .product_template import _rule_source_from_item
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    computed_pricelist_ids = fields.One2many(
+        comodel_name="bemade.product.pricelist.preview",
+        inverse_name="product_id",
+        string="Computed Prices on All Pricelists",
+        compute="_compute_computed_pricelist_ids",
+        store=False,
+    )
+
+    @api.depends_context("company")
+    def _compute_computed_pricelist_ids(self):
+        """Build transient preview rows for each variant/pricelist combination.
+
+        Variant-targeted rules (``applied_on='0_product_variant'``) only
+        surface when the variant record itself is passed to
+        ``_compute_price_rule``, which is why we use ``self`` (product.product)
+        rather than the template.
+        """
+        Preview = self.env["bemade.product.pricelist.preview"]
+        for variant in self:
+            pricelists = variant.product_tmpl_id._bemade_get_preview_pricelists()
+            rows = Preview
+            now = fields.Datetime.now()
+            for pricelist in pricelists:
+                result = pricelist._compute_price_rule(variant, 1.0, date=now)
+                price, rule_id = result.get(variant.id, (0.0, False))
+                if not price or not rule_id:
+                    continue
+                rule = self.env["product.pricelist.item"].browse(rule_id) if rule_id else self.env["product.pricelist.item"]
+                vals = {
+                    "product_id": variant.id,
+                    "product_tmpl_id": variant.product_tmpl_id.id,
+                    "pricelist_id": pricelist.id,
+                    "price": price,
+                    "currency_id": pricelist.currency_id.id,
+                    "rule_id": rule.id if rule else False,
+                    "rule_source": _rule_source_from_item(rule),
+                    "min_quantity": rule.min_quantity if rule else 0.0,
+                    "date_start": rule.date_start if rule else False,
+                    "date_end": rule.date_end if rule else False,
+                    "sequence": pricelist.sequence,
+                }
+                rows |= Preview.create(vals)
+            variant.computed_pricelist_ids = rows

--- a/bemade_product_pricelist_preview/models/product_template.py
+++ b/bemade_product_pricelist_preview/models/product_template.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+import logging
+
+from odoo import api, fields, models
+
+_logger = logging.getLogger(__name__)
+
+_RULE_SOURCE_MAP = {
+    "0_product_variant": "variant",
+    "1_product": "template",
+    "2_product_category": "category",
+}
+
+
+def _rule_source_from_item(rule):
+    """Derive a rule_source selection value from a pricelist.item record.
+
+    :param rule: ``product.pricelist.item`` singleton (may be empty).
+    :returns: one of 'variant', 'template', 'category', 'formula', 'global',
+              or False when the rule recordset is empty.
+    """
+    if not rule:
+        return False
+    if rule.applied_on in _RULE_SOURCE_MAP:
+        return _RULE_SOURCE_MAP[rule.applied_on]
+    # applied_on == '3_global'
+    if rule.compute_price == "formula":
+        return "formula"
+    return "global"
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    computed_pricelist_ids = fields.One2many(
+        comodel_name="bemade.product.pricelist.preview",
+        inverse_name="product_tmpl_id",
+        string="Computed Prices on All Pricelists",
+        compute="_compute_computed_pricelist_ids",
+        store=False,
+    )
+
+    def _bemade_get_preview_pricelists(self):
+        """Return the set of pricelists to evaluate for the price preview.
+
+        Capped at 100 records ordered by ``sequence, name``.  Downstream
+        modules or client configs can override this method to narrow the set
+        (e.g. exclude purchase-only pricelists by name/code convention).
+
+        :returns: ``product.pricelist`` recordset
+        """
+        pricelists = self.env["product.pricelist"].search(
+            [
+                ("active", "=", True),
+                ("company_id", "in", (False, self.env.company.id)),
+            ],
+            order="sequence, name",
+            limit=101,
+        )
+        if len(pricelists) > 100:
+            _logger.warning(
+                "bemade_product_pricelist_preview: more than 100 active pricelists "
+                "found for company %s (product %s). Capping at 100.",
+                self.env.company.display_name,
+                self.display_name,
+            )
+            pricelists = pricelists[:100]
+        return pricelists
+
+    @api.depends_context("company")
+    def _compute_computed_pricelist_ids(self):
+        """Build transient preview rows for each product/pricelist combination."""
+        Preview = self.env["bemade.product.pricelist.preview"]
+        for tmpl in self:
+            pricelists = tmpl._bemade_get_preview_pricelists()
+            rows = Preview
+            now = fields.Datetime.now()
+            for pricelist in pricelists:
+                result = pricelist._compute_price_rule(tmpl, 1.0, date=now)
+                price, rule_id = result.get(tmpl.id, (0.0, False))
+                if not price or not rule_id:
+                    continue
+                rule = self.env["product.pricelist.item"].browse(rule_id) if rule_id else self.env["product.pricelist.item"]
+                vals = {
+                    "product_tmpl_id": tmpl.id,
+                    "pricelist_id": pricelist.id,
+                    "price": price,
+                    "currency_id": pricelist.currency_id.id,
+                    "rule_id": rule.id if rule else False,
+                    "rule_source": _rule_source_from_item(rule),
+                    "min_quantity": rule.min_quantity if rule else 0.0,
+                    "date_start": rule.date_start if rule else False,
+                    "date_end": rule.date_end if rule else False,
+                    "sequence": pricelist.sequence,
+                }
+                rows |= Preview.create(vals)
+            tmpl.computed_pricelist_ids = rows

--- a/bemade_product_pricelist_preview/security/ir.model.access.csv
+++ b/bemade_product_pricelist_preview/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_bemade_product_pricelist_preview_user,bemade.product.pricelist.preview user,model_bemade_product_pricelist_preview,base.group_user,1,1,1,1

--- a/bemade_product_pricelist_preview/tests/__init__.py
+++ b/bemade_product_pricelist_preview/tests/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import test_pricelist_preview

--- a/bemade_product_pricelist_preview/tests/test_pricelist_preview.py
+++ b/bemade_product_pricelist_preview/tests/test_pricelist_preview.py
@@ -1,0 +1,263 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for bemade_product_pricelist_preview.
+
+Acceptance criteria verified:
+1. Global fallback rule: row present with rule_source='global'.
+2. Category rule: row present with rule_source='category'.
+3. Template-level direct item: row present with rule_source='template'.
+4. Formula rule: price is the computed formula output.
+5. No matching price: no row emitted.
+6. Archived pricelist: row excluded.
+7. Other-company pricelist excluded; shared pricelist included.
+8. Cap at 100 with warning log.
+9. View renders without error (Form proxy).
+10. Variant-specific rule: variant row present, sibling absent.
+"""
+from odoo.tests import tagged, Form
+from odoo.tests.common import TransactionCase
+from odoo.tools.misc import mute_logger
+
+
+@tagged("post_install", "-at_install")
+class TestPricelistPreview(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Base currency (USD assumed from demo/test data)
+        cls.currency = cls.env.ref("base.USD")
+
+        # Product category
+        cls.categ = cls.env["product.category"].create({"name": "Test Category PPP"})
+
+        # Product template with a single variant
+        cls.product_tmpl = cls.env["product.template"].create(
+            {
+                "name": "Test Product PPP",
+                "type": "consu",
+                "list_price": 50.0,
+                "categ_id": cls.categ.id,
+            }
+        )
+        cls.variant = cls.product_tmpl.product_variant_ids[0]
+
+    # ── helpers ──────────────────────────────────────────────────────────────
+
+    def _make_pricelist(self, name, **extra):
+        """Create an active pricelist for the current company."""
+        vals = {
+            "name": name,
+            "active": True,
+            "currency_id": self.currency.id,
+            "company_id": self.env.company.id,
+        }
+        vals.update(extra)
+        return self.env["product.pricelist"].create(vals)
+
+    def _make_item(self, pricelist, applied_on="3_global", compute_price="fixed",
+                   fixed_price=10.0, **extra):
+        """Attach a rule to *pricelist* and return it."""
+        vals = {
+            "pricelist_id": pricelist.id,
+            "applied_on": applied_on,
+            "compute_price": compute_price,
+            "fixed_price": fixed_price,
+        }
+        vals.update(extra)
+        return self.env["product.pricelist.item"].create(vals)
+
+    def _preview_rows(self, record):
+        """Return computed_pricelist_ids for *record* (template or variant)."""
+        # Invalidate cache so compute runs fresh
+        record.invalidate_recordset(["computed_pricelist_ids"])
+        return record.computed_pricelist_ids
+
+    # ── tests ─────────────────────────────────────────────────────────────────
+
+    def test_global_fallback_rule_shows_row(self):
+        """AC#1 — global fixed-price rule produces a row with rule_source='global'."""
+        pl = self._make_pricelist("PPP Global")
+        self._make_item(pl, applied_on="3_global", fixed_price=10.0)
+
+        rows = self._preview_rows(self.product_tmpl)
+        pl_rows = rows.filtered(lambda r: r.pricelist_id == pl)
+        self.assertEqual(len(pl_rows), 1, "Expected exactly one row for the global pricelist")
+        self.assertAlmostEqual(pl_rows.price, 10.0, places=2)
+        self.assertEqual(pl_rows.rule_source, "global")
+
+    def test_category_rule_shows_row(self):
+        """AC#2 — category rule matching the product's category surfaces a row."""
+        pl = self._make_pricelist("PPP Category")
+        self._make_item(
+            pl,
+            applied_on="2_product_category",
+            fixed_price=20.0,
+            categ_id=self.categ.id,
+        )
+
+        rows = self._preview_rows(self.product_tmpl)
+        pl_rows = rows.filtered(lambda r: r.pricelist_id == pl)
+        self.assertEqual(len(pl_rows), 1)
+        self.assertAlmostEqual(pl_rows.price, 20.0, places=2)
+        self.assertEqual(pl_rows.rule_source, "category")
+
+    def test_direct_item_shows_row(self):
+        """AC#3 — template-level rule (applied_on='1_product') gives rule_source='template'."""
+        pl = self._make_pricelist("PPP Template Item")
+        self._make_item(
+            pl,
+            applied_on="1_product",
+            fixed_price=30.0,
+            product_tmpl_id=self.product_tmpl.id,
+        )
+
+        rows = self._preview_rows(self.product_tmpl)
+        pl_rows = rows.filtered(lambda r: r.pricelist_id == pl)
+        self.assertEqual(len(pl_rows), 1)
+        self.assertEqual(pl_rows.rule_source, "template")
+
+    def test_formula_rule_uses_computed_price(self):
+        """AC#4 — formula rule: price is list_price with surcharge, rule_source='formula'."""
+        pl = self._make_pricelist("PPP Formula")
+        self._make_item(
+            pl,
+            applied_on="3_global",
+            compute_price="formula",
+            fixed_price=0.0,
+            base="list_price",
+            price_surcharge=5.0,
+            price_discount=0.0,
+        )
+
+        rows = self._preview_rows(self.product_tmpl)
+        pl_rows = rows.filtered(lambda r: r.pricelist_id == pl)
+        self.assertEqual(len(pl_rows), 1)
+        # list_price=50 + surcharge=5 → 55
+        self.assertAlmostEqual(pl_rows.price, 55.0, places=2)
+        self.assertEqual(pl_rows.rule_source, "formula")
+
+    def test_no_price_excluded(self):
+        """AC#5 — pricelist with a rule that doesn't match the product produces no row."""
+        other_categ = self.env["product.category"].create({"name": "Other Cat PPP"})
+        pl = self._make_pricelist("PPP No Match")
+        self._make_item(
+            pl,
+            applied_on="2_product_category",
+            fixed_price=99.0,
+            categ_id=other_categ.id,
+        )
+
+        rows = self._preview_rows(self.product_tmpl)
+        pl_rows = rows.filtered(lambda r: r.pricelist_id == pl)
+        self.assertEqual(len(pl_rows), 0, "Expected no row when no rule matches")
+
+    def test_archived_pricelist_excluded(self):
+        """AC#6 — archived pricelist must not appear in preview."""
+        pl = self._make_pricelist("PPP Archived")
+        self._make_item(pl, fixed_price=15.0)
+        pl.active = False
+
+        rows = self._preview_rows(self.product_tmpl)
+        pl_rows = rows.filtered(lambda r: r.pricelist_id == pl)
+        self.assertEqual(len(pl_rows), 0, "Archived pricelist should be excluded")
+
+    def test_other_company_pricelist_excluded(self):
+        """AC#7 — other-company pricelist absent; shared (company_id=False) included."""
+        other_company = self.env["res.company"].create({"name": "Other Co PPP"})
+
+        pl_other = self._make_pricelist("PPP Other Company", company_id=other_company.id)
+        self._make_item(pl_other, fixed_price=42.0)
+
+        pl_shared = self._make_pricelist("PPP Shared", company_id=False)
+        self._make_item(pl_shared, fixed_price=43.0)
+
+        rows = self._preview_rows(self.product_tmpl)
+        self.assertEqual(
+            len(rows.filtered(lambda r: r.pricelist_id == pl_other)),
+            0,
+            "Other-company pricelist should not appear",
+        )
+        self.assertEqual(
+            len(rows.filtered(lambda r: r.pricelist_id == pl_shared)),
+            1,
+            "Shared pricelist (company_id=False) should appear",
+        )
+
+    def test_cap_at_100_logs_warning(self):
+        """AC#8 — create 101 pricelists, expect exactly 100 rows and a warning log."""
+        pls = self.env["product.pricelist"]
+        for i in range(101):
+            pl = self._make_pricelist(f"PPP Cap {i:03d}")
+            self._make_item(pl, fixed_price=float(i + 1))
+            pls |= pl
+
+        with self.assertLogs(
+            "odoo.addons.bemade_product_pricelist_preview.models.product_template",
+            level="WARNING",
+        ):
+            rows = self._preview_rows(self.product_tmpl)
+
+        cap_rows = rows.filtered(lambda r: r.pricelist_id in pls)
+        self.assertEqual(len(cap_rows), 100, "Should cap at exactly 100 rows")
+
+    def test_view_renders(self):
+        """AC#9 — product.template and product.product forms load without error."""
+        # The 'Prices' tab itself is gated on group_product_pricelist; grant it
+        # so Form sees the page and the computed field within it.
+        self.env.user.group_ids |= self.env.ref("product.group_product_pricelist")
+        with Form(self.product_tmpl) as tmpl_form:
+            # The computed field should be accessible (read-only)
+            self.assertTrue(
+                hasattr(tmpl_form, "computed_pricelist_ids"),
+                "computed_pricelist_ids should be present in template form",
+            )
+
+        with Form(self.variant) as var_form:
+            self.assertTrue(
+                hasattr(var_form, "computed_pricelist_ids"),
+                "computed_pricelist_ids should be present in variant form",
+            )
+
+    def test_variant_specific_rule(self):
+        """AC#10 — variant-only rule shows on that variant; sibling does not see it."""
+        # Create a product template with two variants
+        tmpl = self.env["product.template"].create(
+            {
+                "name": "PPP Multi-Variant",
+                "type": "consu",
+                "list_price": 100.0,
+            }
+        )
+        attr = self.env["product.attribute"].create({"name": "Colour PPP"})
+        val_red = self.env["product.attribute.value"].create(
+            {"name": "Red", "attribute_id": attr.id}
+        )
+        val_blue = self.env["product.attribute.value"].create(
+            {"name": "Blue", "attribute_id": attr.id}
+        )
+        self.env["product.template.attribute.line"].create(
+            {
+                "product_tmpl_id": tmpl.id,
+                "attribute_id": attr.id,
+                "value_ids": [(6, 0, [val_red.id, val_blue.id])],
+            }
+        )
+        variant_red, variant_blue = tmpl.product_variant_ids[:2]
+
+        pl = self._make_pricelist("PPP Variant Specific")
+        self._make_item(
+            pl,
+            applied_on="0_product_variant",
+            fixed_price=77.0,
+            product_id=variant_red.id,
+            product_tmpl_id=tmpl.id,
+        )
+
+        red_rows = self._preview_rows(variant_red).filtered(lambda r: r.pricelist_id == pl)
+        blue_rows = self._preview_rows(variant_blue).filtered(lambda r: r.pricelist_id == pl)
+
+        self.assertEqual(len(red_rows), 1, "Variant-targeted rule should appear on the matched variant")
+        self.assertEqual(red_rows.rule_source, "variant")
+        self.assertAlmostEqual(red_rows.price, 77.0, places=2)
+        self.assertEqual(len(blue_rows), 0, "Variant-targeted rule should NOT appear on the sibling variant")

--- a/bemade_product_pricelist_preview/views/product_views.xml
+++ b/bemade_product_pricelist_preview/views/product_views.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Prices tab extension for product.template form -->
+    <record id="product_template_form_view_pricelist_preview" model="ir.ui.view">
+        <field name="name">product.template.form.pricelist.preview</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//page[@name='sales_price']" position="inside">
+                <separator string="Computed Prices on All Pricelists"/>
+                <field
+                    name="computed_pricelist_ids"
+                    readonly="1"
+                    nolabel="1"
+                >
+                    <list create="0" delete="0" edit="0">
+                        <field name="pricelist_id" string="Pricelist"/>
+                        <field name="price" widget="monetary" options="{'currency_field': 'currency_id'}"/>
+                        <field name="currency_id" string="Currency"/>
+                        <field name="rule_source" string="Rule Type"/>
+                        <field name="rule_id" string="Matched Rule" optional="hide"/>
+                        <field name="min_quantity" string="Min. Qty" optional="hide"/>
+                        <field name="date_start" optional="hide"/>
+                        <field name="date_end" optional="hide"/>
+                    </list>
+                </field>
+            </xpath>
+        </field>
+    </record>
+
+    <!-- Prices tab extension for product.product (variant) form -->
+    <record id="product_normal_form_view_pricelist_preview" model="ir.ui.view">
+        <field name="name">product.product.form.pricelist.preview</field>
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_normal_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//page[@name='sales_price']" position="inside">
+                <separator string="Computed Prices on All Pricelists"/>
+                <field
+                    name="computed_pricelist_ids"
+                    readonly="1"
+                    nolabel="1"
+                >
+                    <list create="0" delete="0" edit="0">
+                        <field name="pricelist_id" string="Pricelist"/>
+                        <field name="price" widget="monetary" options="{'currency_field': 'currency_id'}"/>
+                        <field name="currency_id" string="Currency"/>
+                        <field name="rule_source" string="Rule Type"/>
+                        <field name="rule_id" string="Matched Rule" optional="hide"/>
+                        <field name="min_quantity" string="Min. Qty" optional="hide"/>
+                        <field name="date_start" optional="hide"/>
+                        <field name="date_end" optional="hide"/>
+                    </list>
+                </field>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Summary

Adds a new module `bemade_product_pricelist_preview` that surfaces the computed price for a product on every active sales-channel pricelist (global, category, template, variant and formula rules) in a read-only section on the Prices tab of `product.template` and `product.product`.

- Non-stored `computed_pricelist_ids` One2many computed on form load
- TransientModel backs the displayed rows
- Capped at 100 pricelists with a single warning log beyond
- `rule_source` Selection hints which rule fired (variant/template/category/global/formula)
- Multi-company aware (env.company + shared `company_id=False`)

## Test plan

- 10 tests pass via `odoo-dev test bemade_product_pricelist_preview` (covers global, category, template, formula, no-price exclusion, archived/other-company filter, 100-cap warning, view rendering, variant-specific rules).
- UI test plan in the task-cycle artifact.

## References

Closes Odoo task #3628 (RWI). Cycle artifacts: https://git.bemade.org/bemade/tasks/-/tree/main/task-3628-product-prices-tab-all-pricelists