### PR TITLE
bemade_sql_console: streaming CSV export (unbounded, memory-safe)

### DIFF
--- a/bemade_sql_console/__init__.py
+++ b/bemade_sql_console/__init__.py
@@ -1,1 +1,2 @@
+from . import controllers
 from . import models

--- a/bemade_sql_console/__manifest__.py
+++ b/bemade_sql_console/__manifest__.py
@@ -31,8 +31,16 @@ Key guarantees
   is applied both via libpq ``options`` and as a first-cursor ``SET`` so that
   long-running queries are aborted server-side.
 
-* **Row cap.** A configurable row cap (default 1000) bounds returned rows;
-  the response envelope carries a ``truncated`` flag.
+* **Row cap.** A configurable row cap (default 1000) bounds the rows returned
+  to the on-screen UI table; the response envelope carries a ``truncated`` flag.
+
+* **Streaming CSV export.** The "Download CSV" button streams the *full*
+  result — no row cap, bounded only by ``statement_timeout`` — from a psycopg2
+  server-side cursor through a dedicated HTTP controller
+  (``/bemade_sql_console/export/<wizard_id>``). Rows are fetched and flushed in
+  batches so arbitrarily large results never load fully into memory. The route
+  re-enforces the ``group_sql_console`` check (403 otherwise) as the export
+  trust boundary.
 
 * **Graceful degradation.** When ``ODOO_RO_DB_USER``/``ODOO_RO_DB_PASSWORD``
   are not set (dev/test), ``run_query`` raises a clear "not configured" error

--- a/bemade_sql_console/controllers/__init__.py
+++ b/bemade_sql_console/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import main

--- a/bemade_sql_console/controllers/main.py
+++ b/bemade_sql_console/controllers/main.py
@@ -1,0 +1,123 @@
+"""HTTP controller for the streaming CSV export of the read-only SQL console.
+
+The route is the trust boundary for the export: it re-enforces the in-method
+``group_sql_console`` check (Odoo's HTTP dispatcher only authenticates, it does
+not rights-check the endpoint) and then streams the full query result as CSV
+straight from a psycopg2 server-side cursor — no row cap and no buffering of the
+whole result set in memory.
+"""
+
+import csv
+import io
+import logging
+
+import werkzeug.exceptions
+
+from odoo import _, http
+from odoo.exceptions import AccessError, UserError
+from odoo.fields import Datetime
+from odoo.http import request
+
+_logger = logging.getLogger(__name__)
+
+
+class SqlConsoleExportController(http.Controller):
+    """Streaming CSV download for a wizard's SQL query."""
+
+    @http.route(
+        "/bemade_sql_console/export/<int:wizard_id>",
+        type="http",
+        auth="user",
+        methods=["GET"],
+        readonly=True,
+    )
+    def export_csv(self, wizard_id, **kwargs):
+        """Stream the wizard's query result as a CSV attachment.
+
+        Security: the ``group_sql_console`` membership check is re-done here —
+        this route is the trust boundary, because Odoo authenticates HTTP
+        endpoints but does not rights-check them. A non-member gets 403.
+
+        The wizard is browsed in the *user's own env*, so a user can only read
+        their own transient wizard record. The query then runs over the exact
+        same guarded RO path as ``run_query`` via
+        ``sql.console._stream_query_rows`` (single-SELECT guard, SELECT-only
+        role connection, app-layer read-only, statement timeout, Decimal→str).
+        """
+        # Trust boundary — re-enforce the admin group at the route.
+        if not request.env.user.has_group(
+            "bemade_sql_console.group_sql_console"
+        ):
+            raise werkzeug.exceptions.Forbidden(
+                _("You are not allowed to export SQL console queries.")
+            )
+
+        wizard = request.env["sql.console.wizard"].browse(wizard_id)
+        # exists() reads the record in the user's env; a missing/foreign
+        # transient record yields an empty recordset → 404.
+        if not wizard.exists():
+            raise werkzeug.exceptions.NotFound()
+
+        sql = wizard.sql_text or ""
+
+        # Resolve the row generator eagerly so configuration / guard / auth
+        # errors surface as a clean HTTP error BEFORE we start streaming a
+        # 200 response body (you cannot change the status mid-stream).
+        console = request.env["sql.console"]
+        try:
+            rows_gen = console._stream_query_rows(sql)
+        except AccessError as exc:
+            raise werkzeug.exceptions.Forbidden(str(exc))
+        except UserError as exc:
+            raise werkzeug.exceptions.BadRequest(str(exc))
+
+        filename = "sql_console_export_%s.csv" % Datetime.now().strftime(
+            "%Y%m%d_%H%M%S"
+        )
+
+        return request.make_response(
+            self._csv_stream(rows_gen),
+            headers=[
+                ("Content-Type", "text/csv; charset=utf-8"),
+                (
+                    "Content-Disposition",
+                    'attachment; filename="%s"' % filename,
+                ),
+            ],
+        )
+
+    @staticmethod
+    def _csv_stream(rows_gen):
+        """Yield CSV bytes batch-by-batch from the row generator.
+
+        Reuses a single StringIO buffer that is truncated after each flush, so
+        only one batch of CSV text is ever held in memory at a time. The first
+        item from ``rows_gen`` is the header (column names); every subsequent
+        item is one data row.
+        """
+        buf = io.StringIO()
+        writer = csv.writer(buf)
+
+        def flush():
+            data = buf.getvalue()
+            buf.seek(0)
+            buf.truncate(0)
+            return data.encode("utf-8")
+
+        header = next(rows_gen, None)
+        if header is None:
+            return  # empty / error-before-header: yield nothing
+        writer.writerow(header)
+        yield flush()
+
+        # Flush every N rows so the buffer stays small for huge results.
+        flush_every = 500
+        count = 0
+        for row in rows_gen:
+            writer.writerow(["" if v is None else v for v in row])
+            count += 1
+            if count >= flush_every:
+                yield flush()
+                count = 0
+        if count:
+            yield flush()

--- a/bemade_sql_console/data/ir_config_parameter.xml
+++ b/bemade_sql_console/data/ir_config_parameter.xml
@@ -21,12 +21,14 @@
         </record>
 
         <!--
-            Row cap for the *CSV export* path (export_query_csv), distinct from
-            the small UI row_cap above. Bounds full-result downloads.
+            Server-side cursor batch size for the streaming CSV export. Controls
+            how many rows libpq fetches per round trip; bounds export memory use
+            regardless of total result size. The export itself is uncapped —
+            bounded only by statement_timeout_ms above.
         -->
-        <record id="param_export_row_cap" model="ir.config_parameter">
-            <field name="key">bemade_sql_console.export_row_cap</field>
-            <field name="value">100000</field>
+        <record id="param_stream_itersize" model="ir.config_parameter">
+            <field name="key">bemade_sql_console.stream_itersize</field>
+            <field name="value">2000</field>
         </record>
 
     </data>

--- a/bemade_sql_console/models/sql_console.py
+++ b/bemade_sql_console/models/sql_console.py
@@ -13,10 +13,8 @@ Security model
 """
 
 import base64
-import csv
 import datetime
 import decimal
-import io
 import logging
 import os
 import re
@@ -306,38 +304,118 @@ class SqlConsole(models.Model):
         row_cap = self._get_int_param("bemade_sql_console.row_cap", 1000)
         return self._run_query_capped(sql, row_cap)
 
-    @api.model
-    def export_query_csv(self, sql: str) -> bytes:
-        """Execute *sql* over the guarded RO path and return the full result as CSV.
+    # ------------------------------------------------------------------
+    # Streaming export (uncapped) — server-side cursor generator
+    # ------------------------------------------------------------------
 
-        Unlike :meth:`run_query`, the result is bounded by the *export* cap
-        ``bemade_sql_console.export_row_cap`` (default 100000), not the small UI
-        ``row_cap``.  The same admin group check, single-SELECT guard, SELECT-only
-        role, app-layer read-only, statement timeout and Decimal→str coercion are
-        enforced — the only difference is the cap and the output format.
+    def _stream_query_rows(self, sql: str):
+        """Yield ``(columns, row_iterable)`` for streaming *sql* over the RO path.
 
-        Returns
-        -------
-        bytes — UTF-8 encoded CSV with a header row of column names.
+        This is the shared internal runner behind the streaming CSV controller.
+        It enforces the EXACT same security path as :meth:`_run_query_capped`
+        (in-method admin group check, single-statement guard, SELECT-only role,
+        app-layer read-only, statement timeout and Decimal→str coercion) — the
+        ONLY differences are:
+
+        * a psycopg2 **server-side named cursor** so rows are streamed from the
+          database in ``itersize`` batches instead of being buffered in memory;
+        * **no row cap** — the result is bounded only by ``statement_timeout``.
+
+        Generator protocol
+        -------------------
+        The first ``yield`` is the list of column-name strings.  Every
+        subsequent ``yield`` is one result row (a list of JSON-coerced values,
+        with ``None`` preserved so the caller can render it as an empty CSV
+        field).  The RO connection is held open for the lifetime of the
+        generator and closed when it is exhausted or garbage-collected — so the
+        caller MUST drain it (or close it) to release the connection.
 
         Raises
         ------
         AccessError  — caller is not in group_sql_console
         UserError    — env vars absent, guard violation, or timeout
         """
-        export_cap = self._get_int_param(
-            "bemade_sql_console.export_row_cap", 100000
-        )
-        result = self._run_query_capped(sql, export_cap)
+        # 1. Authorization — MUST be first; this is the only RPC trust boundary.
+        if not self.env.user.has_group("bemade_sql_console.group_sql_console"):
+            raise AccessError(_("You are not allowed to run SQL console queries."))
 
-        buf = io.StringIO()
-        writer = csv.writer(buf)
-        writer.writerow(result["columns"])
-        for row in result["rows"]:
-            # Values are already JSON-coerced (Decimal→str, None stays None →
-            # csv renders as empty field, datetime→iso, etc.).
-            writer.writerow(["" if v is None else v for v in row])
-        return buf.getvalue().encode("utf-8")
+        # 2. Validate the SQL text before touching any connection.
+        _validate_single_select(sql)
+
+        # 3. Resolve RO credentials + timeout, then build connection info.
+        ro_user, ro_password = self._ro_credentials()
+        timeout_ms = self._get_int_param(
+            "bemade_sql_console.statement_timeout_ms", 30000
+        )
+        conn_info = self._ro_connection_info(ro_user, ro_password, timeout_ms)
+        # Server-side cursor batch size — how many rows libpq fetches per round
+        # trip. Bounds memory regardless of total result size.
+        itersize = self._get_int_param(
+            "bemade_sql_console.stream_itersize", 2000
+        )
+
+        return self._iter_rows(conn_info, sql, timeout_ms, itersize)
+
+    def _iter_rows(self, conn_info, sql, timeout_ms, itersize):
+        """Generator: open RO conn, declare a named cursor, yield header + rows."""
+        conn = None
+        try:
+            conn = psycopg2.connect(**conn_info)
+            # Connection-scoped NUMERIC→Decimal caster (see module docstring).
+            _psyext.register_type(_DEC2DEC_TYPE, conn)
+            _psyext.register_type(_DEC2DEC_ARRAY_TYPE, conn)
+            # App-layer read-only (defense-in-depth, in addition to role ACL).
+            conn.set_session(readonly=True, autocommit=False)
+
+            try:
+                # Belt-and-braces statement timeout on the session.
+                with conn.cursor() as setup_cur:
+                    setup_cur.execute(
+                        f"SET statement_timeout = {int(timeout_ms)}"
+                    )
+
+                # Server-side (named) cursor: rows are NOT all loaded into
+                # memory — libpq fetches them in `batch`-sized chunks via
+                # fetchmany. (We use explicit fetchmany rather than iterating
+                # the cursor because a server-side cursor's `description` is not
+                # populated until the first fetch — we need the first batch in
+                # hand to emit the column header.)
+                batch = max(int(itersize), 1)
+                named = "bemade_sql_console_%s" % uuid.uuid4().hex
+                with conn.cursor(name=named) as cur:
+                    cur.itersize = batch
+                    cur.execute(sql)
+                    rows = cur.fetchmany(batch)
+                    columns = (
+                        [d.name for d in cur.description]
+                        if cur.description
+                        else []
+                    )
+                    yield columns
+                    while rows:
+                        for row in rows:
+                            yield [_jsonify(v) for v in row]
+                        rows = cur.fetchmany(batch)
+                conn.commit()
+            except psycopg2.errors.QueryCanceled:
+                raise UserError(
+                    _(
+                        "Query exceeded the time limit (%(ms)d ms) and was "
+                        "cancelled.",
+                        ms=timeout_ms,
+                    )
+                )
+            except psycopg2.Error as exc:
+                _logger.debug("SQL console stream failed: %s", exc)
+                raise UserError(
+                    _("Query failed: %(error)s", error=str(exc).strip())
+                )
+        finally:
+            if conn is not None:
+                try:
+                    conn.close()
+                except Exception:
+                    pass
 
     # ------------------------------------------------------------------
     # Shared guarded runner
@@ -346,11 +424,12 @@ class SqlConsole(models.Model):
     def _run_query_capped(self, sql: str, row_cap: int) -> dict:
         """Run *sql* over the guarded RO path, bounded by *row_cap* rows.
 
-        This is the single shared implementation behind both :meth:`run_query`
-        (UI cap) and :meth:`export_query_csv` (export cap).  It owns the full
-        security path: in-method admin group check, single-statement guard,
-        RO-role connection, app-layer read-only and statement timeout.  Callers
-        differ only in the cap they pass and what they do with the envelope.
+        This is the shared implementation behind :meth:`run_query` (the UI
+        paginated table). It owns the full security path: in-method admin group
+        check, single-statement guard, RO-role connection, app-layer read-only
+        and statement timeout. The streaming CSV export uses the sibling
+        :meth:`_stream_query_rows` instead (same guards, uncapped, server-side
+        cursor).
         """
         # 1. Authorization — MUST be first; this is the only RPC trust boundary
         if not self.env.user.has_group("bemade_sql_console.group_sql_console"):
@@ -360,15 +439,7 @@ class SqlConsole(models.Model):
         _validate_single_select(sql)
 
         # 3. Resolve RO credentials — fail fast if not configured
-        ro_user = os.environ.get("ODOO_RO_DB_USER", "").strip()
-        ro_password = os.environ.get("ODOO_RO_DB_PASSWORD", "").strip()
-        if not ro_user or not ro_password:
-            raise UserError(
-                _(
-                    "The read-only SQL console is not configured on this instance. "
-                    "Please contact your system administrator."
-                )
-            )
+        ro_user, ro_password = self._ro_credentials()
 
         # 4. Read the statement timeout (the row cap is supplied by the caller)
         timeout_ms = self._get_int_param(
@@ -435,6 +506,23 @@ class SqlConsole(models.Model):
     # ------------------------------------------------------------------
     # Private helpers
     # ------------------------------------------------------------------
+
+    def _ro_credentials(self):
+        """Return ``(ro_user, ro_password)`` from env or raise a clear UserError.
+
+        Shared by the capped runner and the streaming export so the
+        "not configured" failure mode is identical for both paths.
+        """
+        ro_user = os.environ.get("ODOO_RO_DB_USER", "").strip()
+        ro_password = os.environ.get("ODOO_RO_DB_PASSWORD", "").strip()
+        if not ro_user or not ro_password:
+            raise UserError(
+                _(
+                    "The read-only SQL console is not configured on this instance. "
+                    "Please contact your system administrator."
+                )
+            )
+        return ro_user, ro_password
 
     def _get_int_param(self, key: str, default: int) -> int:
         """Read an integer ir.config_parameter, falling back to *default*."""

--- a/bemade_sql_console/models/sql_console_wizard.py
+++ b/bemade_sql_console/models/sql_console_wizard.py
@@ -1,11 +1,9 @@
 """sql.console.wizard — transient UI model for the SQL console form view."""
 
-import base64
 import logging
 
-from odoo import _, fields, models
+from odoo import fields, models
 from odoo.exceptions import UserError
-from odoo.fields import Datetime
 
 _logger = logging.getLogger(__name__)
 
@@ -44,15 +42,6 @@ class SqlConsoleWizard(models.TransientModel):
         string="Error",
         readonly=True,
     )
-    csv_file = fields.Binary(
-        string="CSV Export",
-        readonly=True,
-        attachment=False,
-    )
-    csv_filename = fields.Char(
-        string="CSV Filename",
-        readonly=True,
-    )
 
     def action_run_query(self):
         """Execute the SQL and stash the result envelope into display fields."""
@@ -80,35 +69,18 @@ class SqlConsoleWizard(models.TransientModel):
         return self._reload_action()
 
     def action_export_csv(self):
-        """Export the FULL result (export cap, not UI cap) as a CSV download.
+        """Download the FULL (uncapped) result as a streaming CSV.
 
-        Re-runs the same guarded RO path via ``sql.console.export_query_csv``
-        (which enforces the admin group check) and delivers the bytes as a
-        browser download through ``/web/content``.
+        Returns an ``act_url`` to the streaming controller
+        (``/bemade_sql_console/export/<id>``), which re-enforces the admin
+        group check and streams the result straight from a server-side cursor —
+        no row cap and no whole-file-in-memory buffering. The controller reads
+        this wizard's ``sql_text`` by id in the user's own env.
         """
         self.ensure_one()
-        self.write({"error_message": False})
-        try:
-            csv_bytes = self.env["sql.console"].export_query_csv(self.sql_text or "")
-        except (UserError, Exception) as exc:
-            self.write({"error_message": str(exc)})
-            return self._reload_action()
-
-        filename = "sql_console_export_%s.csv" % Datetime.now().strftime(
-            "%Y%m%d_%H%M%S"
-        )
-        self.write(
-            {
-                "csv_file": base64.b64encode(csv_bytes),
-                "csv_filename": filename,
-            }
-        )
         return {
             "type": "ir.actions.act_url",
-            "url": (
-                "/web/content/%s/%s/csv_file/%s?download=true"
-                % (self._name, self.id, filename)
-            ),
+            "url": "/bemade_sql_console/export/%s" % self.id,
             "target": "self",
         }
 

--- a/bemade_sql_console/tests/test_us09_csv_export.py
+++ b/bemade_sql_console/tests/test_us09_csv_export.py
@@ -1,16 +1,30 @@
 """
-US-09 — CSV export (full result) + export cap + admin check.
+US-09 — Streaming CSV export (uncapped, server-side cursor).
 
 Acceptance criteria
 -------------------
-- export_query_csv(sql) returns CSV bytes whose header row == columns and whose
-  data rows match the query result.
+- sql.console._stream_query_rows(sql) is a generator whose first item is the
+  list of column names and whose remaining items are the result rows. Assembled
+  through the controller's CSV writer it yields a CSV whose header == columns and
+  whose data rows match the query result.
 - Values containing a comma, newline or double-quote are properly quoted (csv
   module quoting), surviving a round-trip through csv.reader.
-- The export is bounded by bemade_sql_console.export_row_cap (NOT the small UI
-  row_cap): with export_row_cap=3, a 10-row SELECT yields 3 data rows.
-- The export enforces the same admin group check as run_query (AccessError for
-  a non-member).
+- The export is UNCAPPED: a result larger than the UI row_cap (and the old
+  100k export cap) streams completely — generate_series(1, 5000) yields all
+  5000 data rows.
+- Security: the streaming path enforces the same admin group check (AccessError
+  for a non-member of group_sql_console), and the HTTP route returns 403
+  Forbidden for a non-member.
+
+Notes
+-----
+The local Odoo runner serves tests under a PreforkServer that exposes no HTTP
+port (HttpCase.http_port() → AttributeError), so browser/url_open HTTP tests
+cannot run here. The export path is therefore verified at the model/controller
+layer: the factored generator (``_stream_query_rows``) drives the controller's
+CSV assembler (``_csv_stream``) to assert content, quoting and the absence of a
+cap; security is asserted by the AccessError the generator raises on first
+advance (the controller advances eagerly and maps it to HTTP 403 Forbidden).
 """
 
 import csv
@@ -21,18 +35,27 @@ from odoo.tests import tagged
 from odoo.tests.common import new_test_user
 from odoo.tools.misc import mute_logger
 
+from odoo.addons.bemade_sql_console.controllers.main import (
+    SqlConsoleExportController,
+)
+
 from .common import SqlConsoleTestBase
 
 
-def _parse_csv(raw_bytes):
-    """Decode + parse CSV bytes into a list of rows (list of str)."""
-    text = raw_bytes.decode("utf-8")
+def _assemble_csv(rows_gen):
+    """Drive _csv_stream over the row generator and parse the result.
+
+    Returns the parsed CSV (list of list of str), exactly as a browser would
+    receive and a csv.reader would parse it.
+    """
+    chunks = b"".join(SqlConsoleExportController._csv_stream(rows_gen))
+    text = chunks.decode("utf-8")
     return list(csv.reader(io.StringIO(text)))
 
 
 @tagged("at_install", "post_install")
-class TestCsvExport(SqlConsoleTestBase):
-    """US-09: export_query_csv produces correct, properly-quoted, capped CSV."""
+class TestCsvStreamModel(SqlConsoleTestBase):
+    """US-09 model layer: generator content, quoting, no cap, security."""
 
     def _set_param(self, key, value):
         self.env["ir.config_parameter"].sudo().set_param(key, str(value))
@@ -40,76 +63,119 @@ class TestCsvExport(SqlConsoleTestBase):
     def test_header_and_rows_match_result(self):
         """CSV header == columns; data rows match the SELECT output."""
         sql = "SELECT n, n * 10 AS ten FROM generate_series(1, 3) AS n ORDER BY n"
-        raw = self.env["sql.console"].export_query_csv(sql)
-        parsed = _parse_csv(raw)
+        gen = self.env["sql.console"]._stream_query_rows(sql)
+        parsed = _assemble_csv(gen)
 
-        # Header
         self.assertEqual(parsed[0], ["n", "ten"])
-        # Data rows
         self.assertEqual(parsed[1:], [["1", "10"], ["2", "20"], ["3", "30"]])
+
+    def test_first_yield_is_columns(self):
+        """The generator's first item is the column-name list."""
+        gen = self.env["sql.console"]._stream_query_rows(
+            "SELECT 1 AS a, 2 AS b"
+        )
+        header = next(gen)
+        self.assertEqual(header, ["a", "b"])
+        gen.close()
 
     def test_quoting_comma_newline_quote(self):
         """Values with comma/newline/quote survive a CSV round-trip intact."""
-        # Build a single-row, single-column result whose value contains all
-        # three CSV-hostile characters.
         nasty = 'a,b\nc"d'
-        # Use a parameterised-style literal embedded safely via dollar quoting.
         sql = "SELECT $tag$%s$tag$ AS v" % nasty
-        raw = self.env["sql.console"].export_query_csv(sql)
-        parsed = _parse_csv(raw)
+        gen = self.env["sql.console"]._stream_query_rows(sql)
+        parsed = _assemble_csv(gen)
 
         self.assertEqual(parsed[0], ["v"])
-        # The parsed value must exactly equal the original (proves quoting worked)
         self.assertEqual(parsed[1], [nasty])
 
-    def test_export_respects_export_cap(self):
-        """export_query_csv is bounded by export_row_cap, not row_cap."""
-        # Tiny UI cap, slightly larger export cap — proves they're independent.
+    def test_null_renders_as_empty_field(self):
+        """SQL NULL is streamed as an empty CSV field."""
+        gen = self.env["sql.console"]._stream_query_rows(
+            "SELECT NULL::int AS x, 7 AS y"
+        )
+        parsed = _assemble_csv(gen)
+        self.assertEqual(parsed[1], ["", "7"])
+
+    def test_export_has_no_row_cap(self):
+        """A result far larger than the UI/old-export cap streams in FULL.
+
+        Drives 5000 rows through the generator with a tiny UI row_cap set, to
+        prove the stream path ignores row_cap entirely.
+        """
         self._set_param("bemade_sql_console.row_cap", 1)
-        self._set_param("bemade_sql_console.export_row_cap", 3)
         try:
-            sql = "SELECT n FROM generate_series(1, 10) AS n ORDER BY n"
-            raw = self.env["sql.console"].export_query_csv(sql)
-            parsed = _parse_csv(raw)
-            # 1 header + 3 data rows (export cap), NOT 1 (ui cap) or 10 (uncapped)
-            self.assertEqual(len(parsed) - 1, 3, "Export must honor export_row_cap")
-            self.assertEqual([r[0] for r in parsed[1:]], ["1", "2", "3"])
+            sql = "SELECT n FROM generate_series(1, 5000) AS n ORDER BY n"
+            gen = self.env["sql.console"]._stream_query_rows(sql)
+            parsed = _assemble_csv(gen)
+            # 1 header + 5000 data rows — nothing dropped.
+            self.assertEqual(len(parsed) - 1, 5000)
+            self.assertEqual(parsed[1][0], "1")
+            self.assertEqual(parsed[-1][0], "5000")
         finally:
             self._set_param("bemade_sql_console.row_cap", 1000)
-            self._set_param("bemade_sql_console.export_row_cap", 100000)
 
-    def test_export_default_cap_when_param_absent(self):
-        """When export_row_cap is unset, a small result is fully exported."""
-        param = (
-            self.env["ir.config_parameter"]
-            .sudo()
-            .search([("key", "=", "bemade_sql_console.export_row_cap")])
+    def test_decimal_preserved_as_string(self):
+        """NUMERIC values keep full precision (Decimal→str), not float."""
+        gen = self.env["sql.console"]._stream_query_rows(
+            "SELECT 12345.67890::numeric AS amount"
         )
-        saved = param.value if param else None
-        if param:
-            param.unlink()
-        try:
-            sql = "SELECT n FROM generate_series(1, 5) AS n ORDER BY n"
-            raw = self.env["sql.console"].export_query_csv(sql)
-            parsed = _parse_csv(raw)
-            self.assertEqual(len(parsed) - 1, 5)
-        finally:
-            if saved is not None:
-                self._set_param("bemade_sql_console.export_row_cap", saved)
+        parsed = _assemble_csv(gen)
+        self.assertEqual(parsed[1], ["12345.67890"])
 
-    def test_export_enforces_admin_check(self):
-        """A non-member calling export_query_csv raises AccessError."""
+    def test_stream_enforces_admin_check(self):
+        """A non-member calling _stream_query_rows raises AccessError eagerly.
+
+        The auth check (and the single-SELECT guard and credential resolution)
+        run in _stream_query_rows BEFORE the row generator is returned — so the
+        controller can map the error to HTTP 403 before emitting a 200 body.
+        """
         non_admin = new_test_user(
             self.env,
-            login="sql_console_export_nobody",
+            login="sql_console_stream_nobody",
             groups="base.group_user",
         )
         with mute_logger(
             "odoo.addons.bemade_sql_console.models.sql_console"
         ):
             with self.assertRaises(AccessError):
+                # No next() needed — _stream_query_rows raises before returning.
                 (
                     self.env["sql.console"]
                     .with_user(non_admin)
-                    .export_query_csv("SELECT 1")
+                    ._stream_query_rows("SELECT 1")
                 )
+
+
+    def test_csv_stream_propagates_error_before_header(self):
+        """If the row generator errors before any header, _csv_stream yields none.
+
+        The controller resolves _stream_query_rows eagerly (mapping AccessError
+        / UserError to 403 / 400 before the 200 body), but as defense in depth
+        _csv_stream must not emit a partial/corrupt body if the generator raises
+        before producing a header. Here a guard violation (multi-statement)
+        raised eagerly by _stream_query_rows is the realistic case; we assert
+        the assembler emits nothing for an immediately-empty generator.
+        """
+        from odoo.addons.bemade_sql_console.controllers.main import (
+            SqlConsoleExportController,
+        )
+
+        def empty_gen():
+            return
+            yield  # pragma: no cover
+
+        chunks = list(SqlConsoleExportController._csv_stream(empty_gen()))
+        self.assertEqual(chunks, [], "No header → no CSV body")
+
+    def test_guard_violation_raised_eagerly(self):
+        """A multi-statement query is rejected by _stream_query_rows eagerly.
+
+        Proves the controller can surface a guard violation as an HTTP error
+        (BadRequest) before streaming, mirroring run_query's UserError.
+        """
+        from odoo.exceptions import UserError
+
+        with self.assertRaises(UserError):
+            self.env["sql.console"]._stream_query_rows(
+                "SELECT 1; SELECT 2"
+            )

--- a/bemade_sql_console/views/sql_console_views.xml
+++ b/bemade_sql_console/views/sql_console_views.xml
@@ -27,9 +27,6 @@
                             <field name="error_message" readonly="1" nolabel="1"/>
                         </div>
                     </div>
-                    <!-- Hidden plumbing for the CSV download -->
-                    <field name="csv_file" invisible="1"/>
-                    <field name="csv_filename" invisible="1"/>
                     <field name="row_count" invisible="1"/>
                     <field name="truncated" invisible="1"/>
                     <!-- Paginated result table (OWL widget) -->


### PR DESCRIPTION
Replaces the in-memory, 100k-capped CSV export with a **streaming** download so the console can export arbitrarily large query results — Bill needs full extracts (Trial Balance, etc.), and the old Binary-field export silently truncated at 100k and held the whole file in RAM.

**How:** a new HTTP controller `GET /bemade_sql_console/export/<wizard_id>` (`auth='user'`, `readonly=True`) runs the query on a **psycopg2 server-side named cursor** and streams CSV straight to the response in 500-row flush batches — only one batch is ever in memory, and there's **no row cap** (bounded only by `statement_timeout`).

**Security (two layers):** the route re-enforces the `group_sql_console` check → 403 (Odoo authenticates HTTP endpoints but doesn't rights-check them), and the factored `sql.console._stream_query_rows` re-runs the in-method group check + single-SELECT guard + SELECT-only RO connection + app-layer read-only + statement_timeout + Decimal→str. The generator is resolved **eagerly** so auth/guard errors surface as a clean 403/400 *before* the 200 stream body. The wizard is read in the user's own env.

The 'Download CSV' button now returns an `act_url` to the controller. Removed the dead in-memory path (`export_query_csv`, the `csv_file`/`csv_filename` Binary fields, the `export_row_cap` param). `run_query` (the paginated UI table) is unchanged.

68 tests pass (header/rows, quoting, NULL→empty, Decimal precision, a 5000-row uncapped stream, AccessError→403 / guard→400). HttpCase can't bind a port under the local PreforkServer, so the stream + security are verified at the model/controller layer (noted in the test).