### PR TITLE
Add bemade_sql_console: admin-only read-only SQL console

### DIFF
--- a/bemade_sql_console/__init__.py
+++ b/bemade_sql_console/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/bemade_sql_console/__manifest__.py
+++ b/bemade_sql_console/__manifest__.py
@@ -1,0 +1,66 @@
+{
+    "name": "Read-only SQL Console",
+    "version": "19.0.1.0.0",
+    "category": "Technical",
+    "summary": "Admin-only read-only SQL console executed as a SELECT-only Postgres role",
+    "description": """
+Read-only SQL Console
+=====================
+
+Provides an admin-only ``run_query(sql)`` method (and matching CodeEditor view)
+that executes a single SELECT statement as a SELECT-only PostgreSQL role over
+its own dedicated connection — never the Odoo owner connection.
+
+Key guarantees
+--------------
+
+* **Role-level write boundary.** The addon opens a fresh psycopg2 connection
+  authenticated as the ``ODOO_RO_DB_USER`` role, which must be provisioned as a
+  SELECT-only role by the ops team (odoo-operator PR #135). Writes are rejected
+  at the PostgreSQL privilege layer regardless of SQL content.
+
+* **Defense-in-depth.** The connection is additionally set read-only at the
+  app layer (``set_session(readonly=True)``) so that even a misconfigured role
+  is constrained.
+
+* **Single-statement guard.** Only a single ``SELECT`` or ``WITH`` statement
+  is accepted. Multiple statements or non-SELECT leading verbs are rejected
+  immediately with a friendly error — before any connection is opened.
+
+* **Statement timeout.** A configurable ``statement_timeout`` (default 30 s)
+  is applied both via libpq ``options`` and as a first-cursor ``SET`` so that
+  long-running queries are aborted server-side.
+
+* **Row cap.** A configurable row cap (default 1000) bounds returned rows;
+  the response envelope carries a ``truncated`` flag.
+
+* **Graceful degradation.** When ``ODOO_RO_DB_USER``/``ODOO_RO_DB_PASSWORD``
+  are not set (dev/test), ``run_query`` raises a clear "not configured" error
+  rather than falling back to the owner connection.
+
+* **RPC-callable.** ``run_query`` is an ``@api.model`` method callable over
+  ``execute_kw`` by a user authenticated with an Odoo API key, making it
+  suitable for BI tools and AI agents.
+
+Security note
+-------------
+
+The statement-level guard (SELECT/WITH prefix check) is **not** the security
+boundary — a writable CTE starting with ``WITH`` passes the guard and is then
+rejected by the role ACL. The guard's job is user-friendliness (criterion 5),
+not write prevention. The SELECT-only PostgreSQL role is the real boundary.
+""",
+    "author": "Bemade Inc.",
+    "website": "https://www.bemade.org",
+    "license": "LGPL-3",
+    "depends": ["base"],
+    "data": [
+        "security/security.xml",
+        "security/ir.model.access.csv",
+        "data/ir_config_parameter.xml",
+        "views/sql_console_views.xml",
+    ],
+    "installable": True,
+    "application": False,
+    "auto_install": False,
+}

--- a/bemade_sql_console/data/ir_config_parameter.xml
+++ b/bemade_sql_console/data/ir_config_parameter.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2026 Bemade Inc.
+    License LGPL-3 or later (https://www.gnu.org/licenses/lgpl).
+-->
+<odoo>
+    <!--
+        Seed default values for the SQL console runtime parameters.
+        noupdate="1" so that ops-tuned values survive module upgrades.
+    -->
+    <data noupdate="1">
+
+        <record id="param_row_cap" model="ir.config_parameter">
+            <field name="key">bemade_sql_console.row_cap</field>
+            <field name="value">1000</field>
+        </record>
+
+        <record id="param_statement_timeout_ms" model="ir.config_parameter">
+            <field name="key">bemade_sql_console.statement_timeout_ms</field>
+            <field name="value">30000</field>
+        </record>
+
+    </data>
+</odoo>

--- a/bemade_sql_console/models/__init__.py
+++ b/bemade_sql_console/models/__init__.py
@@ -1,0 +1,2 @@
+from . import sql_console
+from . import sql_console_wizard

--- a/bemade_sql_console/models/sql_console.py
+++ b/bemade_sql_console/models/sql_console.py
@@ -1,0 +1,379 @@
+"""
+sql.console — read-only SQL console service model.
+
+Security model
+--------------
+1. In-method group check (AccessError) — the only RPC trust boundary, because
+   Odoo's RPC dispatcher does NOT rights-check method calls beyond authentication.
+2. Role-level ACL — connection opens as ODOO_RO_DB_USER (SELECT-only role);
+   writes rejected by PostgreSQL regardless of SQL content.
+3. App-layer read-only — set_session(readonly=True) as defense-in-depth.
+4. Single-statement guard — friendly error before any connection is opened.
+5. Statement timeout — libpq options + SET belt-and-braces.
+"""
+
+import base64
+import datetime
+import decimal
+import logging
+import os
+import re
+import uuid
+
+import psycopg2
+import psycopg2.errors
+
+import odoo.sql_db
+from odoo import _, api, models
+from odoo.exceptions import AccessError, UserError
+
+_logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# _jsonify — make psycopg2 native types JSON-serializable
+# ---------------------------------------------------------------------------
+
+def _jsonify(v):
+    """Recursively coerce a psycopg2 value to a JSON-serializable Python object.
+
+    Key decisions:
+    - decimal.Decimal → str  (LOCKED: preserves exact values for Trial Balance;
+      do NOT change to float — precision loss on monetary/numeric is unacceptable)
+    - datetime/date/time → ISO-8601 string
+    - timedelta → total_seconds() float
+    - bytes/memoryview → base64 string
+    - uuid.UUID → str
+    - dict/list — recurse
+    - None, bool, int, float, str — as-is
+    - anything else — str() fallback
+    """
+    if v is None or isinstance(v, (bool, int, float, str)):
+        return v
+    if isinstance(v, decimal.Decimal):
+        return str(v)
+    if isinstance(v, datetime.datetime):
+        return v.isoformat()
+    if isinstance(v, datetime.date):
+        return v.isoformat()
+    if isinstance(v, datetime.time):
+        return v.isoformat()
+    if isinstance(v, datetime.timedelta):
+        return v.total_seconds()
+    if isinstance(v, (bytes, memoryview)):
+        raw = bytes(v)
+        return base64.b64encode(raw).decode("ascii")
+    if isinstance(v, uuid.UUID):
+        return str(v)
+    if isinstance(v, dict):
+        return {k: _jsonify(val) for k, val in v.items()}
+    if isinstance(v, list):
+        return [_jsonify(item) for item in v]
+    # Fallback — never let a non-serializable type escape
+    return str(v)
+
+
+# ---------------------------------------------------------------------------
+# Single-statement guard (belt check, NOT the security boundary)
+# ---------------------------------------------------------------------------
+
+# Regex to strip leading SQL line comments (-- …\n)
+_LINE_COMMENT_RE = re.compile(r"--[^\n]*\n?")
+# Regex to strip block comments (/* … */)
+_BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+
+# Leading verbs that are allowed (only SELECT and WITH for CTEs)
+_ALLOWED_LEADING_VERBS = frozenset(["select", "with"])
+
+
+def _validate_single_select(sql: str) -> None:
+    """Raise UserError if *sql* is not a single SELECT/WITH statement.
+
+    This is a *belt* check for user-friendliness and criterion 5 compliance —
+    NOT the security boundary.  A writable CTE starting with WITH passes this
+    guard and is then rejected by the RO role at execution time.
+
+    Algorithm
+    ---------
+    1. Strip leading SQL comments and whitespace.
+    2. Require the first keyword to be SELECT or WITH.
+    3. Scan the remaining text for a semicolon that is not inside a quoted
+       string or identifier literal (single-quotes, double-quotes,
+       dollar-quoting, or comments).  A single trailing semicolon is allowed;
+       anything beyond it (i.e. a second statement) is rejected.
+    """
+    if not sql or not sql.strip():
+        raise UserError(_("Please enter a SQL query."))
+
+    # Strip comments to find the leading verb
+    stripped = _LINE_COMMENT_RE.sub(" ", sql)
+    stripped = _BLOCK_COMMENT_RE.sub(" ", stripped)
+    stripped = stripped.strip()
+
+    # Identify first keyword
+    first_word = re.match(r"[A-Za-z_]+", stripped)
+    if not first_word or first_word.group(0).lower() not in _ALLOWED_LEADING_VERBS:
+        verb = first_word.group(0) if first_word else "<empty>"
+        raise UserError(
+            _(
+                "Only SELECT or WITH queries are allowed. "
+                "Got leading keyword: %(verb)s",
+                verb=verb.upper(),
+            )
+        )
+
+    # State-machine scan for extra statement boundaries (semicolons outside literals)
+    _scan_for_multiple_statements(sql)
+
+
+def _scan_for_multiple_statements(sql: str) -> None:
+    """Scan *sql* for semicolons outside of string/identifier literals.
+
+    We allow at most one trailing semicolon (common habit).  A semicolon in
+    any position other than the very end of the meaningful SQL (ignoring
+    trailing whitespace/comments) is interpreted as a statement boundary →
+    UserError.
+
+    Handles:
+    - Single-quoted strings  'it''s fine'
+    - Double-quoted identifiers  "my table"
+    - Dollar-quoted strings  $tag$body$tag$
+    - Line comments  -- comment
+    - Block comments  /* comment */
+    """
+    i = 0
+    n = len(sql)
+    semicolon_positions = []  # positions of unquoted semicolons
+
+    while i < n:
+        c = sql[i]
+
+        # Line comment — skip to end of line
+        if c == "-" and i + 1 < n and sql[i + 1] == "-":
+            while i < n and sql[i] != "\n":
+                i += 1
+            continue
+
+        # Block comment — skip to */
+        if c == "/" and i + 1 < n and sql[i + 1] == "*":
+            i += 2
+            while i + 1 < n and not (sql[i] == "*" and sql[i + 1] == "/"):
+                i += 1
+            i += 2  # skip */
+            continue
+
+        # Single-quoted string — skip, handling '' escapes
+        if c == "'":
+            i += 1
+            while i < n:
+                if sql[i] == "'" and i + 1 < n and sql[i + 1] == "'":
+                    i += 2  # escaped quote
+                elif sql[i] == "'":
+                    i += 1
+                    break
+                else:
+                    i += 1
+            continue
+
+        # Double-quoted identifier — skip, handling "" escapes
+        if c == '"':
+            i += 1
+            while i < n:
+                if sql[i] == '"' and i + 1 < n and sql[i + 1] == '"':
+                    i += 2
+                elif sql[i] == '"':
+                    i += 1
+                    break
+                else:
+                    i += 1
+            continue
+
+        # Dollar-quoted string  $tag$...$tag$
+        if c == "$":
+            # Look for the closing $ of the tag
+            j = i + 1
+            while j < n and sql[j] != "$":
+                j += 1
+            if j < n:
+                tag = sql[i : j + 1]  # e.g. "$tag$" or "$$"
+                end = sql.find(tag, j + 1)
+                if end != -1:
+                    i = end + len(tag)
+                    continue
+            # Not a dollar-quote (lone $) — fall through
+            i += 1
+            continue
+
+        # Semicolon outside any literal
+        if c == ";":
+            semicolon_positions.append(i)
+
+        i += 1
+
+    if not semicolon_positions:
+        return  # no semicolons — fine
+
+    # Allow exactly one trailing semicolon (nothing meaningful after it)
+    if len(semicolon_positions) == 1:
+        after = sql[semicolon_positions[0] + 1 :].strip()
+        # Strip trailing comments too
+        after = _LINE_COMMENT_RE.sub("", after).strip()
+        after = _BLOCK_COMMENT_RE.sub("", after).strip()
+        if not after:
+            return  # trailing semicolon — acceptable
+
+    raise UserError(
+        _(
+            "Only a single SQL statement is allowed. "
+            "Multiple statements separated by semicolons are not permitted."
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# sql.console service model
+# ---------------------------------------------------------------------------
+
+
+class SqlConsole(models.Model):
+    """Thin service model exposing run_query over RPC.
+
+    No stored fields — this model exists purely to carry the run_query method
+    and its helpers so it is addressable by name over execute_kw.
+    """
+
+    _name = "sql.console"
+    _description = "Read-only SQL Console"
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    @api.model
+    def run_query(self, sql: str) -> dict:
+        """Execute *sql* as the read-only Postgres role and return a JSON envelope.
+
+        Parameters
+        ----------
+        sql:
+            A single SELECT or WITH statement (WITH may include non-writable CTEs).
+
+        Returns
+        -------
+        dict with keys:
+            columns   — list of column name strings
+            rows      — list of lists (each value JSON-serializable)
+            row_count — int, number of rows returned (≤ row_cap)
+            truncated — bool, True when more rows exist beyond the cap
+
+        Raises
+        ------
+        AccessError  — caller is not in group_sql_console
+        UserError    — env vars absent, guard violation, or timeout
+        """
+        # 1. Authorization — MUST be first; this is the only RPC trust boundary
+        if not self.env.user.has_group("bemade_sql_console.group_sql_console"):
+            raise AccessError(_("You are not allowed to run SQL console queries."))
+
+        # 2. Validate the SQL text before touching any connection
+        _validate_single_select(sql)
+
+        # 3. Resolve RO credentials — fail fast if not configured
+        ro_user = os.environ.get("ODOO_RO_DB_USER", "").strip()
+        ro_password = os.environ.get("ODOO_RO_DB_PASSWORD", "").strip()
+        if not ro_user or not ro_password:
+            raise UserError(
+                _(
+                    "The read-only SQL console is not configured on this instance. "
+                    "Please contact your system administrator."
+                )
+            )
+
+        # 4. Read runtime parameters
+        get_param = self.env["ir.config_parameter"].sudo().get_param
+        try:
+            row_cap = int(get_param("bemade_sql_console.row_cap", "1000"))
+        except (ValueError, TypeError):
+            row_cap = 1000
+        try:
+            timeout_ms = int(
+                get_param("bemade_sql_console.statement_timeout_ms", "30000")
+            )
+        except (ValueError, TypeError):
+            timeout_ms = 30000
+
+        # 5. Build connection info (host/port/sslmode from Odoo config; replica-aware)
+        conn_info = self._ro_connection_info(ro_user, ro_password, timeout_ms)
+
+        # 6. Open RO connection and execute
+        conn = None
+        try:
+            conn = psycopg2.connect(**conn_info)
+            # App-layer read-only (defense-in-depth — in addition to role ACL)
+            conn.set_session(readonly=True, autocommit=False)
+
+            with conn:
+                with conn.cursor() as cur:
+                    # Belt-and-braces: also SET via SQL (catches proxies that strip
+                    # libpq options) — this is inside the RO transaction
+                    cur.execute(f"SET statement_timeout = {int(timeout_ms)}")
+                    cur.execute(sql)
+                    columns = (
+                        [d.name for d in cur.description]
+                        if cur.description
+                        else []
+                    )
+                    rows = cur.fetchmany(row_cap + 1)  # +1 to detect truncation
+                    truncated = len(rows) > row_cap
+                    rows = rows[:row_cap]
+
+            return {
+                "columns": columns,
+                "rows": [[_jsonify(v) for v in row] for row in rows],
+                "row_count": len(rows),
+                "truncated": truncated,
+            }
+
+        except psycopg2.errors.QueryCanceled:
+            raise UserError(
+                _(
+                    "Query exceeded the time limit (%(ms)d ms) and was cancelled.",
+                    ms=timeout_ms,
+                )
+            )
+        except psycopg2.Error as exc:
+            _logger.debug("SQL console query failed: %s", exc)
+            raise UserError(
+                _("Query failed: %(error)s", error=str(exc).strip())
+            )
+        finally:
+            if conn is not None:
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _ro_connection_info(
+        self, ro_user: str, ro_password: str, timeout_ms: int
+    ) -> dict:
+        """Return psycopg2 connect kwargs for the read-only role.
+
+        Strategy
+        --------
+        1. Derive host/port/sslmode from Odoo's own config (replica-aware) via
+           ``odoo.sql_db.connection_info_for(dbname, readonly=True)``.
+        2. Override user/password with the RO credentials from env.
+        3. Set statement_timeout via libpq ``options`` so it applies before the
+           first statement (belt 1; belt 2 is the SET inside run_query).
+        """
+        dbname = self.env.cr.dbname
+        _dbname, info = odoo.sql_db.connection_info_for(dbname, readonly=True)
+        # Override credentials — discard whatever owner user/password was filled in
+        info["user"] = ro_user
+        info["password"] = ro_password
+        # libpq options for statement_timeout (connection-level GUC)
+        info["options"] = f"-c statement_timeout={int(timeout_ms)}"
+        return info

--- a/bemade_sql_console/models/sql_console.py
+++ b/bemade_sql_console/models/sql_console.py
@@ -22,10 +22,41 @@ import uuid
 
 import psycopg2
 import psycopg2.errors
+import psycopg2.extensions as _psyext
 
 import odoo.sql_db
 from odoo import _, api, models
 from odoo.exceptions import AccessError, UserError
+
+# ---------------------------------------------------------------------------
+# Connection-scoped NUMERIC → Decimal type override
+# ---------------------------------------------------------------------------
+# Odoo globally registers a process-wide psycopg2 adapter that maps NUMERIC
+# (OID 1700) to Python float (odoo/sql_db.py, DECIMAL_TO_FLOAT_TYPE).  That
+# adapter fires on every connection in the process, including ours, and makes
+# the decimal.Decimal branch in _jsonify unreachable.
+#
+# We counter this by registering a *connection-scoped* type override on the RO
+# connection immediately after opening it.  psycopg2 resolves type casters in
+# this order: connection-scoped → cursor-scoped → global.  Registering on the
+# connection therefore shadows Odoo's global float adapter for our connection
+# only, without touching the global registration or Odoo's pool.
+#
+# OID 1700 = numeric / decimal  (also used for numeric[])
+# The caster is identical to psycopg2's built-in DECIMAL caster: convert the
+# string representation to decimal.Decimal, or None for SQL NULL.
+_NUMERIC_OID = 1700
+_NUMERIC_ARRAY_OID = 1231  # numeric[]
+_DEC2DEC_TYPE = _psyext.new_type(
+    (_NUMERIC_OID,),
+    "DECIMAL",
+    lambda v, c: decimal.Decimal(v) if v is not None else None,
+)
+_DEC2DEC_ARRAY_TYPE = _psyext.new_array_type(
+    (_NUMERIC_ARRAY_OID,),
+    "DECIMAL[]",
+    _DEC2DEC_TYPE,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -308,6 +339,12 @@ class SqlConsole(models.Model):
         conn = None
         try:
             conn = psycopg2.connect(**conn_info)
+            # Override Odoo's global NUMERIC→float adapter with a
+            # connection-scoped NUMERIC→Decimal caster so _jsonify's
+            # decimal.Decimal → str branch works as specified.
+            # This does NOT affect Odoo's process-global adapter or its pool.
+            _psyext.register_type(_DEC2DEC_TYPE, conn)
+            _psyext.register_type(_DEC2DEC_ARRAY_TYPE, conn)
             # App-layer read-only (defense-in-depth — in addition to role ACL)
             conn.set_session(readonly=True, autocommit=False)
 

--- a/bemade_sql_console/models/sql_console_wizard.py
+++ b/bemade_sql_console/models/sql_console_wizard.py
@@ -1,0 +1,79 @@
+"""sql.console.wizard — transient UI model for the SQL console form view."""
+
+import json
+import logging
+
+from odoo import _, fields, models
+from odoo.exceptions import UserError
+
+_logger = logging.getLogger(__name__)
+
+
+class SqlConsoleWizard(models.TransientModel):
+    """Transient wizard holding the SQL editor and its results.
+
+    The wizard calls ``sql.console.run_query`` — so the security path
+    (group check, RO connection, guard) is identical for UI and RPC callers.
+    """
+
+    _name = "sql.console.wizard"
+    _description = "Read-only SQL Console Wizard"
+
+    sql_text = fields.Text(
+        string="SQL Query",
+        help="Enter a single SELECT or WITH statement.",
+    )
+    result_columns = fields.Text(
+        string="Columns",
+        readonly=True,
+    )
+    result_rows = fields.Text(
+        string="Rows (JSON)",
+        readonly=True,
+    )
+    row_count = fields.Integer(
+        string="Row Count",
+        readonly=True,
+    )
+    truncated = fields.Boolean(
+        string="Truncated",
+        readonly=True,
+        help="True when more rows exist beyond the configured row cap.",
+    )
+    error_message = fields.Text(
+        string="Error",
+        readonly=True,
+    )
+
+    def action_run_query(self):
+        """Execute the SQL and stash the result envelope into display fields."""
+        self.ensure_one()
+        self.write(
+            {
+                "result_columns": False,
+                "result_rows": False,
+                "row_count": 0,
+                "truncated": False,
+                "error_message": False,
+            }
+        )
+        try:
+            result = self.env["sql.console"].run_query(self.sql_text or "")
+            self.write(
+                {
+                    "result_columns": json.dumps(result["columns"], ensure_ascii=False),
+                    "result_rows": json.dumps(result["rows"], ensure_ascii=False),
+                    "row_count": result["row_count"],
+                    "truncated": result["truncated"],
+                }
+            )
+        except (UserError, Exception) as exc:
+            self.write({"error_message": str(exc)})
+
+        return {
+            "type": "ir.actions.act_window",
+            "res_model": self._name,
+            "res_id": self.id,
+            "view_mode": "form",
+            "target": "new",
+        }

--- a/bemade_sql_console/security/ir.model.access.csv
+++ b/bemade_sql_console/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_sql_console_group,sql.console group,model_sql_console,bemade_sql_console.group_sql_console,1,0,1,0
+access_sql_console_wizard_group,sql.console.wizard group,model_sql_console_wizard,bemade_sql_console.group_sql_console,1,0,1,0

--- a/bemade_sql_console/security/security.xml
+++ b/bemade_sql_console/security/security.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2026 Bemade Inc.
+    License LGPL-3 or later (https://www.gnu.org/licenses/lgpl).
+-->
+<odoo>
+    <data noupdate="1">
+
+        <!--
+            SQL Console access group.
+
+            implied_ids ← base.group_system so every existing system
+            administrator inherits console access automatically.  Ops can
+            also grant this group to a dedicated purpose-built user (e.g.
+            Bill's rwi2 acceptance-tester) without handing that user the
+            full system-admin surface.
+        -->
+        <record id="group_sql_console" model="res.groups">
+            <field name="name">SQL Console User</field>
+            <field name="comment">
+                Members may execute read-only SQL queries via the SQL console
+                (run_query RPC method and the admin UI).  The underlying
+                connection always authenticates as a SELECT-only Postgres role,
+                so write operations are rejected at the database privilege layer
+                regardless of the SQL content submitted.
+            </field>
+            <!--
+                implied_by_ids: this group is automatically granted to members
+                of base.group_system (system administrators), so admins get
+                console access without manual assignment.  Ops can also grant
+                this group directly to a non-admin purpose-built user (e.g.
+                Bill's rwi2 acceptance-tester) without elevating that user to
+                full system admin.
+            -->
+            <field name="implied_by_ids" eval="[Command.link(ref('base.group_system'))]"/>
+        </record>
+
+    </data>
+</odoo>

--- a/bemade_sql_console/tests/__init__.py
+++ b/bemade_sql_console/tests/__init__.py
@@ -1,0 +1,11 @@
+# Test bodies are implemented in Phase 4.
+# Stubs created here so the package is importable and the test files are
+# discovered by Odoo's test runner.
+from . import common
+from . import test_us01_envelope
+from . import test_us02_no_owner_cursor
+from . import test_us03_write_rejection
+from . import test_us04_single_select_guard
+from . import test_us05_admin_check
+from . import test_us06_row_cap
+from . import test_us07_degrade

--- a/bemade_sql_console/tests/common.py
+++ b/bemade_sql_console/tests/common.py
@@ -1,19 +1,137 @@
 """Shared test infrastructure for bemade_sql_console.
 
-Phase 4 will implement the RO-role provisioning helpers here.
-Skeleton only — do not instantiate directly.
+Provides SqlConsoleTestBase, which:
+- Creates a throwaway SELECT-only Postgres role in setUpClass using self.env.cr
+  (owner/superuser on the test DB) and sets ODOO_RO_DB_USER / ODOO_RO_DB_PASSWORD
+  env vars so run_query opens a real connection as that role.
+- Tears down the role and restores env vars in tearDownClass.
+- Degrades gracefully (self.skipTest) when CREATEROLE is unavailable, to avoid
+  false CI failures on constrained runners.
 """
 
+import os
+import secrets
+import string
+
+import psycopg2
+
 from odoo.tests.common import TransactionCase
+
+# Characters safe for a Postgres role name (letters/digits/underscore)
+_ROLE_CHARS = string.ascii_lowercase + string.digits
+
+
+def _random_suffix(n=8):
+    return "".join(secrets.choice(_ROLE_CHARS) for _ in range(n))
 
 
 class SqlConsoleTestBase(TransactionCase):
     """Base class for bemade_sql_console tests.
 
-    Phase 4 will add:
-    - setUpClass: CREATE ROLE <tmp_ro> with SELECT-only grants; sets
-      ODOO_RO_DB_USER / ODOO_RO_DB_PASSWORD env vars.
-    - tearDownClass: DROP OWNED BY / DROP ROLE <tmp_ro>; restores env.
-    - _skip_if_no_createrole(): detect CREATEROLE availability and call
-      self.skipTest with a clear message if absent, degrading gracefully.
+    setUpClass provisions a live SELECT-only Postgres role and injects
+    ODOO_RO_DB_USER / ODOO_RO_DB_PASSWORD.  tearDownClass drops the role and
+    restores env.
+
+    If the test-runner's Postgres user lacks the privilege to CREATE ROLE, the
+    entire class is skipped with a clear message — this is a CI-environment
+    limitation, not an implementation defect.
+
+    The env vars are set at the *class* level so all test methods within a
+    subclass share the same RO role.  Individual tests that need to temporarily
+    override the env vars must save/restore them themselves.
     """
+
+    # Will be populated by setUpClass if role creation succeeds
+    _ro_role_name: str = ""
+    _ro_role_password: str = ""
+    _saved_env: dict = {}
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._saved_env = {
+            "ODOO_RO_DB_USER": os.environ.get("ODOO_RO_DB_USER"),
+            "ODOO_RO_DB_PASSWORD": os.environ.get("ODOO_RO_DB_PASSWORD"),
+        }
+        cls._ro_role_name = f"test_ro_{_random_suffix()}"
+        cls._ro_role_password = secrets.token_urlsafe(16)
+
+        dbname = cls.env.cr.dbname
+        cr = cls.env.cr
+
+        # Attempt to create the throwaway SELECT-only role.
+        # On constrained CI runners (no CREATEROLE), we skip rather than fail.
+        try:
+            # Use autocommit-style via savepoint so we can catch the error
+            # without rolling back the whole TransactionCase outer transaction.
+            cr.execute("SAVEPOINT create_ro_role")
+            cr.execute(
+                f"CREATE ROLE {cls._ro_role_name} LOGIN PASSWORD %s",
+                (cls._ro_role_password,),
+            )
+            cr.execute(
+                f"GRANT CONNECT ON DATABASE {dbname} TO {cls._ro_role_name}"
+            )
+            cr.execute(
+                f"GRANT USAGE ON SCHEMA public TO {cls._ro_role_name}"
+            )
+            cr.execute(
+                f"GRANT SELECT ON ALL TABLES IN SCHEMA public TO {cls._ro_role_name}"
+            )
+            # Set default_transaction_read_only as an extra layer of defense
+            cr.execute(
+                f"ALTER ROLE {cls._ro_role_name} SET default_transaction_read_only = on"
+            )
+            cr.execute("RELEASE SAVEPOINT create_ro_role")
+        except Exception as exc:
+            cr.execute("ROLLBACK TO SAVEPOINT create_ro_role")
+            cr.execute("RELEASE SAVEPOINT create_ro_role")
+            cls.skipTest(
+                f"Cannot create SELECT-only Postgres role (CREATEROLE missing?): {exc}. "
+                "ACL-level write rejection (criterion 3) cannot be verified; "
+                "only app-layer read-only (criterion 4) would be tested."
+            )
+
+        # Inject env vars so run_query opens a connection as the RO role
+        os.environ["ODOO_RO_DB_USER"] = cls._ro_role_name
+        os.environ["ODOO_RO_DB_PASSWORD"] = cls._ro_role_password
+
+    @classmethod
+    def tearDownClass(cls):
+        cr = cls.env.cr
+        if cls._ro_role_name:
+            try:
+                cr.execute("SAVEPOINT drop_ro_role")
+                cr.execute(f"DROP OWNED BY {cls._ro_role_name}")
+                cr.execute(f"DROP ROLE IF EXISTS {cls._ro_role_name}")
+                cr.execute("RELEASE SAVEPOINT drop_ro_role")
+            except Exception:
+                cr.execute("ROLLBACK TO SAVEPOINT drop_ro_role")
+                cr.execute("RELEASE SAVEPOINT drop_ro_role")
+
+        # Restore env vars
+        for key, val in cls._saved_env.items():
+            if val is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = val
+
+        super().tearDownClass()
+
+    def _get_ro_pid(self):
+        """Return the backend PID of a fresh RO connection (for US-02 test)."""
+        import psycopg2 as _psycopg2
+        from odoo.models import Model as _OdooModel
+        import odoo.sql_db as _sql_db
+
+        dbname = self.env.cr.dbname
+        _dbname, info = _sql_db.connection_info_for(dbname, readonly=True)
+        info["user"] = os.environ["ODOO_RO_DB_USER"]
+        info["password"] = os.environ["ODOO_RO_DB_PASSWORD"]
+        conn = _psycopg2.connect(**info)
+        try:
+            with conn.cursor() as cur:
+                cur.execute("SELECT pg_backend_pid()")
+                return cur.fetchone()[0]
+        finally:
+            conn.close()

--- a/bemade_sql_console/tests/common.py
+++ b/bemade_sql_console/tests/common.py
@@ -1,20 +1,24 @@
 """Shared test infrastructure for bemade_sql_console.
 
 Provides SqlConsoleTestBase, which:
-- Creates a throwaway SELECT-only Postgres role in setUpClass using self.env.cr
-  (owner/superuser on the test DB) and sets ODOO_RO_DB_USER / ODOO_RO_DB_PASSWORD
-  env vars so run_query opens a real connection as that role.
-- Tears down the role and restores env vars in tearDownClass.
-- Degrades gracefully (self.skipTest) when CREATEROLE is unavailable, to avoid
-  false CI failures on constrained runners.
+- Creates a throwaway SELECT-only Postgres role via a SEPARATE autocommit admin
+  connection in setUpClass so the role is committed and visible to the
+  independent psycopg2 connection opened by run_query.
+- Tears down the role and restores env vars in tearDownClass via the same
+  separate connection.
+- Degrades gracefully (unittest.SkipTest) when CREATEROLE is unavailable, to
+  avoid false CI failures on constrained runners.
 """
 
 import os
 import secrets
 import string
+import unittest
 
 import psycopg2
+import psycopg2.errors
 
+import odoo.sql_db
 from odoo.tests.common import TransactionCase
 
 # Characters safe for a Postgres role name (letters/digits/underscore)
@@ -25,14 +29,68 @@ def _random_suffix(n=8):
     return "".join(secrets.choice(_ROLE_CHARS) for _ in range(n))
 
 
+def _admin_autocommit_conn(dbname):
+    """Open a fresh psycopg2 connection to *dbname* with autocommit=True.
+
+    Strategy: try the Odoo DB user first (same creds as odoo.sql_db). If that
+    user lacks CREATEROLE, fall back to a local peer-auth connection as the OS
+    user (for developer workstations where the OS user is a Postgres superuser).
+
+    autocommit=True is mandatory: CREATE/DROP ROLE are DDL statements on the
+    global role catalog; they must be committed immediately so the new role is
+    visible to the independent psycopg2 connection opened by run_query.
+    """
+    _dbname, info = odoo.sql_db.connection_info_for(dbname)
+    # First try: Odoo owner user (may or may not have CREATEROLE)
+    try:
+        conn = psycopg2.connect(**info)
+        conn.autocommit = True
+        # Quick privilege check — avoids misleading errors later
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT rolcreaterole OR rolsuper FROM pg_roles WHERE rolname = current_user"
+            )
+            has_createrole = cur.fetchone()
+            if has_createrole and has_createrole[0]:
+                return conn
+        conn.close()
+    except Exception:
+        pass
+
+    # Second try: local peer-auth as the OS user (dev workstation, no password)
+    local_user = os.environ.get("USER", "")
+    if local_user:
+        try:
+            peer_info = {"database": dbname, "user": local_user}
+            conn = psycopg2.connect(**peer_info)
+            conn.autocommit = True
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT rolcreaterole OR rolsuper FROM pg_roles WHERE rolname = current_user"
+                )
+                has_createrole = cur.fetchone()
+                if has_createrole and has_createrole[0]:
+                    return conn
+            conn.close()
+        except Exception:
+            pass
+
+    return None
+
+
 class SqlConsoleTestBase(TransactionCase):
     """Base class for bemade_sql_console tests.
 
-    setUpClass provisions a live SELECT-only Postgres role and injects
-    ODOO_RO_DB_USER / ODOO_RO_DB_PASSWORD.  tearDownClass drops the role and
-    restores env.
+    setUpClass provisions a live SELECT-only Postgres role via a SEPARATE
+    autocommit admin connection and injects ODOO_RO_DB_USER /
+    ODOO_RO_DB_PASSWORD.  tearDownClass drops the role and restores env.
 
-    If the test-runner's Postgres user lacks the privilege to CREATE ROLE, the
+    Using a separate autocommit connection is critical: run_query opens its
+    own psycopg2 connection which cannot see roles created (but not committed)
+    inside the TransactionCase outer transaction.  By committing via autocommit
+    the role is immediately visible to all subsequent connections.
+
+    If no connection with CREATEROLE/SUPERUSER privilege is available, the
     entire class is skipped with a clear message — this is a CI-environment
     limitation, not an implementation defect.
 
@@ -45,6 +103,7 @@ class SqlConsoleTestBase(TransactionCase):
     _ro_role_name: str = ""
     _ro_role_password: str = ""
     _saved_env: dict = {}
+    _admin_dbname: str = ""  # dbname used for teardown (peer conn needs it)
 
     @classmethod
     def setUpClass(cls):
@@ -57,40 +116,49 @@ class SqlConsoleTestBase(TransactionCase):
         cls._ro_role_password = secrets.token_urlsafe(16)
 
         dbname = cls.env.cr.dbname
-        cr = cls.env.cr
+        cls._admin_dbname = dbname
 
-        # Attempt to create the throwaway SELECT-only role.
-        # On constrained CI runners (no CREATEROLE), we skip rather than fail.
+        # Attempt to create the throwaway SELECT-only role via a SEPARATE
+        # autocommit connection so the role is committed and visible to
+        # run_query's independent psycopg2 connection.
+        admin_conn = _admin_autocommit_conn(dbname)
+        if admin_conn is None:
+            raise unittest.SkipTest(
+                "No Postgres connection with CREATEROLE/SUPERUSER privilege available. "
+                "ACL-level write rejection (criterion 3) cannot be verified. "
+                "Grant CREATEROLE to the Odoo DB user or run as a superuser OS user."
+            )
+
         try:
-            # Use autocommit-style via savepoint so we can catch the error
-            # without rolling back the whole TransactionCase outer transaction.
-            cr.execute("SAVEPOINT create_ro_role")
-            cr.execute(
+            cur = admin_conn.cursor()
+            cur.execute(
                 f"CREATE ROLE {cls._ro_role_name} LOGIN PASSWORD %s",
                 (cls._ro_role_password,),
             )
-            cr.execute(
+            cur.execute(
                 f"GRANT CONNECT ON DATABASE {dbname} TO {cls._ro_role_name}"
             )
-            cr.execute(
+            cur.execute(
                 f"GRANT USAGE ON SCHEMA public TO {cls._ro_role_name}"
             )
-            cr.execute(
+            cur.execute(
                 f"GRANT SELECT ON ALL TABLES IN SCHEMA public TO {cls._ro_role_name}"
             )
-            # Set default_transaction_read_only as an extra layer of defense
-            cr.execute(
+            # Default RO transaction as extra defense layer
+            cur.execute(
                 f"ALTER ROLE {cls._ro_role_name} SET default_transaction_read_only = on"
             )
-            cr.execute("RELEASE SAVEPOINT create_ro_role")
+            cur.close()
         except Exception as exc:
-            cr.execute("ROLLBACK TO SAVEPOINT create_ro_role")
-            cr.execute("RELEASE SAVEPOINT create_ro_role")
-            cls.skipTest(
-                f"Cannot create SELECT-only Postgres role (CREATEROLE missing?): {exc}. "
-                "ACL-level write rejection (criterion 3) cannot be verified; "
-                "only app-layer read-only (criterion 4) would be tested."
+            raise unittest.SkipTest(
+                f"Cannot create SELECT-only Postgres role: {exc}. "
+                "ACL-level write rejection (criterion 3) cannot be verified."
             )
+        finally:
+            try:
+                admin_conn.close()
+            except Exception:
+                pass
 
         # Inject env vars so run_query opens a connection as the RO role
         os.environ["ODOO_RO_DB_USER"] = cls._ro_role_name
@@ -98,16 +166,22 @@ class SqlConsoleTestBase(TransactionCase):
 
     @classmethod
     def tearDownClass(cls):
-        cr = cls.env.cr
         if cls._ro_role_name:
-            try:
-                cr.execute("SAVEPOINT drop_ro_role")
-                cr.execute(f"DROP OWNED BY {cls._ro_role_name}")
-                cr.execute(f"DROP ROLE IF EXISTS {cls._ro_role_name}")
-                cr.execute("RELEASE SAVEPOINT drop_ro_role")
-            except Exception:
-                cr.execute("ROLLBACK TO SAVEPOINT drop_ro_role")
-                cr.execute("RELEASE SAVEPOINT drop_ro_role")
+            dbname = cls._admin_dbname or cls.env.cr.dbname
+            admin_conn = _admin_autocommit_conn(dbname)
+            if admin_conn is not None:
+                try:
+                    cur = admin_conn.cursor()
+                    cur.execute(f"DROP OWNED BY {cls._ro_role_name}")
+                    cur.execute(f"DROP ROLE IF EXISTS {cls._ro_role_name}")
+                    cur.close()
+                except Exception:
+                    pass
+                finally:
+                    try:
+                        admin_conn.close()
+                    except Exception:
+                        pass
 
         # Restore env vars
         for key, val in cls._saved_env.items():
@@ -121,7 +195,6 @@ class SqlConsoleTestBase(TransactionCase):
     def _get_ro_pid(self):
         """Return the backend PID of a fresh RO connection (for US-02 test)."""
         import psycopg2 as _psycopg2
-        from odoo.models import Model as _OdooModel
         import odoo.sql_db as _sql_db
 
         dbname = self.env.cr.dbname

--- a/bemade_sql_console/tests/common.py
+++ b/bemade_sql_console/tests/common.py
@@ -1,0 +1,19 @@
+"""Shared test infrastructure for bemade_sql_console.
+
+Phase 4 will implement the RO-role provisioning helpers here.
+Skeleton only — do not instantiate directly.
+"""
+
+from odoo.tests.common import TransactionCase
+
+
+class SqlConsoleTestBase(TransactionCase):
+    """Base class for bemade_sql_console tests.
+
+    Phase 4 will add:
+    - setUpClass: CREATE ROLE <tmp_ro> with SELECT-only grants; sets
+      ODOO_RO_DB_USER / ODOO_RO_DB_PASSWORD env vars.
+    - tearDownClass: DROP OWNED BY / DROP ROLE <tmp_ro>; restores env.
+    - _skip_if_no_createrole(): detect CREATEROLE availability and call
+      self.skipTest with a clear message if absent, degrading gracefully.
+    """

--- a/bemade_sql_console/tests/test_us01_envelope.py
+++ b/bemade_sql_console/tests/test_us01_envelope.py
@@ -1,0 +1,19 @@
+"""
+US-01 — Valid SELECT returns correct JSON envelope shape and coerced types.
+
+Acceptance criteria
+-------------------
+- run_query("SELECT 1 AS a, now() AS t, 1.5::numeric AS n") returns a dict
+  with keys columns, rows, row_count, truncated.
+- Every value in the envelope is JSON-serializable (json.dumps succeeds).
+- Decimal values are returned as str (not float).
+- datetime values are returned as ISO-8601 strings.
+
+Phase 4: implement test body.
+"""
+
+from .common import SqlConsoleTestBase
+
+
+class TestEnvelope(SqlConsoleTestBase):
+    """Phase 4 implements the test body."""

--- a/bemade_sql_console/tests/test_us01_envelope.py
+++ b/bemade_sql_console/tests/test_us01_envelope.py
@@ -6,14 +6,80 @@ Acceptance criteria
 - run_query("SELECT 1 AS a, now() AS t, 1.5::numeric AS n") returns a dict
   with keys columns, rows, row_count, truncated.
 - Every value in the envelope is JSON-serializable (json.dumps succeeds).
-- Decimal values are returned as str (not float).
+- Decimal values are returned as str (not float) — locked per task spec.
 - datetime values are returned as ISO-8601 strings.
-
-Phase 4: implement test body.
 """
+
+import json
+
+from odoo.tests import tagged
 
 from .common import SqlConsoleTestBase
 
 
+@tagged("at_install", "post_install")
 class TestEnvelope(SqlConsoleTestBase):
-    """Phase 4 implements the test body."""
+    """US-01: Valid SELECT returns a correct, JSON-serializable envelope."""
+
+    def test_envelope_shape_and_types(self):
+        """run_query returns the expected envelope structure and coerced values."""
+        sql = "SELECT 1 AS a, now() AS t, 1.5::numeric AS n"
+        result = self.env["sql.console"].run_query(sql)
+
+        # Envelope keys
+        self.assertIn("columns", result)
+        self.assertIn("rows", result)
+        self.assertIn("row_count", result)
+        self.assertIn("truncated", result)
+
+        # Column order and names
+        self.assertEqual(result["columns"], ["a", "t", "n"])
+
+        # One row
+        self.assertEqual(result["row_count"], 1)
+        self.assertEqual(len(result["rows"]), 1)
+        self.assertFalse(result["truncated"])
+
+        row = result["rows"][0]
+        a_val, t_val, n_val = row
+
+        # a == 1 (integer passthrough)
+        self.assertEqual(a_val, 1)
+
+        # t is an ISO-8601 string (datetime coerced)
+        self.assertIsInstance(t_val, str, "datetime should be coerced to ISO-8601 string")
+        # Simple check: contains a 'T' separator (ISO-8601 datetime)
+        self.assertIn("T", t_val, "ISO-8601 datetime string should contain 'T'")
+
+        # n is a string, not a float (Decimal → str, LOCKED)
+        self.assertIsInstance(n_val, str, "Decimal should be coerced to str, not float")
+        self.assertEqual(n_val, "1.5")
+
+        # Entire envelope must be JSON-serializable (no non-serializable types)
+        serialized = json.dumps(result)
+        self.assertIsInstance(serialized, str)
+
+    def test_envelope_with_various_types(self):
+        """Coercion covers multiple types: bytea, uuid, bool, null."""
+        sql = (
+            "SELECT "
+            "  TRUE AS b, "
+            "  NULL::text AS n, "
+            "  '\\xDEAD'::bytea AS raw, "
+            "  gen_random_uuid() AS uid"
+        )
+        result = self.env["sql.console"].run_query(sql)
+        self.assertEqual(result["row_count"], 1)
+        row = result["rows"][0]
+        b_val, n_val, raw_val, uid_val = row
+
+        self.assertIs(b_val, True)
+        self.assertIsNone(n_val)
+        # bytea → base64 string
+        self.assertIsInstance(raw_val, str)
+        # uuid → str, should be 36 chars (8-4-4-4-12)
+        self.assertIsInstance(uid_val, str)
+        self.assertEqual(len(uid_val), 36)
+
+        # Full JSON round-trip
+        json.dumps(result)

--- a/bemade_sql_console/tests/test_us02_no_owner_cursor.py
+++ b/bemade_sql_console/tests/test_us02_no_owner_cursor.py
@@ -5,12 +5,66 @@ Acceptance criteria
 -------------------
 - self.env.cr.execute is NOT called during run_query.
 - The query runs on a connection with a different backend_pid than self.env.cr.
-
-Phase 4: implement test body (spy on env.cr.execute via unittest.mock.patch.object).
 """
+
+from unittest.mock import patch
+
+from odoo.tests import tagged
 
 from .common import SqlConsoleTestBase
 
 
+@tagged("at_install", "post_install")
 class TestNoOwnerCursor(SqlConsoleTestBase):
-    """Phase 4 implements the test body."""
+    """US-02: run_query must never touch self.env.cr to run the user's query."""
+
+    def test_cr_execute_not_called_during_query(self):
+        """Spy on env.cr.execute to ensure it is not used for the SQL query.
+
+        We patch env.cr.execute and assert it is NOT called during run_query.
+        (env.cr may still be called by Odoo internals *outside* our code path,
+        but the patch wraps it so we can detect any calls within run_query itself.)
+        """
+        real_execute = self.env.cr.execute
+        call_sqls = []
+
+        def spy_execute(sql, *args, **kwargs):
+            call_sqls.append(str(sql)[:200])
+            return real_execute(sql, *args, **kwargs)
+
+        with patch.object(self.env.cr, "execute", side_effect=spy_execute):
+            # Run a distinctive query that would appear in call_sqls if the
+            # owner cursor were used
+            result = self.env["sql.console"].run_query(
+                "SELECT 42 AS sentinel_value_us02"
+            )
+
+        # The query itself must not appear in calls on env.cr
+        matched = [s for s in call_sqls if "sentinel_value_us02" in s]
+        self.assertFalse(
+            matched,
+            f"User SQL was executed on env.cr (owner connection): {matched}",
+        )
+        # But the result is correct (proving it ran somewhere)
+        self.assertEqual(result["rows"][0][0], 42)
+
+    def test_different_backend_pid(self):
+        """The RO connection reports a different backend_pid than env.cr.
+
+        env.cr's pid is retrieved via pg_backend_pid() on the owner connection.
+        The RO connection pid must differ, confirming separate connections.
+        """
+        # Get env.cr's backend pid
+        self.env.cr.execute("SELECT pg_backend_pid()")
+        owner_pid = self.env.cr.fetchone()[0]
+
+        # run_query returns a different backend_pid via the RO connection
+        result = self.env["sql.console"].run_query("SELECT pg_backend_pid() AS pid")
+        ro_pid = result["rows"][0][0]
+
+        self.assertIsNotNone(ro_pid)
+        self.assertNotEqual(
+            int(ro_pid),
+            owner_pid,
+            "RO connection must use a different backend process than env.cr",
+        )

--- a/bemade_sql_console/tests/test_us02_no_owner_cursor.py
+++ b/bemade_sql_console/tests/test_us02_no_owner_cursor.py
@@ -1,0 +1,16 @@
+"""
+US-02 — run_query never uses self.env.cr for the query.
+
+Acceptance criteria
+-------------------
+- self.env.cr.execute is NOT called during run_query.
+- The query runs on a connection with a different backend_pid than self.env.cr.
+
+Phase 4: implement test body (spy on env.cr.execute via unittest.mock.patch.object).
+"""
+
+from .common import SqlConsoleTestBase
+
+
+class TestNoOwnerCursor(SqlConsoleTestBase):
+    """Phase 4 implements the test body."""

--- a/bemade_sql_console/tests/test_us03_write_rejection.py
+++ b/bemade_sql_console/tests/test_us03_write_rejection.py
@@ -6,18 +6,135 @@ Acceptance criteria
 - Plain DELETE/UPDATE/INSERT statements raise an error.
 - A writable CTE (WITH x AS (DELETE … RETURNING id) SELECT * FROM x) that
   passes the single-SELECT guard is rejected by the RO role.
-- SET default_transaction_read_only = off / SET TRANSACTION READ WRITE raise.
-- Embedded COMMIT raises (multi-statement, caught by guard before role).
-- Post-condition: no rows were modified (verify against scratch data).
+- SET default_transaction_read_only = off raises (via guard or role).
+- Embedded COMMIT raises (multi-statement guard fires before role).
+- Post-condition: no rows were modified.
 
-Requires a live SELECT-only Postgres role (see common.py).  Degrades to
-app-layer-only coverage when CREATEROLE is unavailable on the test runner.
-
-Phase 4: implement test body.
+Requires a live SELECT-only Postgres role (see common.py).  The writable CTE
+test is the critical ACL-boundary proof: it passes the leading-WITH guard and
+is rejected only by the role's lack of write privileges.
 """
+
+from odoo.exceptions import UserError
+from odoo.tests import tagged
+from odoo.tools.misc import mute_logger
 
 from .common import SqlConsoleTestBase
 
 
+@tagged("at_install", "post_install")
 class TestWriteRejection(SqlConsoleTestBase):
-    """Phase 4 implements the test body."""
+    """US-03: Write operations are blocked at the Postgres ACL layer."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Create a small scratch table owned by the test transaction for
+        # post-condition checks.  res.partner rows won't be touched, but
+        # we use a known count so we can verify no rows were inserted/deleted.
+        cls.env.cr.execute(
+            """
+            CREATE TEMP TABLE sql_console_scratch (
+                id SERIAL PRIMARY KEY,
+                val TEXT
+            )
+            """
+        )
+        cls.env.cr.execute(
+            "INSERT INTO sql_console_scratch (val) VALUES ('row1'), ('row2')"
+        )
+
+    def _scratch_row_count(self):
+        self.env.cr.execute("SELECT COUNT(*) FROM sql_console_scratch")
+        return self.env.cr.fetchone()[0]
+
+    def test_insert_rejected(self):
+        """INSERT is rejected at the role ACL level."""
+        initial = self._scratch_row_count()
+        with mute_logger("odoo.addons.bemade_sql_console.models.sql_console"):
+            with self.assertRaises((UserError, Exception)):
+                self.env["sql.console"].run_query(
+                    "INSERT INTO sql_console_scratch (val) VALUES ('injected')"
+                )
+        # Post-condition: no rows added
+        self.assertEqual(self._scratch_row_count(), initial)
+
+    def test_update_rejected(self):
+        """UPDATE is rejected at the role ACL level."""
+        with mute_logger("odoo.addons.bemade_sql_console.models.sql_console"):
+            with self.assertRaises((UserError, Exception)):
+                self.env["sql.console"].run_query(
+                    "UPDATE sql_console_scratch SET val = 'hacked' WHERE TRUE"
+                )
+        # Post-condition: original values unchanged
+        self.env.cr.execute(
+            "SELECT COUNT(*) FROM sql_console_scratch WHERE val != 'hacked'"
+        )
+        unchanged = self.env.cr.fetchone()[0]
+        self.assertEqual(unchanged, 2)
+
+    def test_delete_rejected(self):
+        """DELETE is rejected at the role ACL level."""
+        initial = self._scratch_row_count()
+        with mute_logger("odoo.addons.bemade_sql_console.models.sql_console"):
+            with self.assertRaises((UserError, Exception)):
+                self.env["sql.console"].run_query(
+                    "DELETE FROM sql_console_scratch WHERE TRUE"
+                )
+        # Post-condition: rows still present
+        self.assertEqual(self._scratch_row_count(), initial)
+
+    def test_writable_cte_rejected_by_role(self):
+        """Writable CTE passes the single-SELECT guard but is blocked by the role.
+
+        This is the critical test: WITH … DELETE … RETURNING starts with WITH,
+        so _validate_single_select allows it through.  The rejection must come
+        from Postgres's ACL check on the DELETE inside the CTE, not from our
+        Python guard.  This proves the role is the real security boundary.
+        """
+        initial = self._scratch_row_count()
+        cte_sql = (
+            "WITH deleted AS ("
+            "  DELETE FROM sql_console_scratch RETURNING id"
+            ") SELECT * FROM deleted"
+        )
+        with mute_logger("odoo.addons.bemade_sql_console.models.sql_console"):
+            with self.assertRaises((UserError, Exception)):
+                self.env["sql.console"].run_query(cte_sql)
+        # Post-condition: table untouched
+        self.assertEqual(self._scratch_row_count(), initial)
+
+    def test_writable_cte_insert_rejected_by_role(self):
+        """Writable CTE with INSERT also passes guard and is blocked by the role."""
+        initial = self._scratch_row_count()
+        cte_sql = (
+            "WITH inserted AS ("
+            "  INSERT INTO sql_console_scratch (val) VALUES ('cte_injected') RETURNING id"
+            ") SELECT * FROM inserted"
+        )
+        with mute_logger("odoo.addons.bemade_sql_console.models.sql_console"):
+            with self.assertRaises((UserError, Exception)):
+                self.env["sql.console"].run_query(cte_sql)
+        # Post-condition: no extra rows
+        self.assertEqual(self._scratch_row_count(), initial)
+
+    def test_set_ro_off_rejected(self):
+        """Attempting SET default_transaction_read_only = off is rejected.
+
+        This is caught by the single-statement guard (SET is not SELECT/WITH),
+        so it raises UserError before connecting.  Either the guard or the role
+        rejects it — either way, execution must fail.
+        """
+        with mute_logger("odoo.addons.bemade_sql_console.models.sql_console"):
+            with self.assertRaises((UserError, Exception)):
+                self.env["sql.console"].run_query(
+                    "SET default_transaction_read_only = off"
+                )
+
+    def test_embedded_commit_rejected(self):
+        """Multi-statement with embedded COMMIT is rejected by the guard."""
+        with mute_logger("odoo.addons.bemade_sql_console.models.sql_console"):
+            with self.assertRaises(UserError):
+                self.env["sql.console"].run_query(
+                    "SELECT 1; COMMIT"
+                )

--- a/bemade_sql_console/tests/test_us03_write_rejection.py
+++ b/bemade_sql_console/tests/test_us03_write_rejection.py
@@ -13,6 +13,12 @@ Acceptance criteria
 Requires a live SELECT-only Postgres role (see common.py).  The writable CTE
 test is the critical ACL-boundary proof: it passes the leading-WITH guard and
 is rejected only by the role's lack of write privileges.
+
+We target res_partner (a real committed table) rather than a TEMP table so
+that run_query's SEPARATE psycopg2 connection can see it.  The RO role is
+granted SELECT on all committed tables but has no INSERT/UPDATE/DELETE rights,
+so rejections come from the Postgres ACL layer regardless of whether the WHERE
+clause would match any rows.
 """
 
 from odoo.exceptions import UserError
@@ -26,63 +32,43 @@ from .common import SqlConsoleTestBase
 class TestWriteRejection(SqlConsoleTestBase):
     """US-03: Write operations are blocked at the Postgres ACL layer."""
 
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        # Create a small scratch table owned by the test transaction for
-        # post-condition checks.  res.partner rows won't be touched, but
-        # we use a known count so we can verify no rows were inserted/deleted.
-        cls.env.cr.execute(
-            """
-            CREATE TEMP TABLE sql_console_scratch (
-                id SERIAL PRIMARY KEY,
-                val TEXT
-            )
-            """
-        )
-        cls.env.cr.execute(
-            "INSERT INTO sql_console_scratch (val) VALUES ('row1'), ('row2')"
-        )
-
-    def _scratch_row_count(self):
-        self.env.cr.execute("SELECT COUNT(*) FROM sql_console_scratch")
+    def _partner_count(self):
+        """Count res_partner rows via the owner connection."""
+        self.env.cr.execute("SELECT COUNT(*) FROM res_partner")
         return self.env.cr.fetchone()[0]
 
     def test_insert_rejected(self):
         """INSERT is rejected at the role ACL level."""
-        initial = self._scratch_row_count()
+        initial = self._partner_count()
         with mute_logger("odoo.addons.bemade_sql_console.models.sql_console"):
-            with self.assertRaises((UserError, Exception)):
+            with self.assertRaises(UserError):
                 self.env["sql.console"].run_query(
-                    "INSERT INTO sql_console_scratch (val) VALUES ('injected')"
+                    "INSERT INTO res_partner (name) VALUES ('ro_should_fail')"
                 )
-        # Post-condition: no rows added
-        self.assertEqual(self._scratch_row_count(), initial)
+        # Post-condition: owner connection sees no new committed rows
+        self.assertEqual(self._partner_count(), initial)
 
     def test_update_rejected(self):
         """UPDATE is rejected at the role ACL level."""
+        initial = self._partner_count()
         with mute_logger("odoo.addons.bemade_sql_console.models.sql_console"):
-            with self.assertRaises((UserError, Exception)):
+            with self.assertRaises(UserError):
                 self.env["sql.console"].run_query(
-                    "UPDATE sql_console_scratch SET val = 'hacked' WHERE TRUE"
+                    "UPDATE res_partner SET name = 'ro_hacked' WHERE id = -1"
                 )
-        # Post-condition: original values unchanged
-        self.env.cr.execute(
-            "SELECT COUNT(*) FROM sql_console_scratch WHERE val != 'hacked'"
-        )
-        unchanged = self.env.cr.fetchone()[0]
-        self.assertEqual(unchanged, 2)
+        # Post-condition: partner count unchanged
+        self.assertEqual(self._partner_count(), initial)
 
     def test_delete_rejected(self):
         """DELETE is rejected at the role ACL level."""
-        initial = self._scratch_row_count()
+        initial = self._partner_count()
         with mute_logger("odoo.addons.bemade_sql_console.models.sql_console"):
-            with self.assertRaises((UserError, Exception)):
+            with self.assertRaises(UserError):
                 self.env["sql.console"].run_query(
-                    "DELETE FROM sql_console_scratch WHERE TRUE"
+                    "DELETE FROM res_partner WHERE id = -1"
                 )
-        # Post-condition: rows still present
-        self.assertEqual(self._scratch_row_count(), initial)
+        # Post-condition: partner count unchanged
+        self.assertEqual(self._partner_count(), initial)
 
     def test_writable_cte_rejected_by_role(self):
         """Writable CTE passes the single-SELECT guard but is blocked by the role.
@@ -92,31 +78,31 @@ class TestWriteRejection(SqlConsoleTestBase):
         from Postgres's ACL check on the DELETE inside the CTE, not from our
         Python guard.  This proves the role is the real security boundary.
         """
-        initial = self._scratch_row_count()
+        initial = self._partner_count()
         cte_sql = (
             "WITH deleted AS ("
-            "  DELETE FROM sql_console_scratch RETURNING id"
+            "  DELETE FROM res_partner WHERE id = -1 RETURNING id"
             ") SELECT * FROM deleted"
         )
         with mute_logger("odoo.addons.bemade_sql_console.models.sql_console"):
-            with self.assertRaises((UserError, Exception)):
+            with self.assertRaises(UserError):
                 self.env["sql.console"].run_query(cte_sql)
         # Post-condition: table untouched
-        self.assertEqual(self._scratch_row_count(), initial)
+        self.assertEqual(self._partner_count(), initial)
 
     def test_writable_cte_insert_rejected_by_role(self):
         """Writable CTE with INSERT also passes guard and is blocked by the role."""
-        initial = self._scratch_row_count()
+        initial = self._partner_count()
         cte_sql = (
             "WITH inserted AS ("
-            "  INSERT INTO sql_console_scratch (val) VALUES ('cte_injected') RETURNING id"
+            "  INSERT INTO res_partner (name) VALUES ('cte_ro_injected') RETURNING id"
             ") SELECT * FROM inserted"
         )
         with mute_logger("odoo.addons.bemade_sql_console.models.sql_console"):
-            with self.assertRaises((UserError, Exception)):
+            with self.assertRaises(UserError):
                 self.env["sql.console"].run_query(cte_sql)
         # Post-condition: no extra rows
-        self.assertEqual(self._scratch_row_count(), initial)
+        self.assertEqual(self._partner_count(), initial)
 
     def test_set_ro_off_rejected(self):
         """Attempting SET default_transaction_read_only = off is rejected.
@@ -126,7 +112,7 @@ class TestWriteRejection(SqlConsoleTestBase):
         rejects it — either way, execution must fail.
         """
         with mute_logger("odoo.addons.bemade_sql_console.models.sql_console"):
-            with self.assertRaises((UserError, Exception)):
+            with self.assertRaises(UserError):
                 self.env["sql.console"].run_query(
                     "SET default_transaction_read_only = off"
                 )

--- a/bemade_sql_console/tests/test_us03_write_rejection.py
+++ b/bemade_sql_console/tests/test_us03_write_rejection.py
@@ -1,0 +1,23 @@
+"""
+US-03 — Write operations are rejected by the RO role (not just app-layer).
+
+Acceptance criteria
+-------------------
+- Plain DELETE/UPDATE/INSERT statements raise an error.
+- A writable CTE (WITH x AS (DELETE … RETURNING id) SELECT * FROM x) that
+  passes the single-SELECT guard is rejected by the RO role.
+- SET default_transaction_read_only = off / SET TRANSACTION READ WRITE raise.
+- Embedded COMMIT raises (multi-statement, caught by guard before role).
+- Post-condition: no rows were modified (verify against scratch data).
+
+Requires a live SELECT-only Postgres role (see common.py).  Degrades to
+app-layer-only coverage when CREATEROLE is unavailable on the test runner.
+
+Phase 4: implement test body.
+"""
+
+from .common import SqlConsoleTestBase
+
+
+class TestWriteRejection(SqlConsoleTestBase):
+    """Phase 4 implements the test body."""

--- a/bemade_sql_console/tests/test_us04_single_select_guard.py
+++ b/bemade_sql_console/tests/test_us04_single_select_guard.py
@@ -1,0 +1,20 @@
+"""
+US-04 — Single-statement / SELECT-verb guard rejects bad input before connecting.
+
+Acceptance criteria
+-------------------
+- "SELECT 1; SELECT 2" raises UserError (multi-statement).
+- "DELETE FROM res_partner" raises UserError (non-SELECT verb).
+- "UPDATE res_partner SET name='x' WHERE id=1" raises UserError.
+- "SET statement_timeout=0" raises UserError.
+- Guard fires BEFORE any connection attempt: even with env vars unset, the
+  guard error (not the "not configured" error) is raised.
+
+Phase 4: implement test body.
+"""
+
+from .common import SqlConsoleTestBase
+
+
+class TestSingleSelectGuard(SqlConsoleTestBase):
+    """Phase 4 implements the test body."""

--- a/bemade_sql_console/tests/test_us04_single_select_guard.py
+++ b/bemade_sql_console/tests/test_us04_single_select_guard.py
@@ -9,12 +9,132 @@ Acceptance criteria
 - "SET statement_timeout=0" raises UserError.
 - Guard fires BEFORE any connection attempt: even with env vars unset, the
   guard error (not the "not configured" error) is raised.
-
-Phase 4: implement test body.
 """
+
+import os
+from unittest.mock import patch
+
+from odoo.exceptions import UserError
+from odoo.tests import tagged
+from odoo.tools.misc import mute_logger
 
 from .common import SqlConsoleTestBase
 
+# The "not configured" message fragment for distinguishing guard vs env errors
+_NOT_CONFIGURED_FRAGMENT = "not configured"
+_GUARD_MULTI_FRAGMENT = "single"
+_GUARD_VERB_FRAGMENT = "SELECT or WITH"
 
+
+@tagged("at_install", "post_install")
 class TestSingleSelectGuard(SqlConsoleTestBase):
-    """Phase 4 implements the test body."""
+    """US-04: Statement guard raises UserError before any connection is attempted."""
+
+    def _assert_guard_error_not_configured(self, sql):
+        """Assert that the guard (not the missing-env-var error) fires.
+
+        With env vars unset, the "not configured" UserError would come AFTER the
+        guard.  The guard must fire first, so the error message must be the
+        guard's, not the "not configured" one.
+        """
+        saved_user = os.environ.pop("ODOO_RO_DB_USER", None)
+        saved_pass = os.environ.pop("ODOO_RO_DB_PASSWORD", None)
+        try:
+            with mute_logger("odoo.addons.bemade_sql_console.models.sql_console"):
+                with self.assertRaises(UserError) as cm:
+                    self.env["sql.console"].run_query(sql)
+            msg = str(cm.exception)
+            self.assertNotIn(
+                _NOT_CONFIGURED_FRAGMENT,
+                msg,
+                f"Guard should fire before env-var check, but got 'not configured': {msg}",
+            )
+        finally:
+            if saved_user is not None:
+                os.environ["ODOO_RO_DB_USER"] = saved_user
+            if saved_pass is not None:
+                os.environ["ODOO_RO_DB_PASSWORD"] = saved_pass
+
+    def test_multi_statement_rejected(self):
+        """'SELECT 1; SELECT 2' raises UserError for multiple statements."""
+        with mute_logger("odoo.addons.bemade_sql_console.models.sql_console"):
+            with self.assertRaises(UserError) as cm:
+                self.env["sql.console"].run_query("SELECT 1; SELECT 2")
+        self.assertIn(_GUARD_MULTI_FRAGMENT, str(cm.exception).lower())
+
+    def test_delete_verb_rejected(self):
+        """'DELETE FROM res_partner' raises UserError (non-SELECT leading verb)."""
+        with mute_logger("odoo.addons.bemade_sql_console.models.sql_console"):
+            with self.assertRaises(UserError):
+                self.env["sql.console"].run_query("DELETE FROM res_partner")
+
+    def test_update_verb_rejected(self):
+        """'UPDATE …' raises UserError (non-SELECT leading verb)."""
+        with mute_logger("odoo.addons.bemade_sql_console.models.sql_console"):
+            with self.assertRaises(UserError):
+                self.env["sql.console"].run_query(
+                    "UPDATE res_partner SET name='x' WHERE id=1"
+                )
+
+    def test_insert_verb_rejected(self):
+        """'INSERT …' raises UserError (non-SELECT leading verb)."""
+        with mute_logger("odoo.addons.bemade_sql_console.models.sql_console"):
+            with self.assertRaises(UserError):
+                self.env["sql.console"].run_query(
+                    "INSERT INTO res_partner (name) VALUES ('x')"
+                )
+
+    def test_set_statement_rejected(self):
+        """'SET statement_timeout=0' raises UserError (SET is not SELECT/WITH)."""
+        with mute_logger("odoo.addons.bemade_sql_console.models.sql_console"):
+            with self.assertRaises(UserError):
+                self.env["sql.console"].run_query("SET statement_timeout=0")
+
+    def test_drop_verb_rejected(self):
+        """'DROP TABLE …' raises UserError."""
+        with mute_logger("odoo.addons.bemade_sql_console.models.sql_console"):
+            with self.assertRaises(UserError):
+                self.env["sql.console"].run_query("DROP TABLE res_partner")
+
+    def test_guard_fires_before_env_check_multi_statement(self):
+        """Guard fires before the env-var check for a multi-statement query."""
+        self._assert_guard_error_not_configured("SELECT 1; SELECT 2")
+
+    def test_guard_fires_before_env_check_delete(self):
+        """Guard fires before the env-var check for DELETE verb."""
+        self._assert_guard_error_not_configured("DELETE FROM res_partner")
+
+    def test_guard_fires_before_env_check_set(self):
+        """Guard fires before the env-var check for SET statement."""
+        self._assert_guard_error_not_configured("SET statement_timeout=0")
+
+    def test_no_connection_attempted_on_guard_failure(self):
+        """When the guard fires, psycopg2.connect is never called."""
+        import psycopg2
+        with patch("psycopg2.connect") as mock_connect:
+            with mute_logger("odoo.addons.bemade_sql_console.models.sql_console"):
+                with self.assertRaises(UserError):
+                    self.env["sql.console"].run_query("DELETE FROM res_partner")
+            mock_connect.assert_not_called()
+
+    def test_trailing_semicolon_allowed(self):
+        """A single trailing semicolon is acceptable (common SQL habit)."""
+        result = self.env["sql.console"].run_query("SELECT 42 AS v;")
+        self.assertEqual(result["rows"][0][0], 42)
+
+    def test_select_with_cte_allowed(self):
+        """A non-writable CTE (WITH … SELECT) passes the guard and executes."""
+        result = self.env["sql.console"].run_query(
+            "WITH x AS (SELECT 1 AS n) SELECT n FROM x"
+        )
+        self.assertEqual(result["row_count"], 1)
+        self.assertEqual(result["rows"][0][0], 1)
+
+    def test_empty_sql_rejected(self):
+        """Empty or whitespace-only SQL raises UserError."""
+        with mute_logger("odoo.addons.bemade_sql_console.models.sql_console"):
+            with self.assertRaises(UserError):
+                self.env["sql.console"].run_query("")
+        with mute_logger("odoo.addons.bemade_sql_console.models.sql_console"):
+            with self.assertRaises(UserError):
+                self.env["sql.console"].run_query("   ")

--- a/bemade_sql_console/tests/test_us05_admin_check.py
+++ b/bemade_sql_console/tests/test_us05_admin_check.py
@@ -1,0 +1,18 @@
+"""
+US-05 — Non-admin user calling run_query raises AccessError.
+
+Acceptance criteria
+-------------------
+- A user with only base.group_user (not group_sql_console) calling
+  env["sql.console"].with_user(non_admin).run_query("SELECT 1")
+  raises odoo.exceptions.AccessError.
+
+Phase 4: implement test body using new_test_user(env, login="nobody",
+groups="base.group_user").
+"""
+
+from .common import SqlConsoleTestBase
+
+
+class TestAdminCheck(SqlConsoleTestBase):
+    """Phase 4 implements the test body."""

--- a/bemade_sql_console/tests/test_us05_admin_check.py
+++ b/bemade_sql_console/tests/test_us05_admin_check.py
@@ -6,13 +6,83 @@ Acceptance criteria
 - A user with only base.group_user (not group_sql_console) calling
   env["sql.console"].with_user(non_admin).run_query("SELECT 1")
   raises odoo.exceptions.AccessError.
-
-Phase 4: implement test body using new_test_user(env, login="nobody",
-groups="base.group_user").
+- The AccessError is raised BEFORE any SQL is validated or connection opened.
 """
+
+from odoo.exceptions import AccessError
+from odoo.tests import tagged
+from odoo.tests.common import new_test_user
+from odoo.tools.misc import mute_logger
 
 from .common import SqlConsoleTestBase
 
 
+@tagged("at_install", "post_install")
 class TestAdminCheck(SqlConsoleTestBase):
-    """Phase 4 implements the test body."""
+    """US-05: Non-members of group_sql_console are denied at the method boundary."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Create a plain portal/internal user without group_sql_console
+        cls.non_admin_user = new_test_user(
+            cls.env,
+            login="sql_console_nobody",
+            groups="base.group_user",
+        )
+
+    def test_non_admin_raises_access_error(self):
+        """with_user(non_admin).run_query raises AccessError immediately."""
+        with mute_logger("odoo.addons.bemade_sql_console.models.sql_console"):
+            with self.assertRaises(AccessError):
+                (
+                    self.env["sql.console"]
+                    .with_user(self.non_admin_user)
+                    .run_query("SELECT 1")
+                )
+
+    def test_access_error_before_env_check(self):
+        """AccessError fires even when env vars are unset (auth is first check)."""
+        import os
+
+        saved_user = os.environ.pop("ODOO_RO_DB_USER", None)
+        saved_pass = os.environ.pop("ODOO_RO_DB_PASSWORD", None)
+        try:
+            with mute_logger("odoo.addons.bemade_sql_console.models.sql_console"):
+                with self.assertRaises(AccessError):
+                    (
+                        self.env["sql.console"]
+                        .with_user(self.non_admin_user)
+                        .run_query("SELECT 1")
+                    )
+        finally:
+            if saved_user is not None:
+                os.environ["ODOO_RO_DB_USER"] = saved_user
+            if saved_pass is not None:
+                os.environ["ODOO_RO_DB_PASSWORD"] = saved_pass
+
+    def test_admin_user_is_allowed(self):
+        """The test-running admin (env.user) is a member of group_sql_console.
+
+        Because group_sql_console uses implied_by_ids = [base.group_system],
+        all system admins inherit it.  This verifies that the module's group
+        inheritance wiring is correct.
+        """
+        # self.env.user is admin in TransactionCase
+        is_member = self.env.user.has_group(
+            "bemade_sql_console.group_sql_console"
+        )
+        self.assertTrue(
+            is_member,
+            "Admin user should be a member of group_sql_console via implied_by_ids",
+        )
+
+    def test_non_admin_user_not_in_group(self):
+        """The non-admin test user does not have group_sql_console."""
+        is_member = self.non_admin_user.has_group(
+            "bemade_sql_console.group_sql_console"
+        )
+        self.assertFalse(
+            is_member,
+            "Non-admin user should NOT be in group_sql_console",
+        )

--- a/bemade_sql_console/tests/test_us06_row_cap.py
+++ b/bemade_sql_console/tests/test_us06_row_cap.py
@@ -1,0 +1,17 @@
+"""
+US-06 — Row cap and truncated flag.
+
+Acceptance criteria
+-------------------
+- Set bemade_sql_console.row_cap = 2 in ir.config_parameter.
+- SELECT generate_series(1,5) → row_count == 2, len(rows) == 2, truncated is True.
+- SELECT generate_series(1,2) → truncated is False.
+
+Phase 4: implement test body.
+"""
+
+from .common import SqlConsoleTestBase
+
+
+class TestRowCap(SqlConsoleTestBase):
+    """Phase 4 implements the test body."""

--- a/bemade_sql_console/tests/test_us06_row_cap.py
+++ b/bemade_sql_console/tests/test_us06_row_cap.py
@@ -6,12 +6,107 @@ Acceptance criteria
 - Set bemade_sql_console.row_cap = 2 in ir.config_parameter.
 - SELECT generate_series(1,5) → row_count == 2, len(rows) == 2, truncated is True.
 - SELECT generate_series(1,2) → truncated is False.
-
-Phase 4: implement test body.
 """
+
+from odoo.tests import tagged
 
 from .common import SqlConsoleTestBase
 
 
+@tagged("at_install", "post_install")
 class TestRowCap(SqlConsoleTestBase):
-    """Phase 4 implements the test body."""
+    """US-06: Row cap limits returned rows and truncated flag is set correctly."""
+
+    def _set_row_cap(self, cap):
+        """Set the row cap system parameter."""
+        self.env["ir.config_parameter"].sudo().set_param(
+            "bemade_sql_console.row_cap", str(cap)
+        )
+
+    def _restore_row_cap(self):
+        """Restore the default row cap."""
+        self.env["ir.config_parameter"].sudo().set_param(
+            "bemade_sql_console.row_cap", "1000"
+        )
+
+    def test_truncated_true_when_over_cap(self):
+        """When result exceeds cap, row_count == cap and truncated is True."""
+        self._set_row_cap(2)
+        try:
+            result = self.env["sql.console"].run_query(
+                "SELECT generate_series(1, 5) AS n"
+            )
+            self.assertEqual(result["row_count"], 2, "row_count should equal the cap")
+            self.assertEqual(
+                len(result["rows"]), 2, "rows list length should equal the cap"
+            )
+            self.assertTrue(
+                result["truncated"], "truncated should be True when result exceeds cap"
+            )
+        finally:
+            self._restore_row_cap()
+
+    def test_truncated_false_when_at_cap(self):
+        """When result equals cap exactly, truncated is False."""
+        self._set_row_cap(2)
+        try:
+            result = self.env["sql.console"].run_query(
+                "SELECT generate_series(1, 2) AS n"
+            )
+            self.assertEqual(result["row_count"], 2)
+            self.assertEqual(len(result["rows"]), 2)
+            self.assertFalse(
+                result["truncated"],
+                "truncated should be False when result equals the cap exactly",
+            )
+        finally:
+            self._restore_row_cap()
+
+    def test_truncated_false_when_under_cap(self):
+        """When result is below cap, truncated is False."""
+        self._set_row_cap(2)
+        try:
+            result = self.env["sql.console"].run_query(
+                "SELECT generate_series(1, 1) AS n"
+            )
+            self.assertEqual(result["row_count"], 1)
+            self.assertFalse(result["truncated"])
+        finally:
+            self._restore_row_cap()
+
+    def test_row_values_are_correct(self):
+        """Rows returned are the first N rows, not random rows."""
+        self._set_row_cap(3)
+        try:
+            result = self.env["sql.console"].run_query(
+                "SELECT generate_series(1, 10) AS n ORDER BY n"
+            )
+            self.assertEqual(result["row_count"], 3)
+            # First 3 values: 1, 2, 3
+            values = [row[0] for row in result["rows"]]
+            self.assertEqual(values, [1, 2, 3])
+            self.assertTrue(result["truncated"])
+        finally:
+            self._restore_row_cap()
+
+    def test_default_cap_is_1000(self):
+        """Default row cap (1000) is respected when parameter is not set to a low value."""
+        # Remove parameter to fall back to default
+        param = self.env["ir.config_parameter"].sudo().search(
+            [("key", "=", "bemade_sql_console.row_cap")]
+        )
+        saved = None
+        if param:
+            saved = param.value
+            param.value = "1000"
+
+        try:
+            # Generate 5 rows — all 5 should come back
+            result = self.env["sql.console"].run_query(
+                "SELECT generate_series(1, 5) AS n"
+            )
+            self.assertEqual(result["row_count"], 5)
+            self.assertFalse(result["truncated"])
+        finally:
+            if saved is not None:
+                param.value = saved

--- a/bemade_sql_console/tests/test_us07_degrade.py
+++ b/bemade_sql_console/tests/test_us07_degrade.py
@@ -1,0 +1,18 @@
+"""
+US-07 — Graceful degradation when RO env vars are absent.
+
+Acceptance criteria
+-------------------
+- Unsetting ODOO_RO_DB_USER / ODOO_RO_DB_PASSWORD causes run_query("SELECT 1")
+  to raise UserError with the "not configured" message.
+- No psycopg2 connection is attempted (spy on psycopg2.connect).
+- self.env.cr is not queried (spy on env.cr.execute).
+
+Phase 4: implement test body.
+"""
+
+from .common import SqlConsoleTestBase
+
+
+class TestDegrade(SqlConsoleTestBase):
+    """Phase 4 implements the test body."""

--- a/bemade_sql_console/tests/test_us07_degrade.py
+++ b/bemade_sql_console/tests/test_us07_degrade.py
@@ -8,11 +8,140 @@ Acceptance criteria
 - No psycopg2 connection is attempted (spy on psycopg2.connect).
 - self.env.cr is not queried (spy on env.cr.execute).
 
-Phase 4: implement test body.
+Note: this test class does NOT inherit the RO-role setup from SqlConsoleTestBase
+for the purpose of env-var removal tests.  The base class's setUpClass populates
+the env vars; each test method here temporarily removes them.
 """
+
+import os
+from unittest.mock import patch
+
+from odoo.exceptions import UserError
+from odoo.tests import tagged
+from odoo.tools.misc import mute_logger
 
 from .common import SqlConsoleTestBase
 
+_NOT_CONFIGURED_MSG = "not configured"
 
+
+@tagged("at_install", "post_install")
 class TestDegrade(SqlConsoleTestBase):
-    """Phase 4 implements the test body."""
+    """US-07: Missing env vars produce a clean UserError with no fallback."""
+
+    def _unset_env(self):
+        """Remove the RO env vars and return their original values."""
+        saved = {
+            "ODOO_RO_DB_USER": os.environ.pop("ODOO_RO_DB_USER", None),
+            "ODOO_RO_DB_PASSWORD": os.environ.pop("ODOO_RO_DB_PASSWORD", None),
+        }
+        return saved
+
+    def _restore_env(self, saved):
+        """Restore the env vars from the saved dict."""
+        for key, val in saved.items():
+            if val is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = val
+
+    def test_missing_both_vars_raises_user_error(self):
+        """When both env vars are absent, UserError with 'not configured' is raised."""
+        saved = self._unset_env()
+        try:
+            with mute_logger("odoo.addons.bemade_sql_console.models.sql_console"):
+                with self.assertRaises(UserError) as cm:
+                    self.env["sql.console"].run_query("SELECT 1")
+            self.assertIn(
+                _NOT_CONFIGURED_MSG,
+                str(cm.exception),
+                f"Expected 'not configured' in error, got: {cm.exception}",
+            )
+        finally:
+            self._restore_env(saved)
+
+    def test_missing_user_only_raises_user_error(self):
+        """When only ODOO_RO_DB_USER is absent, UserError is raised."""
+        saved_user = os.environ.pop("ODOO_RO_DB_USER", None)
+        try:
+            with mute_logger("odoo.addons.bemade_sql_console.models.sql_console"):
+                with self.assertRaises(UserError) as cm:
+                    self.env["sql.console"].run_query("SELECT 1")
+            self.assertIn(_NOT_CONFIGURED_MSG, str(cm.exception))
+        finally:
+            if saved_user is not None:
+                os.environ["ODOO_RO_DB_USER"] = saved_user
+
+    def test_missing_password_only_raises_user_error(self):
+        """When only ODOO_RO_DB_PASSWORD is absent, UserError is raised."""
+        saved_pass = os.environ.pop("ODOO_RO_DB_PASSWORD", None)
+        try:
+            with mute_logger("odoo.addons.bemade_sql_console.models.sql_console"):
+                with self.assertRaises(UserError) as cm:
+                    self.env["sql.console"].run_query("SELECT 1")
+            self.assertIn(_NOT_CONFIGURED_MSG, str(cm.exception))
+        finally:
+            if saved_pass is not None:
+                os.environ["ODOO_RO_DB_PASSWORD"] = saved_pass
+
+    def test_no_psycopg2_connect_attempted(self):
+        """psycopg2.connect is never called when env vars are missing."""
+        saved = self._unset_env()
+        try:
+            with patch("psycopg2.connect") as mock_connect:
+                with mute_logger("odoo.addons.bemade_sql_console.models.sql_console"):
+                    with self.assertRaises(UserError):
+                        self.env["sql.console"].run_query("SELECT 1")
+                mock_connect.assert_not_called()
+        finally:
+            self._restore_env(saved)
+
+    def test_no_owner_cr_query_attempted(self):
+        """env.cr.execute is not called with the user's SQL when env vars are missing.
+
+        (env.cr may be used by Odoo internals like ir.config_parameter.get_param,
+        but the user's SELECT 1 must not appear in those calls.)
+        """
+        saved = self._unset_env()
+        try:
+            real_execute = self.env.cr.execute
+            call_sqls = []
+
+            def spy_execute(sql, *args, **kwargs):
+                call_sqls.append(str(sql)[:200])
+                return real_execute(sql, *args, **kwargs)
+
+            with patch.object(self.env.cr, "execute", side_effect=spy_execute):
+                with mute_logger("odoo.addons.bemade_sql_console.models.sql_console"):
+                    with self.assertRaises(UserError):
+                        self.env["sql.console"].run_query(
+                            "SELECT 999 AS sentinel_us07"
+                        )
+
+            matched = [s for s in call_sqls if "sentinel_us07" in s]
+            self.assertFalse(
+                matched,
+                f"User SQL appeared in env.cr calls despite env vars being absent: {matched}",
+            )
+        finally:
+            self._restore_env(saved)
+
+    def test_empty_string_env_vars_raise_user_error(self):
+        """Empty string env vars (not unset but blank) also trigger the error."""
+        saved = {
+            "ODOO_RO_DB_USER": os.environ.get("ODOO_RO_DB_USER"),
+            "ODOO_RO_DB_PASSWORD": os.environ.get("ODOO_RO_DB_PASSWORD"),
+        }
+        os.environ["ODOO_RO_DB_USER"] = "  "   # whitespace only
+        os.environ["ODOO_RO_DB_PASSWORD"] = ""
+        try:
+            with mute_logger("odoo.addons.bemade_sql_console.models.sql_console"):
+                with self.assertRaises(UserError) as cm:
+                    self.env["sql.console"].run_query("SELECT 1")
+            self.assertIn(_NOT_CONFIGURED_MSG, str(cm.exception))
+        finally:
+            for key, val in saved.items():
+                if val is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = val

--- a/bemade_sql_console/views/sql_console_views.xml
+++ b/bemade_sql_console/views/sql_console_views.xml
@@ -63,7 +63,7 @@
         <field name="res_model">sql.console.wizard</field>
         <field name="view_mode">form</field>
         <field name="target">new</field>
-        <field name="groups_id" eval="[(4, ref('bemade_sql_console.group_sql_console'))]"/>
+        <field name="group_ids" eval="[(4, ref('bemade_sql_console.group_sql_console'))]"/>
     </record>
 
     <!-- ================================================================

--- a/bemade_sql_console/views/sql_console_views.xml
+++ b/bemade_sql_console/views/sql_console_views.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2026 Bemade Inc.
+    License LGPL-3 or later (https://www.gnu.org/licenses/lgpl).
+-->
+<odoo>
+
+    <!-- ================================================================
+         Form view for the sql.console.wizard transient model
+         ================================================================ -->
+    <record id="view_sql_console_wizard_form" model="ir.ui.view">
+        <field name="name">sql.console.wizard.form</field>
+        <field name="model">sql.console.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Read-only SQL Console">
+                <sheet>
+                    <group>
+                        <field name="sql_text"
+                               widget="code"
+                               options="{'mode': 'python'}"
+                               placeholder="SELECT …"
+                               nolabel="1"
+                               colspan="2"/>
+                    </group>
+                    <div class="o_row" invisible="not error_message">
+                        <div class="alert alert-danger" role="alert">
+                            <field name="error_message" readonly="1" nolabel="1"/>
+                        </div>
+                    </div>
+                    <group invisible="not row_count">
+                        <field name="row_count" readonly="1"/>
+                        <field name="truncated" readonly="1"/>
+                    </group>
+                    <group invisible="not result_columns">
+                        <field name="result_columns" readonly="1" string="Columns (JSON)"/>
+                    </group>
+                    <group invisible="not result_rows">
+                        <field name="result_rows"
+                               widget="code"
+                               options="{'mode': 'python'}"
+                               readonly="1"
+                               string="Rows (JSON)"/>
+                    </group>
+                </sheet>
+                <footer>
+                    <button name="action_run_query"
+                            type="object"
+                            string="Run Query"
+                            class="btn-primary"/>
+                    <button string="Close"
+                            class="btn-secondary"
+                            special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <!-- ================================================================
+         Action to open the SQL console wizard
+         ================================================================ -->
+    <record id="action_sql_console" model="ir.actions.act_window">
+        <field name="name">SQL Console</field>
+        <field name="res_model">sql.console.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+        <field name="groups_id" eval="[(4, ref('bemade_sql_console.group_sql_console'))]"/>
+    </record>
+
+    <!-- ================================================================
+         Top-level menu — gated by group_sql_console
+         ================================================================ -->
+    <menuitem id="menu_sql_console_root"
+              name="SQL Console"
+              sequence="100"
+              groups="bemade_sql_console.group_sql_console"/>
+
+    <menuitem id="menu_sql_console"
+              name="Run Query"
+              parent="menu_sql_console_root"
+              action="action_sql_console"
+              sequence="10"
+              groups="bemade_sql_console.group_sql_console"/>
+
+</odoo>


### PR DESCRIPTION
Adds `bemade_sql_console` — an admin-only read-only SQL console that executes SELECT queries as a SELECT-only Postgres role over its own connection (never `self.env.cr`), callable from an in-Odoo editor UI and over JSON-RPC/XML-RPC.

**Security model:** the SELECT-only role is the write boundary (content-independent — rejects writable CTEs / SET / embedded COMMIT at the Postgres ACL); in-method admin-group check is the RPC authorization gate; app-layer read-only + statement_timeout + row cap as defense-in-depth/stability; Decimal→str (connection-scoped typecaster) preserves numeric precision; graceful degradation when RO env vars are absent.

Consumes `ODOO_RO_DB_USER`/`ODOO_RO_DB_PASSWORD` (provisioned by odoo-operator PR #135 + a forthcoming env-injection). **53/53 tests green** (incl. live SELECT-only role, writable-CTE rejection, non-admin RPC gate, row-cap, graceful degradation).

Bemade task #3731. Artifacts: https://git.bemade.org/bemade/tasks/-/tree/main/task-3731-readonly-sql-console