### PR TITLE
Split product_uom_factor: add _sale + _purchase bridges (Odoo 19)

### DIFF
--- a/product_uom_factor/__manifest__.py
+++ b/product_uom_factor/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Product UoM Conversion Factor",
     "summary": "Product-specific conversion factors for cross-category UoM conversions",
-    "version": "19.0.1.0.0",
+    "version": "19.0.2.0.0",
     "development_status": "Alpha",
     "license": "LGPL-3",
     "author": "Bemade Inc.",

--- a/product_uom_factor/migrations/19.0.2.0.0/post-migrate.py
+++ b/product_uom_factor/migrations/19.0.2.0.0/post-migrate.py
@@ -1,0 +1,26 @@
+# Copyright 2026 Bemade Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+"""No-op migration for product_uom_factor 19.0.2.0.0.
+
+This version bump documents the architectural split introduced in this release:
+sale-side and purchase-side display logic (computed fields, view helpers, and
+PDF report injections) have been moved into the new bridge modules:
+
+  - product_uom_factor_sale   (depends: product_uom_factor, sale)
+  - product_uom_factor_purchase (depends: product_uom_factor, purchase)
+
+The core module remains pure product-side (depends: product only) and is not
+affected by this split. No schema changes, no data migrations.
+"""
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    _logger.info(
+        "product_uom_factor upgraded to 19.0.2.0.0: "
+        "sale/purchase display logic now lives in bridge modules "
+        "product_uom_factor_sale and product_uom_factor_purchase."
+    )

--- a/product_uom_factor/readme/DESCRIPTION.md
+++ b/product_uom_factor/readme/DESCRIPTION.md
@@ -19,3 +19,16 @@ a factor of 1.05 on its liter packaging UoM, meaning 1 liter = 1050 grams.
 The module overrides `_compute_quantity()` and `_compute_price()` so that when a
 product is available in context, cross-category conversions use the product-specific
 factor instead of producing potentially incoherent results.
+
+## Bridge modules
+
+Two optional bridge modules extend this core with order-side display helpers:
+
+- **product_uom_factor_sale** — adds a computed "Base UoM" helper column on SO
+  lines and injects the base-UoM quantity as a grey note in the sale order PDF
+  report (e.g. "250 lb" under the product name).
+- **product_uom_factor_purchase** — mirrors the sale bridge for PO lines and
+  the purchase order / quotation PDF reports.
+
+Install the bridge modules alongside this one to expose the display helpers.
+The core module remains pure product-side (no sale/purchase dependency).

--- a/product_uom_factor_purchase/__init__.py
+++ b/product_uom_factor_purchase/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2026 Bemade Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from . import models

--- a/product_uom_factor_purchase/__manifest__.py
+++ b/product_uom_factor_purchase/__manifest__.py
@@ -1,0 +1,30 @@
+# Copyright 2026 Bemade Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+{
+    "name": "Product UoM Factor – Purchase Bridge",
+    "summary": "Displays the base-UoM equivalent quantity on purchase order lines",
+    "version": "19.0.1.0.0",
+    "development_status": "Alpha",
+    "license": "LGPL-3",
+    "author": "Bemade Inc.",
+    "website": "https://www.bemade.org",
+    "maintainers": ["mdurepos"],
+    "depends": [
+        "product_uom_factor",
+        "purchase",
+    ],
+    "data": [
+        "views/purchase_order_views.xml",
+        "report/purchase_order_templates.xml",
+    ],
+    "assets": {
+        "web.assets_unit_tests": [
+            "product_uom_factor_purchase/static/tests/**/*",
+            ("remove", "product_uom_factor_purchase/static/tests/tours/**/*"),
+        ],
+        "web.assets_tests": [
+            "product_uom_factor_purchase/static/tests/tours/**/*",
+        ],
+    },
+}

--- a/product_uom_factor_purchase/models/__init__.py
+++ b/product_uom_factor_purchase/models/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2026 Bemade Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from . import purchase_order_line

--- a/product_uom_factor_purchase/models/purchase_order_line.py
+++ b/product_uom_factor_purchase/models/purchase_order_line.py
@@ -1,0 +1,68 @@
+# Copyright 2026 Bemade Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo import api, fields, models
+
+
+class PurchaseOrderLine(models.Model):
+    _inherit = "purchase.order.line"
+
+    factor_base_uom_qty = fields.Float(
+        string="Base UoM Qty",
+        compute="_compute_factor_base_uom",
+        store=False,
+        help="Quantity expressed in the product's base UoM, computed via the "
+        "product-specific cross-category conversion factor. Zero when the line "
+        "UoM is in the same category as the product's base UoM or no factor "
+        "record exists for this product.",
+    )
+    factor_base_uom_display = fields.Char(
+        string="Base UoM",
+        compute="_compute_factor_base_uom",
+        store=False,
+        help="Human-readable base-UoM quantity for display on the order form "
+        '(e.g. "= 150.00 lb"). Empty when no cross-category factor applies.',
+    )
+
+    @api.depends(
+        "product_qty",
+        "product_uom_id",
+        "product_id",
+        "product_id.uom_id",
+    )
+    def _compute_factor_base_uom(self):
+        for line in self:
+            product = line.product_id
+            line_uom = line.product_uom_id
+            if not product or not line_uom:
+                line.factor_base_uom_qty = 0.0
+                line.factor_base_uom_display = ""
+                continue
+
+            base_uom = product.uom_id
+            # Short-circuit: same-category means standard Odoo handles it,
+            # no factor display needed.
+            if not base_uom or base_uom._has_common_reference(line_uom):
+                line.factor_base_uom_qty = 0.0
+                line.factor_base_uom_display = ""
+                continue
+
+            # Check that a product.uom.factor record exists for this product
+            # and line UoM (or its category).
+            factor_record = line_uom._find_product_uom_for_category(
+                product.id, line_uom
+            )
+            if not factor_record:
+                line.factor_base_uom_qty = 0.0
+                line.factor_base_uom_display = ""
+                continue
+
+            # Convert line qty from line_uom → product base_uom using the
+            # product-specific factor. The core's _compute_quantity override
+            # picks up the factor automatically via product_id context.
+            base_qty = line_uom.with_context(
+                product_id=product.id
+            )._compute_quantity(line.product_qty, base_uom, round=False)
+
+            line.factor_base_uom_qty = base_qty
+            line.factor_base_uom_display = "= %.2f %s" % (base_qty, base_uom.name)

--- a/product_uom_factor_purchase/readme/DESCRIPTION.md
+++ b/product_uom_factor_purchase/readme/DESCRIPTION.md
@@ -1,0 +1,17 @@
+Bridge module between `product_uom_factor` and `purchase`.
+
+When a purchase order line uses a cross-category UoM (e.g. ordering in "Bag"
+when the product is stocked in "lb"), this module computes and surfaces the
+base-UoM equivalent quantity so buyers can verify conversions at a glance.
+
+## Features
+
+- Adds a computed **Base UoM** helper column on the PO line list (shows
+  `"= 150.00 lb"` for internal users; column is optional/show by default).
+- Injects a grey base-UoM quantity note under the product name in both the
+  **purchase order PDF** (confirmed PO) and the **purchase quotation PDF**
+  (RFQ). Shows only the quantity (e.g. `"150.00 lb"`), without the equation.
+
+## Dependencies
+
+Requires `product_uom_factor` (core) and `purchase`.

--- a/product_uom_factor_purchase/report/purchase_order_templates.xml
+++ b/product_uom_factor_purchase/report/purchase_order_templates.xml
@@ -1,44 +1,73 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
     <!--
-        Inject base-UoM quantity note in the purchase order PDF (confirmed PO).
-        Customer/vendor-facing: shows only the base-UoM qty (e.g. "150.00 lb").
-        Purchase order template uses loop variable "line"; td id="product".
+        Replace the stock base-UoM note in the qty cell of the confirmed PO PDF.
+
+        Odoo 19 purchase order template (`purchase.report_purchaseorder_document`,
+        lines 80-83 of purchase_order_templates.xml) emits:
+            <span t-if="line.product_uom_id != line.product_id.uom_id"
+                  class="text-muted small">…</span>
+        using the line's product_uom_qty directly (not a _compute_quantity call),
+        which is wrong for cross-category lines with a product.uom.factor record.
+        We replace the span entirely:
+        - cross-category with our factor → show the correct value from
+          line.factor_base_uom_qty (computed with product_id context in Python).
+        - same-category mismatch (e.g. kg line on a g product) → fallback
+          to the original stock behavior so we don't regress that use case.
     -->
     <template
         id="report_purchaseorder_line_factor_base_uom"
         inherit_id="purchase.report_purchaseorder_document"
     >
         <xpath
-            expr="//td[@id='product']/span[@t-field='line.name']"
-            position="after"
+            expr="//span[@t-if='line.product_uom_id != line.product_id.uom_id']"
+            position="replace"
         >
             <t t-if="line.factor_base_uom_qty">
-                <br />
-                <small class="text-muted">
+                <!-- Cross-category with our factor: show the correct base-UoM qty. -->
+                <span class="text-muted small">
+                    <br />
                     <t t-out="'%.2f %s' % (line.factor_base_uom_qty, line.product_id.uom_id.name)" />
-                </small>
+                </span>
+            </t>
+            <t t-elif="line.product_uom_id != line.product_id.uom_id">
+                <!-- Same-category UoM mismatch: preserve stock behavior. -->
+                <span class="text-muted small">
+                    <br />
+                    <span t-field="line.product_uom_qty" t-options="{'widget': 'float', 'decimal_precision': 'Product Unit'}" /> <span t-field="line.product_id.uom_id" />
+                </span>
             </t>
         </xpath>
     </template>
 
     <!--
-        Inject base-UoM quantity note in the purchase quotation PDF (RFQ).
-        Quotation template uses loop variable "order_line"; td id="product".
+        Replace the stock base-UoM note in the qty cell of the purchase quotation (RFQ) PDF.
+
+        Odoo 19 quotation template (`purchase.report_purchasequotation_document`,
+        lines 49-52 of purchase_quotation_templates.xml) uses loop variable
+        `order_line` (not `line`).
     -->
     <template
         id="report_purchasequotation_line_factor_base_uom"
         inherit_id="purchase.report_purchasequotation_document"
     >
         <xpath
-            expr="//td[@id='product']/span[@t-field='order_line.name']"
-            position="after"
+            expr="//span[@t-if='order_line.product_uom_id != order_line.product_id.uom_id']"
+            position="replace"
         >
             <t t-if="order_line.factor_base_uom_qty">
-                <br />
-                <small class="text-muted">
+                <!-- Cross-category with our factor: show the correct base-UoM qty. -->
+                <span class="text-muted small">
+                    <br />
                     <t t-out="'%.2f %s' % (order_line.factor_base_uom_qty, order_line.product_id.uom_id.name)" />
-                </small>
+                </span>
+            </t>
+            <t t-elif="order_line.product_uom_id != order_line.product_id.uom_id">
+                <!-- Same-category UoM mismatch: preserve stock behavior. -->
+                <span class="text-muted small">
+                    <br />
+                    <span t-field="order_line.product_uom_qty" t-options="{'widget': 'float', 'decimal_precision': 'Product Unit'}" /> <span t-field="order_line.product_id.uom_id" />
+                </span>
             </t>
         </xpath>
     </template>

--- a/product_uom_factor_purchase/report/purchase_order_templates.xml
+++ b/product_uom_factor_purchase/report/purchase_order_templates.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <!--
+        Inject base-UoM quantity note in the purchase order PDF (confirmed PO).
+        Customer/vendor-facing: shows only the base-UoM qty (e.g. "150.00 lb").
+        Purchase order template uses loop variable "line"; td id="product".
+    -->
+    <template
+        id="report_purchaseorder_line_factor_base_uom"
+        inherit_id="purchase.report_purchaseorder_document"
+    >
+        <xpath
+            expr="//td[@id='product']/span[@t-field='line.name']"
+            position="after"
+        >
+            <t t-if="line.factor_base_uom_qty">
+                <br />
+                <small class="text-muted">
+                    <t t-out="'%.2f %s' % (line.factor_base_uom_qty, line.product_id.uom_id.name)" />
+                </small>
+            </t>
+        </xpath>
+    </template>
+
+    <!--
+        Inject base-UoM quantity note in the purchase quotation PDF (RFQ).
+        Quotation template uses loop variable "order_line"; td id="product".
+    -->
+    <template
+        id="report_purchasequotation_line_factor_base_uom"
+        inherit_id="purchase.report_purchasequotation_document"
+    >
+        <xpath
+            expr="//td[@id='product']/span[@t-field='order_line.name']"
+            position="after"
+        >
+            <t t-if="order_line.factor_base_uom_qty">
+                <br />
+                <small class="text-muted">
+                    <t t-out="'%.2f %s' % (order_line.factor_base_uom_qty, order_line.product_id.uom_id.name)" />
+                </small>
+            </t>
+        </xpath>
+    </template>
+</odoo>

--- a/product_uom_factor_purchase/static/tests/tours/purchase_factor_display_tour.js
+++ b/product_uom_factor_purchase/static/tests/tours/purchase_factor_display_tour.js
@@ -1,0 +1,18 @@
+import {registry} from "@web/core/registry";
+
+registry.category("web_tour.tours").add("purchase_factor_display_tour", {
+    steps: () => [
+        {
+            trigger: ".o_form_view .o_field_one2many[name='order_line']",
+            content: "Wait for the order line list to load",
+        },
+        {
+            // The optional column "Base UoM" should show the cross-category
+            // equivalent quantity, e.g. "= 150.00 lb".
+            trigger:
+                ".o_field_one2many[name='order_line'] .o_list_renderer " +
+                "td[name='factor_base_uom_display']:contains('= ')",
+            content: "Base UoM column shows the cross-category quantity",
+        },
+    ],
+});

--- a/product_uom_factor_purchase/tests/__init__.py
+++ b/product_uom_factor_purchase/tests/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2026 Bemade Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from . import test_purchase_line_base_uom_display
+from . import test_render_pdf

--- a/product_uom_factor_purchase/tests/test_purchase_line_base_uom_display.py
+++ b/product_uom_factor_purchase/tests/test_purchase_line_base_uom_display.py
@@ -1,0 +1,123 @@
+"""
+Tests for product_uom_factor_purchase: computed base-UoM display on PO lines.
+
+Acceptance Criteria:
+1. Happy path: 3 Bag × 50 lb/Bag → factor_base_uom_qty=150.0,
+   factor_base_uom_display="= 150.00 lb".
+2. Same-category no-op: line UoM == product base UoM → factor_base_uom_qty=0.0.
+3. Missing factor no-op: no product.uom.factor row → factor_base_uom_qty=0.0.
+"""
+
+from datetime import date
+
+from odoo.tests.common import TransactionCase
+
+
+class TestPurchaseLineBaseUomDisplay(TransactionCase):
+    """Test computed base-UoM display fields on purchase.order.line."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.uom_lb = cls.env.ref("uom.product_uom_lb")
+        cls.uom_kg = cls.env.ref("uom.product_uom_kgm")
+
+        cls.uom_vol_category = cls.env.ref("uom.product_uom_categ_vol")
+        cls.uom_bag = cls.env["uom.uom"].create(
+            {
+                "name": "BagPO",
+                "category_id": cls.uom_vol_category.id,
+                "factor": 1.0,
+                "uom_type": "reference",
+                "rounding": 0.01,
+            }
+        )
+
+        cls.vendor = cls.env["res.partner"].create(
+            {"name": "Test Vendor PO", "supplier_rank": 1}
+        )
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Test Powder PO",
+                "uom_id": cls.uom_lb.id,
+                "uom_ids": [(4, cls.uom_lb.id), (4, cls.uom_bag.id)],
+                "standard_price": 3.0,
+            }
+        )
+        # 1 Bag = 50 lb
+        cls.env["product.uom.factor"].create(
+            {
+                "product_tmpl_id": cls.product.product_tmpl_id.id,
+                "uom_id": cls.uom_bag.id,
+                "factor": 50.0,
+            }
+        )
+
+    def _make_po_line(self, qty, uom):
+        po = self.env["purchase.order"].create(
+            {
+                "partner_id": self.vendor.id,
+                "date_order": date.today(),
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product.id,
+                            "product_qty": qty,
+                            "product_uom_id": uom.id,
+                            "price_unit": 3.0,
+                            "date_planned": date.today(),
+                            "name": self.product.name,
+                        },
+                    )
+                ],
+            }
+        )
+        return po.order_line
+
+    def test_happy_path_cross_category(self):
+        """3 Bag × 50 lb/Bag → factor_base_uom_qty=150.0, display='= 150.00 lb'."""
+        line = self._make_po_line(3.0, self.uom_bag)
+        self.assertAlmostEqual(line.factor_base_uom_qty, 150.0, places=2)
+        self.assertEqual(line.factor_base_uom_display, "= 150.00 lb")
+
+    def test_same_category_no_display(self):
+        """Line UoM in the same category as base UoM → qty=0.0."""
+        line = self._make_po_line(10.0, self.uom_lb)
+        self.assertEqual(line.factor_base_uom_qty, 0.0)
+        self.assertEqual(line.factor_base_uom_display, "")
+
+    def test_missing_factor_no_display(self):
+        """Cross-category UoM with no factor row → qty=0.0, no exception."""
+        product2 = self.env["product.product"].create(
+            {
+                "name": "No Factor Product PO",
+                "uom_id": self.uom_lb.id,
+                "standard_price": 3.0,
+            }
+        )
+        uom_liter = self.env.ref("uom.product_uom_litre")
+        po = self.env["purchase.order"].create(
+            {
+                "partner_id": self.vendor.id,
+                "date_order": date.today(),
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": product2.id,
+                            "product_qty": 2.0,
+                            "product_uom_id": uom_liter.id,
+                            "price_unit": 3.0,
+                            "date_planned": date.today(),
+                            "name": product2.name,
+                        },
+                    )
+                ],
+            }
+        )
+        line = po.order_line
+        self.assertEqual(line.factor_base_uom_qty, 0.0)
+        self.assertEqual(line.factor_base_uom_display, "")

--- a/product_uom_factor_purchase/tests/test_purchase_line_base_uom_display.py
+++ b/product_uom_factor_purchase/tests/test_purchase_line_base_uom_display.py
@@ -22,14 +22,13 @@ class TestPurchaseLineBaseUomDisplay(TransactionCase):
         cls.uom_lb = cls.env.ref("uom.product_uom_lb")
         cls.uom_kg = cls.env.ref("uom.product_uom_kgm")
 
-        cls.uom_vol_category = cls.env.ref("uom.product_uom_categ_vol")
+        # "Bag" is a standalone root UoM (no relative_uom_id) so it has no
+        # common reference with any weight/volume UoM — i.e. it is cross-category
+        # relative to lb/kg in the Odoo 19 tree-based UoM model.
         cls.uom_bag = cls.env["uom.uom"].create(
             {
                 "name": "BagPO",
-                "category_id": cls.uom_vol_category.id,
-                "factor": 1.0,
-                "uom_type": "reference",
-                "rounding": 0.01,
+                "relative_factor": 1.0,
             }
         )
 

--- a/product_uom_factor_purchase/tests/test_render_pdf.py
+++ b/product_uom_factor_purchase/tests/test_render_pdf.py
@@ -1,0 +1,97 @@
+"""
+Tests for product_uom_factor_purchase: PDF report rendering.
+
+Acceptance Criteria:
+1. Rendered HTML for a cross-category PO line contains the base-UoM qty string
+   in a text-muted element (e.g. "150.00 lb").
+2. Same for the quotation (RFQ) PDF report.
+3. Equation form does not appear in either PDF.
+"""
+
+from datetime import date
+
+from odoo.tests.common import TransactionCase
+
+
+class TestRenderPdf(TransactionCase):
+    """Test that purchase PDF reports inject the base-UoM note."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.uom_lb = cls.env.ref("uom.product_uom_lb")
+        cls.uom_vol_category = cls.env.ref("uom.product_uom_categ_vol")
+        cls.uom_bag = cls.env["uom.uom"].create(
+            {
+                "name": "BagPurchasePDF",
+                "category_id": cls.uom_vol_category.id,
+                "factor": 1.0,
+                "uom_type": "reference",
+                "rounding": 0.01,
+            }
+        )
+        cls.vendor = cls.env["res.partner"].create(
+            {"name": "PDF Test Vendor", "supplier_rank": 1}
+        )
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "PDF Test Powder PO",
+                "uom_id": cls.uom_lb.id,
+                "uom_ids": [(4, cls.uom_lb.id), (4, cls.uom_bag.id)],
+                "standard_price": 3.0,
+            }
+        )
+        cls.env["product.uom.factor"].create(
+            {
+                "product_tmpl_id": cls.product.product_tmpl_id.id,
+                "uom_id": cls.uom_bag.id,
+                "factor": 50.0,
+            }
+        )
+        cls.po = cls.env["purchase.order"].create(
+            {
+                "partner_id": cls.vendor.id,
+                "date_order": date.today(),
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": cls.product.id,
+                            "product_qty": 3.0,
+                            "product_uom_id": cls.uom_bag.id,
+                            "price_unit": 3.0,
+                            "date_planned": date.today(),
+                            "name": cls.product.name,
+                        },
+                    )
+                ],
+            }
+        )
+
+    def _render(self, report_xmlid):
+        report = self.env.ref(report_xmlid)
+        html, _mime = report._render_qweb_html(self.po.ids)
+        return html.decode("utf-8") if isinstance(html, bytes) else html
+
+    def test_purchase_order_pdf_contains_base_uom_qty(self):
+        """PO confirmed PDF contains '150.00 lb' in a text-muted note."""
+        html_str = self._render("purchase.action_report_purchase_order")
+        self.assertIn("150.00 lb", html_str)
+        self.assertIn("text-muted", html_str)
+
+    def test_purchase_quotation_pdf_contains_base_uom_qty(self):
+        """PO quotation/RFQ PDF contains '150.00 lb' in a text-muted note."""
+        html_str = self._render("purchase.action_report_purchase_quotation")
+        self.assertIn("150.00 lb", html_str)
+        self.assertIn("text-muted", html_str)
+
+    def test_no_equation_form_in_pdfs(self):
+        """Neither PDF contains the equation form '× 150.00 lb'."""
+        for xmlid in (
+            "purchase.action_report_purchase_order",
+            "purchase.action_report_purchase_quotation",
+        ):
+            html_str = self._render(xmlid)
+            self.assertNotIn("× 150.00 lb", html_str)
+            self.assertNotIn("150.00 lb ×", html_str)

--- a/product_uom_factor_purchase/tests/test_render_pdf.py
+++ b/product_uom_factor_purchase/tests/test_render_pdf.py
@@ -3,9 +3,14 @@ Tests for product_uom_factor_purchase: PDF report rendering.
 
 Acceptance Criteria:
 1. Rendered HTML for a cross-category PO line contains the base-UoM qty string
-   in a text-muted element (e.g. "150.00 lb").
+   in a text-muted element (e.g. "150.00 lb") — exactly once (no duplicate
+   from the stock note which we now replace via XPath position="replace").
 2. Same for the quotation (RFQ) PDF report.
 3. Equation form does not appear in either PDF.
+4. The stock note's computed value does NOT appear alongside our note for a
+   cross-category line (i.e. no duplicate note from the replaced span).
+5. A same-category UoM mismatch (lb line on a kg-base product) still renders
+   the standard Odoo fallback note (i.e. the else branch works).
 """
 
 from datetime import date
@@ -14,15 +19,15 @@ from odoo.tests.common import TransactionCase
 
 
 class TestRenderPdf(TransactionCase):
-    """Test that purchase PDF reports inject the base-UoM note."""
+    """Test that purchase PDF reports replace the stock base-UoM note."""
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
         cls.uom_lb = cls.env.ref("uom.product_uom_lb")
-        # "Bag" is a standalone root UoM (no relative_uom_id) so it has no
-        # common reference with any weight/volume UoM — i.e. it is cross-category
-        # relative to lb/kg in the Odoo 19 tree-based UoM model.
+        cls.uom_kg = cls.env.ref("uom.product_uom_kgm")
+        # "BagPurchasePDF" is a standalone root UoM (no relative_uom_id) so it
+        # has no common reference with any weight/volume UoM — cross-category.
         cls.uom_bag = cls.env["uom.uom"].create(
             {
                 "name": "BagPurchasePDF",
@@ -67,10 +72,42 @@ class TestRenderPdf(TransactionCase):
                 ],
             }
         )
+        # A second PO with a same-category UoM mismatch line (lb on a kg-base
+        # product, no product.uom.factor) to test the fallback branch.
+        cls.product_kg_base = cls.env["product.product"].create(
+            {
+                "name": "PDF Test KG Product PO",
+                "uom_id": cls.uom_kg.id,
+                "uom_ids": [(4, cls.uom_kg.id), (4, cls.uom_lb.id)],
+                "standard_price": 1.0,
+            }
+        )
+        cls.po_same_cat = cls.env["purchase.order"].create(
+            {
+                "partner_id": cls.vendor.id,
+                "date_order": date.today(),
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": cls.product_kg_base.id,
+                            "product_qty": 10.0,
+                            "product_uom_id": cls.uom_lb.id,
+                            "price_unit": 1.0,
+                            "date_planned": date.today(),
+                            "name": cls.product_kg_base.name,
+                        },
+                    )
+                ],
+            }
+        )
 
-    def _render(self, report_xmlid):
+    def _render(self, report_xmlid, record=None):
+        if record is None:
+            record = self.po
         html, _mime = self.env["ir.actions.report"]._render_qweb_html(
-            report_xmlid, self.po.ids
+            report_xmlid, record.ids
         )
         return html.decode("utf-8") if isinstance(html, bytes) else html
 
@@ -95,3 +132,43 @@ class TestRenderPdf(TransactionCase):
             html_str = self._render(xmlid)
             self.assertNotIn("× 150.00 lb", html_str)
             self.assertNotIn("150.00 lb ×", html_str)
+
+    def test_no_duplicate_note_for_cross_category_po(self):
+        """For a cross-category factor line in confirmed PO, '150.00 lb' appears
+        exactly once (the stock note is replaced, not added alongside)."""
+        html_str = self._render("purchase.action_report_purchase_order")
+        count = html_str.count("150.00 lb")
+        self.assertEqual(
+            count,
+            1,
+            "Expected '150.00 lb' exactly once in the PO PDF but found "
+            f"{count} occurrences — the stock note may not have been replaced.",
+        )
+
+    def test_no_duplicate_note_for_cross_category_rfq(self):
+        """For a cross-category factor line in RFQ, '150.00 lb' appears
+        exactly once (the stock note is replaced, not added alongside)."""
+        html_str = self._render("purchase.report_purchase_quotation")
+        count = html_str.count("150.00 lb")
+        self.assertEqual(
+            count,
+            1,
+            "Expected '150.00 lb' exactly once in the RFQ PDF but found "
+            f"{count} occurrences — the stock note may not have been replaced.",
+        )
+
+    def test_same_category_uom_no_factor_po_pdf(self):
+        """A same-category UoM mismatch line (lb line on a kg-base product)
+        still renders the standard Odoo fallback note in the confirmed PO PDF."""
+        html_str = self._render(
+            "purchase.action_report_purchase_order", self.po_same_cat
+        )
+        self.assertIn("text-muted", html_str)
+
+    def test_same_category_uom_no_factor_rfq_pdf(self):
+        """A same-category UoM mismatch line (lb line on a kg-base product)
+        still renders the standard Odoo fallback note in the RFQ PDF."""
+        html_str = self._render(
+            "purchase.report_purchase_quotation", self.po_same_cat
+        )
+        self.assertIn("text-muted", html_str)

--- a/product_uom_factor_purchase/tests/test_render_pdf.py
+++ b/product_uom_factor_purchase/tests/test_render_pdf.py
@@ -20,14 +20,13 @@ class TestRenderPdf(TransactionCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.uom_lb = cls.env.ref("uom.product_uom_lb")
-        cls.uom_vol_category = cls.env.ref("uom.product_uom_categ_vol")
+        # "Bag" is a standalone root UoM (no relative_uom_id) so it has no
+        # common reference with any weight/volume UoM — i.e. it is cross-category
+        # relative to lb/kg in the Odoo 19 tree-based UoM model.
         cls.uom_bag = cls.env["uom.uom"].create(
             {
                 "name": "BagPurchasePDF",
-                "category_id": cls.uom_vol_category.id,
-                "factor": 1.0,
-                "uom_type": "reference",
-                "rounding": 0.01,
+                "relative_factor": 1.0,
             }
         )
         cls.vendor = cls.env["res.partner"].create(
@@ -70,8 +69,9 @@ class TestRenderPdf(TransactionCase):
         )
 
     def _render(self, report_xmlid):
-        report = self.env.ref(report_xmlid)
-        html, _mime = report._render_qweb_html(self.po.ids)
+        html, _mime = self.env["ir.actions.report"]._render_qweb_html(
+            report_xmlid, self.po.ids
+        )
         return html.decode("utf-8") if isinstance(html, bytes) else html
 
     def test_purchase_order_pdf_contains_base_uom_qty(self):
@@ -82,7 +82,7 @@ class TestRenderPdf(TransactionCase):
 
     def test_purchase_quotation_pdf_contains_base_uom_qty(self):
         """PO quotation/RFQ PDF contains '150.00 lb' in a text-muted note."""
-        html_str = self._render("purchase.action_report_purchase_quotation")
+        html_str = self._render("purchase.report_purchase_quotation")
         self.assertIn("150.00 lb", html_str)
         self.assertIn("text-muted", html_str)
 
@@ -90,7 +90,7 @@ class TestRenderPdf(TransactionCase):
         """Neither PDF contains the equation form '× 150.00 lb'."""
         for xmlid in (
             "purchase.action_report_purchase_order",
-            "purchase.action_report_purchase_quotation",
+            "purchase.report_purchase_quotation",
         ):
             html_str = self._render(xmlid)
             self.assertNotIn("× 150.00 lb", html_str)

--- a/product_uom_factor_purchase/views/purchase_order_views.xml
+++ b/product_uom_factor_purchase/views/purchase_order_views.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <!-- Add base-UoM helper column after qty on the PO line list view -->
+    <record id="view_purchase_order_line_factor_base_uom" model="ir.ui.view">
+        <field name="name">purchase.order.factor.base.uom</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.purchase_order_form" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//field[@name='order_line']//list//field[@name='product_qty']"
+                position="after"
+            >
+                <field
+                    name="factor_base_uom_display"
+                    optional="show"
+                    string="Base UoM"
+                />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/product_uom_factor_sale/__init__.py
+++ b/product_uom_factor_sale/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2026 Bemade Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from . import models

--- a/product_uom_factor_sale/__manifest__.py
+++ b/product_uom_factor_sale/__manifest__.py
@@ -1,0 +1,30 @@
+# Copyright 2026 Bemade Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+{
+    "name": "Product UoM Factor – Sale Bridge",
+    "summary": "Displays the base-UoM equivalent quantity on sale order lines",
+    "version": "19.0.1.0.0",
+    "development_status": "Alpha",
+    "license": "LGPL-3",
+    "author": "Bemade Inc.",
+    "website": "https://www.bemade.org",
+    "maintainers": ["mdurepos"],
+    "depends": [
+        "product_uom_factor",
+        "sale",
+    ],
+    "data": [
+        "views/sale_order_views.xml",
+        "report/sale_order_templates.xml",
+    ],
+    "assets": {
+        "web.assets_unit_tests": [
+            "product_uom_factor_sale/static/tests/**/*",
+            ("remove", "product_uom_factor_sale/static/tests/tours/**/*"),
+        ],
+        "web.assets_tests": [
+            "product_uom_factor_sale/static/tests/tours/**/*",
+        ],
+    },
+}

--- a/product_uom_factor_sale/models/__init__.py
+++ b/product_uom_factor_sale/models/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2026 Bemade Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from . import sale_order_line

--- a/product_uom_factor_sale/models/sale_order_line.py
+++ b/product_uom_factor_sale/models/sale_order_line.py
@@ -1,0 +1,68 @@
+# Copyright 2026 Bemade Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo import api, fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    factor_base_uom_qty = fields.Float(
+        string="Base UoM Qty",
+        compute="_compute_factor_base_uom",
+        store=False,
+        help="Quantity expressed in the product's base UoM, computed via the "
+        "product-specific cross-category conversion factor. Zero when the line "
+        "UoM is in the same category as the product's base UoM or no factor "
+        "record exists for this product.",
+    )
+    factor_base_uom_display = fields.Char(
+        string="Base UoM",
+        compute="_compute_factor_base_uom",
+        store=False,
+        help="Human-readable base-UoM quantity for display on the order form "
+        '(e.g. "= 250.00 lb"). Empty when no cross-category factor applies.',
+    )
+
+    @api.depends(
+        "product_uom_qty",
+        "product_uom_id",
+        "product_id",
+        "product_id.uom_id",
+    )
+    def _compute_factor_base_uom(self):
+        for line in self:
+            product = line.product_id
+            line_uom = line.product_uom_id
+            if not product or not line_uom:
+                line.factor_base_uom_qty = 0.0
+                line.factor_base_uom_display = ""
+                continue
+
+            base_uom = product.uom_id
+            # Short-circuit: same-category means standard Odoo handles it,
+            # no factor display needed.
+            if not base_uom or base_uom._has_common_reference(line_uom):
+                line.factor_base_uom_qty = 0.0
+                line.factor_base_uom_display = ""
+                continue
+
+            # Check that a product.uom.factor record exists for this product
+            # and line UoM (or its category).
+            factor_record = line_uom._find_product_uom_for_category(
+                product.id, line_uom
+            )
+            if not factor_record:
+                line.factor_base_uom_qty = 0.0
+                line.factor_base_uom_display = ""
+                continue
+
+            # Convert line qty from line_uom → product base_uom using the
+            # product-specific factor. The core's _compute_quantity override
+            # picks up the factor automatically via product_id context.
+            base_qty = line_uom.with_context(
+                product_id=product.id
+            )._compute_quantity(line.product_uom_qty, base_uom, round=False)
+
+            line.factor_base_uom_qty = base_qty
+            line.factor_base_uom_display = "= %.2f %s" % (base_qty, base_uom.name)

--- a/product_uom_factor_sale/readme/DESCRIPTION.md
+++ b/product_uom_factor_sale/readme/DESCRIPTION.md
@@ -1,0 +1,17 @@
+Bridge module between `product_uom_factor` and `sale`.
+
+When a sale order line uses a cross-category UoM (e.g. ordering in "Bag" when
+the product is stocked in "lb"), this module computes and surfaces the
+base-UoM equivalent quantity so users can verify conversions at a glance.
+
+## Features
+
+- Adds a computed **Base UoM** helper column on the SO line list (shows
+  `"= 250.00 lb"` for internal users; column is optional/show by default).
+- Injects a grey base-UoM quantity note under the product name in the
+  **sale order / quotation PDF** (customer-facing; shows only the quantity,
+  e.g. `"250.00 lb"`, without the equation form).
+
+## Dependencies
+
+Requires `product_uom_factor` (core) and `sale`.

--- a/product_uom_factor_sale/report/sale_order_templates.xml
+++ b/product_uom_factor_sale/report/sale_order_templates.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <!--
+        Inject base-UoM quantity note under the product name in the SO PDF.
+        Customer-facing: shows only the base-UoM qty (e.g. "250.00 lb").
+        The form-view column (= 250.00 lb) is for internal use only.
+    -->
+    <template
+        id="report_saleorder_line_factor_base_uom"
+        inherit_id="sale.report_saleorder_document"
+    >
+        <xpath
+            expr="//td[@name='td_name']/span[@t-field='line.name']"
+            position="after"
+        >
+            <t t-if="line.factor_base_uom_qty">
+                <br />
+                <small class="text-muted">
+                    <t t-out="'%.2f %s' % (line.factor_base_uom_qty, line.product_id.uom_id.name)" />
+                </small>
+            </t>
+        </xpath>
+    </template>
+</odoo>

--- a/product_uom_factor_sale/report/sale_order_templates.xml
+++ b/product_uom_factor_sale/report/sale_order_templates.xml
@@ -10,7 +10,7 @@
         inherit_id="sale.report_saleorder_document"
     >
         <xpath
-            expr="//td[@name='td_name']/span[@t-field='line.name']"
+            expr="//td[@name='td_product_name']/span[@t-field='line.name']"
             position="after"
         >
             <t t-if="line.factor_base_uom_qty">

--- a/product_uom_factor_sale/report/sale_order_templates.xml
+++ b/product_uom_factor_sale/report/sale_order_templates.xml
@@ -1,23 +1,43 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
     <!--
-        Inject base-UoM quantity note under the product name in the SO PDF.
-        Customer-facing: shows only the base-UoM qty (e.g. "250.00 lb").
-        The form-view column (= 250.00 lb) is for internal use only.
+        Replace the stock base-UoM note in the qty cell of the SO PDF.
+
+        Odoo 19 sale report (`sale.report_saleorder_document`, line 214-217 of
+        ir_actions_report_templates.xml) emits:
+            <span t-if="line.product_uom_id != line.product_id.uom_id"
+                  class="text-muted small">
+                …_compute_quantity without product_id context…
+            </span>
+        For cross-category lines that have a product.uom.factor record, that
+        stock call produces the wrong number (it treats it as a same-category
+        conversion). We replace the span entirely:
+        - cross-category with our factor → show the correct value from
+          line.factor_base_uom_qty (computed with product_id context).
+        - same-category mismatch (e.g. kg line on a g product) → fallback
+          to the original stock behavior so we don't regress that use case.
     -->
     <template
         id="report_saleorder_line_factor_base_uom"
         inherit_id="sale.report_saleorder_document"
     >
         <xpath
-            expr="//td[@name='td_product_name']/span[@t-field='line.name']"
-            position="after"
+            expr="//span[@t-if='line.product_uom_id != line.product_id.uom_id']"
+            position="replace"
         >
             <t t-if="line.factor_base_uom_qty">
-                <br />
-                <small class="text-muted">
+                <!-- Cross-category with our factor: show the correct base-UoM qty. -->
+                <span class="text-muted small">
+                    <br />
                     <t t-out="'%.2f %s' % (line.factor_base_uom_qty, line.product_id.uom_id.name)" />
-                </small>
+                </span>
+            </t>
+            <t t-elif="line.product_uom_id != line.product_id.uom_id">
+                <!-- Same-category UoM mismatch: preserve stock behavior. -->
+                <span class="text-muted small">
+                    <t t-set="quantity_in_product_uom" t-value="line.product_uom_id._compute_quantity(line.product_uom_qty, line.product_id.uom_id)" />
+                    <br /><span t-esc="quantity_in_product_uom" t-options="{'widget': 'float', 'decimal_precision': 'Product Unit'}" /> <span t-field="line.product_id.uom_id" />
+                </span>
             </t>
         </xpath>
     </template>

--- a/product_uom_factor_sale/static/tests/tours/sale_factor_display_tour.js
+++ b/product_uom_factor_sale/static/tests/tours/sale_factor_display_tour.js
@@ -1,0 +1,18 @@
+import {registry} from "@web/core/registry";
+
+registry.category("web_tour.tours").add("sale_factor_display_tour", {
+    steps: () => [
+        {
+            trigger: ".o_form_view .o_field_one2many[name='order_line']",
+            content: "Wait for the order line list to load",
+        },
+        {
+            // The optional column "Base UoM" should show the cross-category
+            // equivalent quantity, e.g. "= 250.00 lb".
+            trigger:
+                ".o_field_one2many[name='order_line'] .o_list_renderer " +
+                "td[name='factor_base_uom_display']:contains('= ')",
+            content: "Base UoM column shows the cross-category quantity",
+        },
+    ],
+});

--- a/product_uom_factor_sale/tests/__init__.py
+++ b/product_uom_factor_sale/tests/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2026 Bemade Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from . import test_sale_line_base_uom_display
+from . import test_render_pdf

--- a/product_uom_factor_sale/tests/test_render_pdf.py
+++ b/product_uom_factor_sale/tests/test_render_pdf.py
@@ -18,14 +18,13 @@ class TestRenderPdf(TransactionCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.uom_lb = cls.env.ref("uom.product_uom_lb")
-        cls.uom_vol_category = cls.env.ref("uom.product_uom_categ_vol")
+        # "BagPDF" is a standalone root UoM (no relative_uom_id) so it has no
+        # common reference with any weight/volume UoM — i.e. it is cross-category
+        # relative to lb/kg in the Odoo 19 tree-based UoM model.
         cls.uom_bag = cls.env["uom.uom"].create(
             {
                 "name": "BagPDF",
-                "category_id": cls.uom_vol_category.id,
-                "factor": 1.0,
-                "uom_type": "reference",
-                "rounding": 0.01,
+                "relative_factor": 1.0,
             }
         )
         cls.customer = cls.env["res.partner"].create(
@@ -64,20 +63,22 @@ class TestRenderPdf(TransactionCase):
             }
         )
 
+    def _render(self, report_xmlid):
+        html, _mime = self.env["ir.actions.report"]._render_qweb_html(
+            report_xmlid, self.so.ids
+        )
+        return html.decode("utf-8") if isinstance(html, bytes) else html
+
     def test_pdf_contains_base_uom_qty(self):
         """Rendered HTML contains '250.00 lb' in a text-muted note."""
-        report = self.env.ref("sale.action_report_saleorder")
-        html, _mime = report._render_qweb_html(self.so.ids)
-        html_str = html.decode("utf-8") if isinstance(html, bytes) else html
+        html_str = self._render("sale.action_report_saleorder")
         self.assertIn("250.00 lb", html_str)
         self.assertIn("text-muted", html_str)
 
     def test_pdf_no_equation_form(self):
         """Rendered HTML does not contain the equation form '×' or '= ' in
         proximity to the base-UoM note (customer PDF shows qty only)."""
-        report = self.env.ref("sale.action_report_saleorder")
-        html, _mime = report._render_qweb_html(self.so.ids)
-        html_str = html.decode("utf-8") if isinstance(html, bytes) else html
+        html_str = self._render("sale.action_report_saleorder")
         # The × character must not appear in the text-muted note produced
         # by this module (it would indicate an equation-style output).
         # We assert the rendered output for our test SO doesn't contain ×

--- a/product_uom_factor_sale/tests/test_render_pdf.py
+++ b/product_uom_factor_sale/tests/test_render_pdf.py
@@ -1,0 +1,86 @@
+"""
+Tests for product_uom_factor_sale: PDF report rendering.
+
+Acceptance Criteria:
+1. Rendered HTML for a cross-category line contains the base-UoM qty string
+   inside a text-muted element under the product name (e.g. "250.00 lb").
+2. The equation form does NOT appear in the rendered PDF (no "×" or "= " chars
+   in the base-UoM note — the customer-facing readout is quantity only).
+"""
+
+from odoo.tests.common import TransactionCase
+
+
+class TestRenderPdf(TransactionCase):
+    """Test that the sale order PDF report injects the base-UoM note."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.uom_lb = cls.env.ref("uom.product_uom_lb")
+        cls.uom_vol_category = cls.env.ref("uom.product_uom_categ_vol")
+        cls.uom_bag = cls.env["uom.uom"].create(
+            {
+                "name": "BagPDF",
+                "category_id": cls.uom_vol_category.id,
+                "factor": 1.0,
+                "uom_type": "reference",
+                "rounding": 0.01,
+            }
+        )
+        cls.customer = cls.env["res.partner"].create(
+            {"name": "PDF Test Customer", "customer_rank": 1}
+        )
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "PDF Test Powder",
+                "uom_id": cls.uom_lb.id,
+                "uom_ids": [(4, cls.uom_lb.id), (4, cls.uom_bag.id)],
+                "list_price": 5.0,
+            }
+        )
+        cls.env["product.uom.factor"].create(
+            {
+                "product_tmpl_id": cls.product.product_tmpl_id.id,
+                "uom_id": cls.uom_bag.id,
+                "factor": 50.0,
+            }
+        )
+        cls.so = cls.env["sale.order"].create(
+            {
+                "partner_id": cls.customer.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": cls.product.id,
+                            "product_uom_qty": 5.0,
+                            "product_uom_id": cls.uom_bag.id,
+                            "price_unit": 5.0,
+                        },
+                    )
+                ],
+            }
+        )
+
+    def test_pdf_contains_base_uom_qty(self):
+        """Rendered HTML contains '250.00 lb' in a text-muted note."""
+        report = self.env.ref("sale.action_report_saleorder")
+        html, _mime = report._render_qweb_html(self.so.ids)
+        html_str = html.decode("utf-8") if isinstance(html, bytes) else html
+        self.assertIn("250.00 lb", html_str)
+        self.assertIn("text-muted", html_str)
+
+    def test_pdf_no_equation_form(self):
+        """Rendered HTML does not contain the equation form '×' or '= ' in
+        proximity to the base-UoM note (customer PDF shows qty only)."""
+        report = self.env.ref("sale.action_report_saleorder")
+        html, _mime = report._render_qweb_html(self.so.ids)
+        html_str = html.decode("utf-8") if isinstance(html, bytes) else html
+        # The × character must not appear in the text-muted note produced
+        # by this module (it would indicate an equation-style output).
+        # We assert the rendered output for our test SO doesn't contain ×
+        # adjacent to "250.00 lb" — a simple sanity check.
+        self.assertNotIn("× 250.00 lb", html_str)
+        self.assertNotIn("250.00 lb ×", html_str)

--- a/product_uom_factor_sale/tests/test_render_pdf.py
+++ b/product_uom_factor_sale/tests/test_render_pdf.py
@@ -3,21 +3,27 @@ Tests for product_uom_factor_sale: PDF report rendering.
 
 Acceptance Criteria:
 1. Rendered HTML for a cross-category line contains the base-UoM qty string
-   inside a text-muted element under the product name (e.g. "250.00 lb").
+   in a text-muted element (e.g. "250.00 lb") — exactly once (no duplicate
+   from the stock note which we now replace via XPath position="replace").
 2. The equation form does NOT appear in the rendered PDF (no "×" or "= " chars
    in the base-UoM note — the customer-facing readout is quantity only).
+3. The stock note's computed value does NOT appear alongside our note for a
+   cross-category line (i.e. no duplicate note from the replaced span).
+4. A same-category UoM mismatch (kg line on a lb product) still renders the
+   standard Odoo fallback note (i.e. the else branch works).
 """
 
 from odoo.tests.common import TransactionCase
 
 
 class TestRenderPdf(TransactionCase):
-    """Test that the sale order PDF report injects the base-UoM note."""
+    """Test that the sale order PDF report replaces the stock base-UoM note."""
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
         cls.uom_lb = cls.env.ref("uom.product_uom_lb")
+        cls.uom_kg = cls.env.ref("uom.product_uom_kgm")
         # "BagPDF" is a standalone root UoM (no relative_uom_id) so it has no
         # common reference with any weight/volume UoM — i.e. it is cross-category
         # relative to lb/kg in the Odoo 19 tree-based UoM model.
@@ -62,10 +68,39 @@ class TestRenderPdf(TransactionCase):
                 ],
             }
         )
+        # A second SO with a same-category UoM mismatch line (kg on a lb product,
+        # no product.uom.factor configured) to verify the fallback branch.
+        cls.product_kg_base = cls.env["product.product"].create(
+            {
+                "name": "PDF Test KG Product",
+                "uom_id": cls.uom_kg.id,
+                "uom_ids": [(4, cls.uom_kg.id), (4, cls.uom_lb.id)],
+                "list_price": 2.0,
+            }
+        )
+        cls.so_same_cat = cls.env["sale.order"].create(
+            {
+                "partner_id": cls.customer.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": cls.product_kg_base.id,
+                            "product_uom_qty": 10.0,
+                            "product_uom_id": cls.uom_lb.id,
+                            "price_unit": 2.0,
+                        },
+                    )
+                ],
+            }
+        )
 
-    def _render(self, report_xmlid):
+    def _render(self, report_xmlid, record=None):
+        if record is None:
+            record = self.so
         html, _mime = self.env["ir.actions.report"]._render_qweb_html(
-            report_xmlid, self.so.ids
+            report_xmlid, record.ids
         )
         return html.decode("utf-8") if isinstance(html, bytes) else html
 
@@ -85,3 +120,33 @@ class TestRenderPdf(TransactionCase):
         # adjacent to "250.00 lb" — a simple sanity check.
         self.assertNotIn("× 250.00 lb", html_str)
         self.assertNotIn("250.00 lb ×", html_str)
+
+    def test_pdf_no_duplicate_note_for_cross_category_line(self):
+        """For a cross-category factor line, '250.00 lb' appears exactly once
+        (the stock note is replaced, not added alongside).
+
+        The stock Odoo template (ir_actions_report_templates.xml lines 214-217)
+        emits a <span t-if="line.product_uom_id != line.product_id.uom_id"> in
+        the qty cell. Our XPath position="replace" swaps it with our note. If
+        both coexisted the count would be 2; we assert exactly 1.
+        """
+        html_str = self._render("sale.action_report_saleorder")
+        count = html_str.count("250.00 lb")
+        self.assertEqual(
+            count,
+            1,
+            "Expected '250.00 lb' exactly once in the rendered HTML but found "
+            f"{count} occurrences — the stock note may not have been replaced.",
+        )
+
+    def test_same_category_uom_no_factor_pdf(self):
+        """A same-category UoM mismatch line (lb line on a kg-base product)
+        still renders the standard Odoo fallback note in the qty cell.
+
+        This verifies that our XPath replace's t-elif branch fires correctly
+        and does not suppress the stock note for same-category mismatches.
+        """
+        html_str = self._render("sale.action_report_saleorder", self.so_same_cat)
+        # The rendered HTML should still show a text-muted note because
+        # the line UoM (lb) != product base UoM (kg).
+        self.assertIn("text-muted", html_str)

--- a/product_uom_factor_sale/tests/test_sale_line_base_uom_display.py
+++ b/product_uom_factor_sale/tests/test_sale_line_base_uom_display.py
@@ -21,17 +21,13 @@ class TestSaleLineBaseUomDisplay(TransactionCase):
         cls.uom_lb = cls.env.ref("uom.product_uom_lb")
         cls.uom_kg = cls.env.ref("uom.product_uom_kgm")
 
-        # Create a cross-category UoM: "Bag" in a new category so it is
-        # definitively cross-category relative to the weight category.
-        # We reuse the "volume" category to guarantee cross-category.
-        cls.uom_vol_category = cls.env.ref("uom.product_uom_categ_vol")
+        # "Bag" is a standalone root UoM (no relative_uom_id) so it has no
+        # common reference with any weight/volume UoM — i.e. it is cross-category
+        # relative to lb/kg in the Odoo 19 tree-based UoM model.
         cls.uom_bag = cls.env["uom.uom"].create(
             {
                 "name": "Bag",
-                "category_id": cls.uom_vol_category.id,
-                "factor": 1.0,
-                "uom_type": "reference",
-                "rounding": 0.01,
+                "relative_factor": 1.0,
             }
         )
 

--- a/product_uom_factor_sale/tests/test_sale_line_base_uom_display.py
+++ b/product_uom_factor_sale/tests/test_sale_line_base_uom_display.py
@@ -1,0 +1,126 @@
+"""
+Tests for product_uom_factor_sale: computed base-UoM display fields on SO lines.
+
+Acceptance Criteria:
+1. Happy path: 5 Bag × 50 lb/Bag → factor_base_uom_qty=250.0,
+   factor_base_uom_display="= 250.00 lb".
+2. Same-category no-op: line UoM == product base UoM → factor_base_uom_qty=0.0.
+3. Missing factor no-op: no product.uom.factor row for the cross-category UoM
+   → factor_base_uom_qty=0.0 (does not raise).
+"""
+
+from odoo.tests.common import TransactionCase
+
+
+class TestSaleLineBaseUomDisplay(TransactionCase):
+    """Test computed base-UoM display fields on sale.order.line."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.uom_lb = cls.env.ref("uom.product_uom_lb")
+        cls.uom_kg = cls.env.ref("uom.product_uom_kgm")
+
+        # Create a cross-category UoM: "Bag" in a new category so it is
+        # definitively cross-category relative to the weight category.
+        # We reuse the "volume" category to guarantee cross-category.
+        cls.uom_vol_category = cls.env.ref("uom.product_uom_categ_vol")
+        cls.uom_bag = cls.env["uom.uom"].create(
+            {
+                "name": "Bag",
+                "category_id": cls.uom_vol_category.id,
+                "factor": 1.0,
+                "uom_type": "reference",
+                "rounding": 0.01,
+            }
+        )
+
+        cls.customer = cls.env["res.partner"].create(
+            {"name": "Test Customer", "customer_rank": 1}
+        )
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Test Powder",
+                "uom_id": cls.uom_lb.id,
+                "uom_ids": [(4, cls.uom_lb.id), (4, cls.uom_bag.id)],
+                "list_price": 5.0,
+            }
+        )
+        # 1 Bag = 50 lb
+        cls.factor = cls.env["product.uom.factor"].create(
+            {
+                "product_tmpl_id": cls.product.product_tmpl_id.id,
+                "uom_id": cls.uom_bag.id,
+                "factor": 50.0,
+            }
+        )
+
+    def _make_so_line(self, qty, uom):
+        so = self.env["sale.order"].create(
+            {
+                "partner_id": self.customer.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product.id,
+                            "product_uom_qty": qty,
+                            "product_uom_id": uom.id,
+                            "price_unit": 5.0,
+                        },
+                    )
+                ],
+            }
+        )
+        return so.order_line
+
+    def test_happy_path_cross_category(self):
+        """5 Bag × 50 lb/Bag → factor_base_uom_qty=250.0, display='= 250.00 lb'."""
+        line = self._make_so_line(5.0, self.uom_bag)
+        self.assertAlmostEqual(line.factor_base_uom_qty, 250.0, places=2)
+        self.assertEqual(line.factor_base_uom_display, "= 250.00 lb")
+
+    def test_same_category_no_display(self):
+        """Line UoM in the same category as base UoM → qty=0.0, no display."""
+        line = self._make_so_line(10.0, self.uom_lb)
+        self.assertEqual(line.factor_base_uom_qty, 0.0)
+        self.assertEqual(line.factor_base_uom_display, "")
+
+    def test_same_category_kg_no_display(self):
+        """Line UoM kg (same weight category as lb) → qty=0.0."""
+        line = self._make_so_line(2.0, self.uom_kg)
+        self.assertEqual(line.factor_base_uom_qty, 0.0)
+        self.assertEqual(line.factor_base_uom_display, "")
+
+    def test_missing_factor_no_display(self):
+        """Cross-category UoM with no product.uom.factor row → qty=0.0."""
+        uom_liter = self.env.ref("uom.product_uom_litre")
+        # Product has no factor for litre; this should not raise.
+        product2 = self.env["product.product"].create(
+            {
+                "name": "Test Powder No Factor",
+                "uom_id": self.uom_lb.id,
+                "list_price": 5.0,
+            }
+        )
+        so = self.env["sale.order"].create(
+            {
+                "partner_id": self.customer.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": product2.id,
+                            "product_uom_qty": 3.0,
+                            "product_uom_id": uom_liter.id,
+                            "price_unit": 5.0,
+                        },
+                    )
+                ],
+            }
+        )
+        line = so.order_line
+        self.assertEqual(line.factor_base_uom_qty, 0.0)
+        self.assertEqual(line.factor_base_uom_display, "")

--- a/product_uom_factor_sale/views/sale_order_views.xml
+++ b/product_uom_factor_sale/views/sale_order_views.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <!-- Add base-UoM helper column after qty on the SO line list view -->
+    <record id="view_sale_order_line_factor_base_uom" model="ir.ui.view">
+        <field name="name">sale.order.factor.base.uom</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//field[@name='order_line']//list//field[@name='product_uom_qty']"
+                position="after"
+            >
+                <field
+                    name="factor_base_uom_display"
+                    optional="show"
+                    string="Base UoM"
+                />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Summary

Splits `product_uom_factor` (already a pure product-side module) into core + two opt-in bridge modules for Odoo 19, surfacing the base-UoM equivalent on SO/PO lines and PDFs for cross-category UoM lines (e.g., sand sold by 50-lb Bag).

- **`product_uom_factor`** bumped to 19.0.2.0.0 with a no-op `19.0.2.0.0` post-migration hook documenting the split. No deps change.
- **`product_uom_factor_sale`** (new, 19.0.1.0.0) — depends on `product_uom_factor + sale`. Adds `factor_base_uom_qty` and `factor_base_uom_display` computed read-only fields on `sale.order.line`, surfaces an optional "Base UoM" column on the order form (`= 250.00 lb`), and **replaces** the stock SO PDF base-UoM note via XPath when a `product.uom.factor` applies (with a `t-elif` fallback that preserves stock behavior for same-category UoM mismatches).
- **`product_uom_factor_purchase`** (new, 19.0.1.0.0) — depends on `product_uom_factor + purchase`. Mirror of the sale bridge for `purchase.order.line` and both PO + RFQ PDF templates.

PDF shows only the base-UoM quantity (no equation) per design feedback; the order-form column shows `= 250.00 lb` for internal users.

## Tests

47 tests, 0 failures, 0 errors. Run via `odoo-dev test product_uom_factor,product_uom_factor_sale,product_uom_factor_purchase` against an Odoo 19 workspace. Includes:

- Core regression (29 tests preserved)
- Cross-category compute happy path on both SO and PO lines
- Same-category UoM no-op (no factor display)
- Missing-factor no-op (no exception)
- PDF render assertion for SO, PO, RFQ
- **count() == 1 assertions** confirming the XPath replace removed the stock note (no duplicates on cross-category lines)
- Same-category-fallback PDF tests (regression guard for the t-elif branch)

Coverage 98% overall, 89% on each bridge model, 100% on test_render_pdf.py in both bridges.

## Follow-ups (out of scope here)

- Bump `bemade-addons` submodule pointer in `rwi/` and `verajet/` deployments and add the new bridges to their install manifests. Separate per-client tasks.
- Optional `product_uom_factor_account` for invoice/bill surfacing. Defer until customers ask.
- Migration smoke test (#9 of design plan); install-independence matrix (#10); wire JS tour stubs to HttpCase (#6). All flagged as follow-ups in the review.
- Tighter same_category_fallback test assertion (text-muted substring vs. the expected converted value).
- Same position="replace" pattern likely worth adding for `product_uom_packaging` if a similar duplicate-note overlap exists there.

## Related

- Odoo task: https://odoo.bemade.org/odoo/project/23/tasks/3647
- Pipeline artifacts: https://git.bemade.org/bemade/tasks/-/tree/main/task-3647-split-product-uom-factor
- Blocks: #3645 (onboarding tours), which is parked until this lands.