### PR TITLE
test(bemade_product_pricelist_preview): make cap test resilient to pre-existing pricelists

### DIFF
--- a/bemade_product_pricelist_preview/tests/test_pricelist_preview.py
+++ b/bemade_product_pricelist_preview/tests/test_pricelist_preview.py
@@ -185,12 +185,20 @@ class TestPricelistPreview(TransactionCase):
         )
 
     def test_cap_at_100_logs_warning(self):
-        """AC#8 — create 101 pricelists, expect exactly 100 rows and a warning log."""
-        pls = self.env["product.pricelist"]
-        for i in range(101):
+        """AC#8 — when more than 100 active pricelists exist, the preview is
+        capped at 100 rows and a warning is logged. Resilient to pre-existing
+        pricelists in the test DB (e.g. Odoo core's Public Pricelist)."""
+        existing = self.env["product.pricelist"].search_count(
+            [
+                ("active", "=", True),
+                ("company_id", "in", (False, self.env.company.id)),
+            ]
+        )
+        # Always overshoot the 100-cap by at least one.
+        to_create = max(0, 100 - existing) + 1
+        for i in range(to_create):
             pl = self._make_pricelist(f"PPP Cap {i:03d}")
             self._make_item(pl, fixed_price=float(i + 1))
-            pls |= pl
 
         with self.assertLogs(
             "odoo.addons.bemade_product_pricelist_preview.models.product_template",
@@ -198,8 +206,7 @@ class TestPricelistPreview(TransactionCase):
         ):
             rows = self._preview_rows(self.product_tmpl)
 
-        cap_rows = rows.filtered(lambda r: r.pricelist_id in pls)
-        self.assertEqual(len(cap_rows), 100, "Should cap at exactly 100 rows")
+        self.assertEqual(len(rows), 100, "Should cap at exactly 100 rows")
 
     def test_view_renders(self):
         """AC#9 — product.template and product.product forms load without error."""


### PR DESCRIPTION
## Problem

The 100-cap test on the new pricelist preview module fails on the CI DB:

```
AssertionError: 99 != 100 : Should cap at exactly 100 rows
```

The test creates 101 new pricelists and asserts that exactly 100 of them appear in the preview. But the CI DB carries Odoo core's `Public Pricelist` (and potentially others), so the 100-cap (ordered by `sequence, name`) ends up including a pre-existing pricelist and excluding one of the 101 test-created ones — leaving only 99 in the filtered count.

## Fix

Restructure the test to assert the cap behaviour itself:
- Query the existing pricelist count first
- Create just enough new pricelists to overshoot the 100-cap
- Assert `len(rows) == 100` (the total, regardless of which pricelists are in it) plus the warning log

This is what the test was really trying to validate — the cap, not a specific membership.

## Test plan

- `odoo-dev test bemade_product_pricelist_preview` → all 10 tests pass

Surfaced by failure on rwi MR !26 against the merged #112.