### PR TITLE
fix(fsm_visit_confirmation): use tz_name key so partner-local hour renders correctly (task 3559)

### DIFF
--- a/fsm_visit_confirmation/data/mail_templates.xml
+++ b/fsm_visit_confirmation/data/mail_templates.xml
@@ -27,7 +27,7 @@
                         <td style="padding:10px;border-bottom:1px solid #e7e7e7;">
                             <t t-set="partner" t-value="object.work_order_contacts and object.work_order_contacts[0] or object.partner_id"/>
                             <t t-set="partner_tz" t-value="partner.tz or object.company_id.partner_id.tz or 'America/Toronto'"/>
-                            <span t-field="object.planned_date_begin" t-options="{'widget': 'datetime', 'timezone': partner_tz}"/>
+                            <span t-field="object.planned_date_begin" t-options="{'widget': 'datetime', 'tz_name': partner_tz}"/>
                             <div style="font-size: 12px; color: #666;">
                                 (Timezone: <t t-out="partner_tz"/>)
                             </div>

--- a/fsm_visit_confirmation/tests/test_fsm_visit_confirmation.py
+++ b/fsm_visit_confirmation/tests/test_fsm_visit_confirmation.py
@@ -311,31 +311,109 @@ class TestFSMVisitConfirmation(HttpCase):
         self.assertIn("Water will be off for 2 hours", new_mail.body_html, "Email should contain first requirement description")
         self.assertIn("Power will be interrupted briefly", new_mail.body_html, "Email should contain second requirement description")
 
-    def test_07_confirmation_email_uses_partner_timezone(self):
-        """Le courriel doit afficher l'heure dans le fuseau du partenaire,
-        pas celui de l'utilisateur (odoo-bot a souvent UTC, ce qui causait
-        un décalage de 4-5h dans les confirmations envoyées aux clients)."""
-        from datetime import datetime
-
-        # Partenaire dans le fuseau EST; utilisateur simulé en UTC (odoo-bot)
-        self.customer.write({"tz": "America/Toronto"})
-        self.env.user.write({"tz": "UTC"})
-
-        self.task.write({
-            "planned_date_begin": datetime(2026, 6, 15, 14, 0, 0),  # 14h UTC = 10h EDT
-        })
-
+    def _send_confirmation_email(self, task):
+        """Helper: attach the production confirmation template to the approved stage
+        and move the task into that stage, triggering a mail send. Returns the
+        most-recently-created mail.mail record."""
         template = self.env.ref(
             "fsm_visit_confirmation.fsm_visit_confirmation_email_template"
         )
         self.stage_approved.approval_template_id = template
-        self.task.write({"stage_id": self.stage_approved.id})
+        task.write({"stage_id": self.stage_approved.id})
+        return self.env["mail.mail"].search([], order="id desc", limit=1)
 
-        new_mail = self.env["mail.mail"].search([], order="id desc", limit=1)
+    def test_07_confirmation_email_uses_partner_timezone(self):
+        """The email must display the visit time in the partner's timezone, not
+        the sending user's timezone (odoo-bot runs in UTC, which caused a 4-5h
+        offset in confirmation emails sent to clients).
 
-        # Le fuseau affiché doit être celui du partenaire (America/Toronto)
+        DST note: June 15 is firmly inside North-American DST (EDT = UTC-4), so
+        14:00 UTC → 10:00 EDT.  Winter dates (EST = UTC-5) would render 09:00:00
+        instead — do not change the date without updating the assertions.
+        """
+        from datetime import datetime
+
+        # Partner in America/Toronto; simulated sender in UTC (odoo-bot)
+        self.customer.write({"tz": "America/Toronto", "lang": "en_US"})
+        self.env.user.write({"tz": "UTC"})
+
+        # 14:00 UTC on June 15 = 10:00 EDT (DST active, UTC-4)
+        self.task.write({
+            "planned_date_begin": datetime(2026, 6, 15, 14, 0, 0),
+        })
+
+        new_mail = self._send_confirmation_email(self.task)
+
+        # The partner-local EDT hour must appear (not the UTC hour)
+        self.assertIn(
+            "06/15/2026 10:00:00",
+            new_mail.body_html,
+            "Email must show partner-local EDT time 10:00:00 for a 14:00 UTC visit on June 15",
+        )
+        self.assertNotIn(
+            "14:00:00",
+            new_mail.body_html,
+            "UTC hour 14:00:00 must NOT appear in the email body",
+        )
+        # The timezone label must also be the partner's
         self.assertIn(
             "America/Toronto",
             new_mail.body_html,
-            "Le courriel doit afficher le fuseau du partenaire (America/Toronto), pas UTC",
+            "Email must show partner timezone label America/Toronto",
+        )
+
+    def test_08_confirmation_email_fallback_to_company_tz(self):
+        """When partner.tz is not set, the template falls back to
+        company.partner_id.tz and still renders the correct local hour."""
+        from datetime import datetime
+
+        # Partner has no tz; company partner has America/Toronto
+        self.customer.write({"tz": False, "lang": "en_US"})
+        company = self.env.company
+        company.partner_id.write({"tz": "America/Toronto"})
+        self.env.user.write({"tz": "UTC"})
+
+        # 14:00 UTC on June 15 = 10:00 EDT (DST active, UTC-4)
+        self.task.write({
+            "planned_date_begin": datetime(2026, 6, 15, 14, 0, 0),
+        })
+
+        new_mail = self._send_confirmation_email(self.task)
+
+        # Should still fall back to America/Toronto and render 10:00 EDT
+        self.assertIn(
+            "America/Toronto",
+            new_mail.body_html,
+            "Fallback should use company partner tz (America/Toronto)",
+        )
+        self.assertIn(
+            "10:00:00",
+            new_mail.body_html,
+            "Fallback tz should still render the correct local hour (10:00 EDT)",
+        )
+
+    def test_09_confirmation_email_fallback_hardcoded_tz(self):
+        """When both partner.tz and company.partner_id.tz are unset, the template
+        falls back to the hardcoded 'America/Toronto' and renders without error."""
+        from datetime import datetime
+
+        # Both partner and company partner have no tz
+        self.customer.write({"tz": False, "lang": "en_US"})
+        company = self.env.company
+        company.partner_id.write({"tz": False})
+        self.env.user.write({"tz": "UTC"})
+
+        # 14:00 UTC on June 15 = 10:00 EDT (DST active, UTC-4) — hardcoded fallback
+        self.task.write({
+            "planned_date_begin": datetime(2026, 6, 15, 14, 0, 0),
+        })
+
+        new_mail = self._send_confirmation_email(self.task)
+
+        # Template should not crash and should use America/Toronto fallback
+        self.assertTrue(new_mail, "Mail should be created even when both partner.tz and company.partner_id.tz are unset")
+        self.assertIn(
+            "America/Toronto",
+            new_mail.body_html,
+            "Hardcoded fallback 'America/Toronto' must appear in the email body",
         )


### PR DESCRIPTION
## Summary

Fixes the FSM visit-confirmation email rendering the visit time in UTC instead of the partner's local timezone. Customer-visible symptom (task 3559): client received a confirmation showing **15h00** when the visit was scheduled for **11h00** — a 4-hour offset matching UTC↔America/Toronto in DST.

## Root cause

Commit `c2a62779` previously fixed the timezone *label* by changing `user.tz` → `partner.tz` in the `t-set` at line 29 of `fsm_visit_confirmation/data/mail_templates.xml`. But line 30 passes `'timezone': partner_tz` to the qweb datetime widget, and `ir.qweb.field.datetime.value_to_html` (`odoo/addons/base/models/ir_qweb_fields.py`, lines 268–270) only honours the `tz_name` option key. `timezone` was silently ignored — the rendered wall-clock hour kept falling back to the env user's tz (UTC for Odoo-bot), even though the displayed label was correct.

## Change

- `fsm_visit_confirmation/data/mail_templates.xml` line 30: `'timezone': partner_tz` → `'tz_name': partner_tz` (one-line production fix).
- `fsm_visit_confirmation/tests/test_fsm_visit_confirmation.py`: strengthen `test_07_confirmation_email_uses_partner_timezone` to assert the rendered hour (`06/15/2026 10:00:00` for a `14:00 UTC` `planned_date_begin` with partner tz `America/Toronto`), assert UTC hour is absent, pin `partner.lang = en_US` for deterministic format. Add `test_08` (company-partner-tz fallback) and `test_09` (hardcoded `America/Toronto` fallback). Extract `_send_confirmation_email()` test helper.

All 9 `fsm_visit_confirmation` tests pass.

## Test plan

- [x] `odoo-dev test fsm_visit_confirmation` — 9 passed, 0 failed.
- [ ] After merge: bump submodule pointer in `durpro` (task-cycle follow-up), deploy to staging, send a test confirmation to a partner with tz America/Toronto, verify body shows local hour not UTC.

## Origin

- Odoo task: https://odoo.bemade.org/odoo/project/10/tasks/3559
- Pipeline artifacts: https://git.bemade.org/bemade/tasks/-/tree/main/task-3559-fsm-visit-tz