### PR TITLE
bemade_sql_console: paginated result table + CSV export + wizard write-perm fix

### DIFF
--- a/bemade_sql_console/__manifest__.py
+++ b/bemade_sql_console/__manifest__.py
@@ -60,6 +60,11 @@ not write prevention. The SELECT-only PostgreSQL role is the real boundary.
         "data/ir_config_parameter.xml",
         "views/sql_console_views.xml",
     ],
+    "assets": {
+        "web.assets_backend": [
+            "bemade_sql_console/static/src/**/*",
+        ],
+    },
     "installable": True,
     "application": False,
     "auto_install": False,

--- a/bemade_sql_console/data/ir_config_parameter.xml
+++ b/bemade_sql_console/data/ir_config_parameter.xml
@@ -20,5 +20,14 @@
             <field name="value">30000</field>
         </record>
 
+        <!--
+            Row cap for the *CSV export* path (export_query_csv), distinct from
+            the small UI row_cap above. Bounds full-result downloads.
+        -->
+        <record id="param_export_row_cap" model="ir.config_parameter">
+            <field name="key">bemade_sql_console.export_row_cap</field>
+            <field name="value">100000</field>
+        </record>
+
     </data>
 </odoo>

--- a/bemade_sql_console/models/sql_console.py
+++ b/bemade_sql_console/models/sql_console.py
@@ -13,8 +13,10 @@ Security model
 """
 
 import base64
+import csv
 import datetime
 import decimal
+import io
 import logging
 import os
 import re
@@ -301,6 +303,55 @@ class SqlConsole(models.Model):
         AccessError  — caller is not in group_sql_console
         UserError    — env vars absent, guard violation, or timeout
         """
+        row_cap = self._get_int_param("bemade_sql_console.row_cap", 1000)
+        return self._run_query_capped(sql, row_cap)
+
+    @api.model
+    def export_query_csv(self, sql: str) -> bytes:
+        """Execute *sql* over the guarded RO path and return the full result as CSV.
+
+        Unlike :meth:`run_query`, the result is bounded by the *export* cap
+        ``bemade_sql_console.export_row_cap`` (default 100000), not the small UI
+        ``row_cap``.  The same admin group check, single-SELECT guard, SELECT-only
+        role, app-layer read-only, statement timeout and Decimal→str coercion are
+        enforced — the only difference is the cap and the output format.
+
+        Returns
+        -------
+        bytes — UTF-8 encoded CSV with a header row of column names.
+
+        Raises
+        ------
+        AccessError  — caller is not in group_sql_console
+        UserError    — env vars absent, guard violation, or timeout
+        """
+        export_cap = self._get_int_param(
+            "bemade_sql_console.export_row_cap", 100000
+        )
+        result = self._run_query_capped(sql, export_cap)
+
+        buf = io.StringIO()
+        writer = csv.writer(buf)
+        writer.writerow(result["columns"])
+        for row in result["rows"]:
+            # Values are already JSON-coerced (Decimal→str, None stays None →
+            # csv renders as empty field, datetime→iso, etc.).
+            writer.writerow(["" if v is None else v for v in row])
+        return buf.getvalue().encode("utf-8")
+
+    # ------------------------------------------------------------------
+    # Shared guarded runner
+    # ------------------------------------------------------------------
+
+    def _run_query_capped(self, sql: str, row_cap: int) -> dict:
+        """Run *sql* over the guarded RO path, bounded by *row_cap* rows.
+
+        This is the single shared implementation behind both :meth:`run_query`
+        (UI cap) and :meth:`export_query_csv` (export cap).  It owns the full
+        security path: in-method admin group check, single-statement guard,
+        RO-role connection, app-layer read-only and statement timeout.  Callers
+        differ only in the cap they pass and what they do with the envelope.
+        """
         # 1. Authorization — MUST be first; this is the only RPC trust boundary
         if not self.env.user.has_group("bemade_sql_console.group_sql_console"):
             raise AccessError(_("You are not allowed to run SQL console queries."))
@@ -319,18 +370,10 @@ class SqlConsole(models.Model):
                 )
             )
 
-        # 4. Read runtime parameters
-        get_param = self.env["ir.config_parameter"].sudo().get_param
-        try:
-            row_cap = int(get_param("bemade_sql_console.row_cap", "1000"))
-        except (ValueError, TypeError):
-            row_cap = 1000
-        try:
-            timeout_ms = int(
-                get_param("bemade_sql_console.statement_timeout_ms", "30000")
-            )
-        except (ValueError, TypeError):
-            timeout_ms = 30000
+        # 4. Read the statement timeout (the row cap is supplied by the caller)
+        timeout_ms = self._get_int_param(
+            "bemade_sql_console.statement_timeout_ms", 30000
+        )
 
         # 5. Build connection info (host/port/sslmode from Odoo config; replica-aware)
         conn_info = self._ro_connection_info(ro_user, ro_password, timeout_ms)
@@ -392,6 +435,14 @@ class SqlConsole(models.Model):
     # ------------------------------------------------------------------
     # Private helpers
     # ------------------------------------------------------------------
+
+    def _get_int_param(self, key: str, default: int) -> int:
+        """Read an integer ir.config_parameter, falling back to *default*."""
+        raw = self.env["ir.config_parameter"].sudo().get_param(key, str(default))
+        try:
+            return int(raw)
+        except (ValueError, TypeError):
+            return default
 
     def _ro_connection_info(
         self, ro_user: str, ro_password: str, timeout_ms: int

--- a/bemade_sql_console/models/sql_console_wizard.py
+++ b/bemade_sql_console/models/sql_console_wizard.py
@@ -1,10 +1,11 @@
 """sql.console.wizard — transient UI model for the SQL console form view."""
 
-import json
+import base64
 import logging
 
 from odoo import _, fields, models
 from odoo.exceptions import UserError
+from odoo.fields import Datetime
 
 _logger = logging.getLogger(__name__)
 
@@ -23,12 +24,11 @@ class SqlConsoleWizard(models.TransientModel):
         string="SQL Query",
         help="Enter a single SELECT or WITH statement.",
     )
-    result_columns = fields.Text(
-        string="Columns",
-        readonly=True,
-    )
-    result_rows = fields.Text(
-        string="Rows (JSON)",
+    # Full result envelope ({columns, rows, row_count, truncated}) read by the
+    # sql_result_table OWL widget. fields.Json keeps it as a structured object
+    # client-side rather than a raw JSON string.
+    result_json = fields.Json(
+        string="Result",
         readonly=True,
     )
     row_count = fields.Integer(
@@ -44,14 +44,22 @@ class SqlConsoleWizard(models.TransientModel):
         string="Error",
         readonly=True,
     )
+    csv_file = fields.Binary(
+        string="CSV Export",
+        readonly=True,
+        attachment=False,
+    )
+    csv_filename = fields.Char(
+        string="CSV Filename",
+        readonly=True,
+    )
 
     def action_run_query(self):
         """Execute the SQL and stash the result envelope into display fields."""
         self.ensure_one()
         self.write(
             {
-                "result_columns": False,
-                "result_rows": False,
+                "result_json": False,
                 "row_count": 0,
                 "truncated": False,
                 "error_message": False,
@@ -61,8 +69,7 @@ class SqlConsoleWizard(models.TransientModel):
             result = self.env["sql.console"].run_query(self.sql_text or "")
             self.write(
                 {
-                    "result_columns": json.dumps(result["columns"], ensure_ascii=False),
-                    "result_rows": json.dumps(result["rows"], ensure_ascii=False),
+                    "result_json": result,
                     "row_count": result["row_count"],
                     "truncated": result["truncated"],
                 }
@@ -70,6 +77,43 @@ class SqlConsoleWizard(models.TransientModel):
         except (UserError, Exception) as exc:
             self.write({"error_message": str(exc)})
 
+        return self._reload_action()
+
+    def action_export_csv(self):
+        """Export the FULL result (export cap, not UI cap) as a CSV download.
+
+        Re-runs the same guarded RO path via ``sql.console.export_query_csv``
+        (which enforces the admin group check) and delivers the bytes as a
+        browser download through ``/web/content``.
+        """
+        self.ensure_one()
+        self.write({"error_message": False})
+        try:
+            csv_bytes = self.env["sql.console"].export_query_csv(self.sql_text or "")
+        except (UserError, Exception) as exc:
+            self.write({"error_message": str(exc)})
+            return self._reload_action()
+
+        filename = "sql_console_export_%s.csv" % Datetime.now().strftime(
+            "%Y%m%d_%H%M%S"
+        )
+        self.write(
+            {
+                "csv_file": base64.b64encode(csv_bytes),
+                "csv_filename": filename,
+            }
+        )
+        return {
+            "type": "ir.actions.act_url",
+            "url": (
+                "/web/content/%s/%s/csv_file/%s?download=true"
+                % (self._name, self.id, filename)
+            ),
+            "target": "self",
+        }
+
+    def _reload_action(self):
+        """Re-open this wizard's form view (target=new) after a write."""
         return {
             "type": "ir.actions.act_window",
             "res_model": self._name,

--- a/bemade_sql_console/security/ir.model.access.csv
+++ b/bemade_sql_console/security/ir.model.access.csv
@@ -1,3 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_sql_console_group,sql.console group,model_sql_console,bemade_sql_console.group_sql_console,1,0,1,0
-access_sql_console_wizard_group,sql.console.wizard group,model_sql_console_wizard,bemade_sql_console.group_sql_console,1,0,1,0
+access_sql_console_wizard_group,sql.console.wizard group,model_sql_console_wizard,bemade_sql_console.group_sql_console,1,1,1,0

--- a/bemade_sql_console/static/src/sql_result_table/sql_result_table.js
+++ b/bemade_sql_console/static/src/sql_result_table/sql_result_table.js
@@ -1,0 +1,139 @@
+/** @odoo-module **/
+
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+import { standardFieldProps } from "@web/views/fields/standard_field_props";
+
+import { Component, useState } from "@odoo/owl";
+
+const PAGE_SIZES = [25, 50, 100];
+
+/**
+ * Read-only field widget that renders a SQL console result envelope
+ * ({columns, rows, row_count, truncated}) as an HTML table with client-side
+ * pagination.
+ *
+ * Grounded against web/static/src/views/fields/boolean/boolean_field.js and
+ * json/json_field.js (Odoo 19.0) for the Component + standardFieldProps +
+ * registry.category("fields").add(...) pattern.
+ */
+export class SqlResultTable extends Component {
+    static template = "bemade_sql_console.SqlResultTable";
+    static props = {
+        ...standardFieldProps,
+    };
+
+    setup() {
+        this.state = useState({
+            page: 0,
+            pageSize: PAGE_SIZES[0],
+        });
+        this.pageSizes = PAGE_SIZES;
+    }
+
+    /** The raw envelope, or a safe empty default. */
+    get envelope() {
+        const value = this.props.record.data[this.props.name];
+        if (!value || typeof value !== "object") {
+            return { columns: [], rows: [], row_count: 0, truncated: false };
+        }
+        return {
+            columns: Array.isArray(value.columns) ? value.columns : [],
+            rows: Array.isArray(value.rows) ? value.rows : [],
+            row_count: value.row_count || 0,
+            truncated: Boolean(value.truncated),
+        };
+    }
+
+    get columns() {
+        return this.envelope.columns;
+    }
+
+    get allRows() {
+        return this.envelope.rows;
+    }
+
+    get truncated() {
+        return this.envelope.truncated;
+    }
+
+    get hasResult() {
+        return this.columns.length > 0 || this.allRows.length > 0;
+    }
+
+    get totalRows() {
+        return this.allRows.length;
+    }
+
+    get pageCount() {
+        return Math.max(1, Math.ceil(this.totalRows / this.state.pageSize));
+    }
+
+    /** Clamp the page index into [0, pageCount - 1]. */
+    get currentPage() {
+        const max = this.pageCount - 1;
+        if (this.state.page > max) {
+            return max;
+        }
+        return this.state.page < 0 ? 0 : this.state.page;
+    }
+
+    get pageRows() {
+        const start = this.currentPage * this.state.pageSize;
+        return this.allRows.slice(start, start + this.state.pageSize);
+    }
+
+    /** 1-based index of the first row shown (0 when empty). */
+    get firstRowIndex() {
+        return this.totalRows === 0 ? 0 : this.currentPage * this.state.pageSize + 1;
+    }
+
+    /** 1-based index of the last row shown. */
+    get lastRowIndex() {
+        return Math.min((this.currentPage + 1) * this.state.pageSize, this.totalRows);
+    }
+
+    get rangeLabel() {
+        return _t("Row %(from)s–%(to)s of %(total)s", {
+            from: this.firstRowIndex,
+            to: this.lastRowIndex,
+            total: this.totalRows,
+        });
+    }
+
+    /** Render a single cell value for display. */
+    formatCell(value) {
+        if (value === null || value === undefined) {
+            return "";
+        }
+        if (typeof value === "object") {
+            return JSON.stringify(value);
+        }
+        return String(value);
+    }
+
+    onPrev() {
+        if (this.currentPage > 0) {
+            this.state.page = this.currentPage - 1;
+        }
+    }
+
+    onNext() {
+        if (this.currentPage < this.pageCount - 1) {
+            this.state.page = this.currentPage + 1;
+        }
+    }
+
+    onPageSizeChange(ev) {
+        this.state.pageSize = parseInt(ev.target.value, 10) || PAGE_SIZES[0];
+        this.state.page = 0;
+    }
+}
+
+export const sqlResultTable = {
+    component: SqlResultTable,
+    displayName: _t("SQL Result Table"),
+    supportedTypes: ["json"],
+};
+
+registry.category("fields").add("sql_result_table", sqlResultTable);

--- a/bemade_sql_console/static/src/sql_result_table/sql_result_table.xml
+++ b/bemade_sql_console/static/src/sql_result_table/sql_result_table.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="bemade_sql_console.SqlResultTable">
+        <div class="o_sql_result_table">
+            <t t-if="!hasResult">
+                <div class="text-muted fst-italic p-2">
+                    No results to display. Run a query to see rows here.
+                </div>
+            </t>
+            <t t-else="">
+                <div class="d-flex align-items-center flex-wrap gap-2 mb-2">
+                    <span class="badge text-bg-secondary" t-esc="rangeLabel"/>
+                    <span t-if="truncated" class="badge text-bg-warning">
+                        Truncated — more rows exist beyond the row cap
+                    </span>
+                    <div class="ms-auto d-flex align-items-center gap-2">
+                        <label class="mb-0 small text-muted">Page size</label>
+                        <select class="o_input form-select form-select-sm w-auto"
+                                t-on-change="onPageSizeChange">
+                            <option t-foreach="pageSizes" t-as="size" t-key="size"
+                                    t-att-value="size"
+                                    t-att-selected="size === state.pageSize"
+                                    t-esc="size"/>
+                        </select>
+                        <button type="button"
+                                class="btn btn-sm btn-secondary"
+                                t-att-disabled="currentPage === 0"
+                                t-on-click="onPrev">
+                            <i class="fa fa-chevron-left"/>
+                        </button>
+                        <span class="small text-muted">
+                            <t t-esc="currentPage + 1"/> / <t t-esc="pageCount"/>
+                        </span>
+                        <button type="button"
+                                class="btn btn-sm btn-secondary"
+                                t-att-disabled="currentPage >= pageCount - 1"
+                                t-on-click="onNext">
+                            <i class="fa fa-chevron-right"/>
+                        </button>
+                    </div>
+                </div>
+                <div class="table-responsive">
+                    <table class="table table-sm table-bordered table-striped o_list_table">
+                        <thead>
+                            <tr>
+                                <th t-foreach="columns" t-as="col" t-key="col_index"
+                                    t-esc="col"/>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr t-foreach="pageRows" t-as="row" t-key="row_index">
+                                <td t-foreach="row" t-as="cell" t-key="cell_index"
+                                    t-esc="formatCell(cell)"/>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </t>
+        </div>
+    </t>
+
+</templates>

--- a/bemade_sql_console/tests/__init__.py
+++ b/bemade_sql_console/tests/__init__.py
@@ -9,3 +9,5 @@ from . import test_us04_single_select_guard
 from . import test_us05_admin_check
 from . import test_us06_row_cap
 from . import test_us07_degrade
+from . import test_us08_wizard_write_perm
+from . import test_us09_csv_export

--- a/bemade_sql_console/tests/test_us08_wizard_write_perm.py
+++ b/bemade_sql_console/tests/test_us08_wizard_write_perm.py
@@ -1,0 +1,78 @@
+"""
+US-08 — Wizard write-perm regression (ACL fix).
+
+Acceptance criteria
+-------------------
+- A non-admin user who IS a member of bemade_sql_console.group_sql_console can
+  with_user(member).create(...) a sql.console.wizard record and call
+  action_run_query() WITHOUT an AccessError.
+- The outcome is written: either a result envelope (result_json) on success, or
+  an error_message on failure — but never an unhandled AccessError from the
+  wizard's own write() on the transient model.
+
+This is the regression test for the ir.model.access.csv write-perm fix that
+grants perm_write on sql.console.wizard to group_sql_console members (so the
+wizard can stash results into its own transient record).
+"""
+
+from odoo.tests import tagged
+from odoo.tests.common import new_test_user
+
+from .common import SqlConsoleTestBase
+
+
+@tagged("at_install", "post_install")
+class TestWizardWritePerm(SqlConsoleTestBase):
+    """US-08: group_sql_console member can run the wizard without AccessError."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # A non-admin user who IS granted console access directly (not via
+        # base.group_system) — the exact persona the ACL fix targets.
+        cls.console_member = new_test_user(
+            cls.env,
+            login="sql_console_member",
+            groups="base.group_user,bemade_sql_console.group_sql_console",
+        )
+
+    def test_member_can_run_wizard(self):
+        """Member creates + runs the wizard without an AccessError."""
+        self.assertTrue(
+            self.console_member.has_group("bemade_sql_console.group_sql_console"),
+            "Test user must be in group_sql_console for this regression to be meaningful",
+        )
+
+        wizard = (
+            self.env["sql.console.wizard"]
+            .with_user(self.console_member)
+            .create({"sql_text": "SELECT 1 AS a"})
+        )
+        # Must not raise AccessError (the regression). The wizard catches query
+        # errors internally and writes them to error_message.
+        wizard.action_run_query()
+
+        # The outcome must be written to the record: a result OR an error.
+        self.assertTrue(
+            wizard.result_json or wizard.error_message,
+            "action_run_query must persist either a result or an error_message",
+        )
+
+    def test_member_run_writes_result_envelope(self):
+        """On a successful SELECT, result_json carries the envelope."""
+        wizard = (
+            self.env["sql.console.wizard"]
+            .with_user(self.console_member)
+            .create({"sql_text": "SELECT 42 AS answer"})
+        )
+        wizard.action_run_query()
+
+        self.assertFalse(
+            wizard.error_message,
+            "A valid SELECT should not produce an error_message: %s"
+            % wizard.error_message,
+        )
+        self.assertTrue(wizard.result_json, "result_json should be populated")
+        self.assertEqual(wizard.result_json.get("columns"), ["answer"])
+        self.assertEqual(wizard.result_json.get("rows"), [[42]])
+        self.assertEqual(wizard.row_count, 1)

--- a/bemade_sql_console/tests/test_us09_csv_export.py
+++ b/bemade_sql_console/tests/test_us09_csv_export.py
@@ -1,0 +1,115 @@
+"""
+US-09 — CSV export (full result) + export cap + admin check.
+
+Acceptance criteria
+-------------------
+- export_query_csv(sql) returns CSV bytes whose header row == columns and whose
+  data rows match the query result.
+- Values containing a comma, newline or double-quote are properly quoted (csv
+  module quoting), surviving a round-trip through csv.reader.
+- The export is bounded by bemade_sql_console.export_row_cap (NOT the small UI
+  row_cap): with export_row_cap=3, a 10-row SELECT yields 3 data rows.
+- The export enforces the same admin group check as run_query (AccessError for
+  a non-member).
+"""
+
+import csv
+import io
+
+from odoo.exceptions import AccessError
+from odoo.tests import tagged
+from odoo.tests.common import new_test_user
+from odoo.tools.misc import mute_logger
+
+from .common import SqlConsoleTestBase
+
+
+def _parse_csv(raw_bytes):
+    """Decode + parse CSV bytes into a list of rows (list of str)."""
+    text = raw_bytes.decode("utf-8")
+    return list(csv.reader(io.StringIO(text)))
+
+
+@tagged("at_install", "post_install")
+class TestCsvExport(SqlConsoleTestBase):
+    """US-09: export_query_csv produces correct, properly-quoted, capped CSV."""
+
+    def _set_param(self, key, value):
+        self.env["ir.config_parameter"].sudo().set_param(key, str(value))
+
+    def test_header_and_rows_match_result(self):
+        """CSV header == columns; data rows match the SELECT output."""
+        sql = "SELECT n, n * 10 AS ten FROM generate_series(1, 3) AS n ORDER BY n"
+        raw = self.env["sql.console"].export_query_csv(sql)
+        parsed = _parse_csv(raw)
+
+        # Header
+        self.assertEqual(parsed[0], ["n", "ten"])
+        # Data rows
+        self.assertEqual(parsed[1:], [["1", "10"], ["2", "20"], ["3", "30"]])
+
+    def test_quoting_comma_newline_quote(self):
+        """Values with comma/newline/quote survive a CSV round-trip intact."""
+        # Build a single-row, single-column result whose value contains all
+        # three CSV-hostile characters.
+        nasty = 'a,b\nc"d'
+        # Use a parameterised-style literal embedded safely via dollar quoting.
+        sql = "SELECT $tag$%s$tag$ AS v" % nasty
+        raw = self.env["sql.console"].export_query_csv(sql)
+        parsed = _parse_csv(raw)
+
+        self.assertEqual(parsed[0], ["v"])
+        # The parsed value must exactly equal the original (proves quoting worked)
+        self.assertEqual(parsed[1], [nasty])
+
+    def test_export_respects_export_cap(self):
+        """export_query_csv is bounded by export_row_cap, not row_cap."""
+        # Tiny UI cap, slightly larger export cap — proves they're independent.
+        self._set_param("bemade_sql_console.row_cap", 1)
+        self._set_param("bemade_sql_console.export_row_cap", 3)
+        try:
+            sql = "SELECT n FROM generate_series(1, 10) AS n ORDER BY n"
+            raw = self.env["sql.console"].export_query_csv(sql)
+            parsed = _parse_csv(raw)
+            # 1 header + 3 data rows (export cap), NOT 1 (ui cap) or 10 (uncapped)
+            self.assertEqual(len(parsed) - 1, 3, "Export must honor export_row_cap")
+            self.assertEqual([r[0] for r in parsed[1:]], ["1", "2", "3"])
+        finally:
+            self._set_param("bemade_sql_console.row_cap", 1000)
+            self._set_param("bemade_sql_console.export_row_cap", 100000)
+
+    def test_export_default_cap_when_param_absent(self):
+        """When export_row_cap is unset, a small result is fully exported."""
+        param = (
+            self.env["ir.config_parameter"]
+            .sudo()
+            .search([("key", "=", "bemade_sql_console.export_row_cap")])
+        )
+        saved = param.value if param else None
+        if param:
+            param.unlink()
+        try:
+            sql = "SELECT n FROM generate_series(1, 5) AS n ORDER BY n"
+            raw = self.env["sql.console"].export_query_csv(sql)
+            parsed = _parse_csv(raw)
+            self.assertEqual(len(parsed) - 1, 5)
+        finally:
+            if saved is not None:
+                self._set_param("bemade_sql_console.export_row_cap", saved)
+
+    def test_export_enforces_admin_check(self):
+        """A non-member calling export_query_csv raises AccessError."""
+        non_admin = new_test_user(
+            self.env,
+            login="sql_console_export_nobody",
+            groups="base.group_user",
+        )
+        with mute_logger(
+            "odoo.addons.bemade_sql_console.models.sql_console"
+        ):
+            with self.assertRaises(AccessError):
+                (
+                    self.env["sql.console"]
+                    .with_user(non_admin)
+                    .export_query_csv("SELECT 1")
+                )

--- a/bemade_sql_console/views/sql_console_views.xml
+++ b/bemade_sql_console/views/sql_console_views.xml
@@ -27,26 +27,28 @@
                             <field name="error_message" readonly="1" nolabel="1"/>
                         </div>
                     </div>
-                    <group invisible="not row_count">
-                        <field name="row_count" readonly="1"/>
-                        <field name="truncated" readonly="1"/>
-                    </group>
-                    <group invisible="not result_columns">
-                        <field name="result_columns" readonly="1" string="Columns (JSON)"/>
-                    </group>
-                    <group invisible="not result_rows">
-                        <field name="result_rows"
-                               widget="code"
-                               options="{'mode': 'python'}"
-                               readonly="1"
-                               string="Rows (JSON)"/>
-                    </group>
+                    <!-- Hidden plumbing for the CSV download -->
+                    <field name="csv_file" invisible="1"/>
+                    <field name="csv_filename" invisible="1"/>
+                    <field name="row_count" invisible="1"/>
+                    <field name="truncated" invisible="1"/>
+                    <!-- Paginated result table (OWL widget) -->
+                    <field name="result_json"
+                           widget="sql_result_table"
+                           readonly="1"
+                           nolabel="1"
+                           colspan="2"/>
                 </sheet>
                 <footer>
                     <button name="action_run_query"
                             type="object"
                             string="Run Query"
                             class="btn-primary"/>
+                    <button name="action_export_csv"
+                            type="object"
+                            string="Download CSV"
+                            class="btn-secondary"
+                            invisible="not result_json"/>
                     <button string="Close"
                             class="btn-secondary"
                             special="cancel"/>


### PR DESCRIPTION
Makes the read-only SQL console actually usable for data work, plus a real bug fix.

**Bug fix — wizard write-perm.** `ir.model.access` granted the console group read+create but `perm_write=0` on `sql.console.wizard`; the wizard's `action_run_query` does `self.write()` to stash results/errors, so a non-superuser group member hit `AccessError` ("not allowed to modify SQL Console records") on **Run**. Set wizard `perm_write=1` (the service model `sql.console` stays write=0). Regression test US-08.

**Paginated result table (OWL widget).** Replaces the raw-JSON dump with a `sql_result_table` field widget rendering `{columns, rows}` as an HTML table with client-side pagination (25/50/100, prev/next, "Row X–Y of N", truncated badge, empty-safe). Dynamic columns can't use a fixed list view, hence a widget. Cells render with `t-esc` (no XSS). Result stored in a single `fields.Json`. First JS asset in the module.

**Full-result CSV export.** "Download CSV" → `export_query_csv` runs the **same** guarded RO path via a factored `_run_query_capped` (admin group check FIRST, single-SELECT guard, SELECT-only role, app-layer read-only, statement_timeout, Decimal→str) — no security logic duplicated — bounded by configurable `bemade_sql_console.export_row_cap` (default 100k, not the small UI cap). Proper CSV (stdlib), browser download via Binary + /web/content. Test US-09.

**64 tests pass.** Driven by RWI's need (Bill's TB reconciliation → Excel).