### PR TITLE
[3747] crm_account_management: convert mixed-currency bookings (FX) instead of summing as CAD

### DIFF
--- a/crm_account_management/models/organizational_unit.py
+++ b/crm_account_management/models/organizational_unit.py
@@ -552,6 +552,7 @@ class OrganizationalUnit(models.Model):
         "owner_id.sale_order_ids.state",
         "owner_id.sale_order_ids.amount_total",
         "owner_id.sale_order_ids.date_order",
+        "owner_id.sale_order_ids.currency_id",
     )
     def _compute_quotation_metrics(self):
         for record in self:
@@ -576,7 +577,9 @@ class OrganizationalUnit(models.Model):
                 ]
             )
             record.open_quotations_count = len(open_quotes)
-            record.open_quotations_amount = sum(open_quotes.mapped("amount_total"))
+            record.open_quotations_amount = record._sum_in_currency(
+                open_quotes, "amount_total", "date_order"
+            )
 
             # Won quotations YTD (confirmed this year)
             won_quotes = self.env["sale.order"].search(
@@ -588,7 +591,9 @@ class OrganizationalUnit(models.Model):
                 ]
             )
             record.won_quotations_count = len(won_quotes)
-            record.won_quotations_amount = sum(won_quotes.mapped("amount_total"))
+            record.won_quotations_amount = record._sum_in_currency(
+                won_quotes, "amount_total", "date_order"
+            )
 
             # Won quotations prior YTD
             won_quotes_prior = self.env["sale.order"].search(
@@ -600,8 +605,8 @@ class OrganizationalUnit(models.Model):
                 ]
             )
             record.won_quotations_prior_count = len(won_quotes_prior)
-            record.won_quotations_prior_amount = sum(
-                won_quotes_prior.mapped("amount_total")
+            record.won_quotations_prior_amount = record._sum_in_currency(
+                won_quotes_prior, "amount_total", "date_order"
             )
 
     @api.depends(
@@ -615,6 +620,7 @@ class OrganizationalUnit(models.Model):
         "owner_id.sale_order_ids.commitment_date",
         "owner_id.sale_order_ids.expected_date",
         "owner_id.sale_order_ids.date_order",
+        "owner_id.sale_order_ids.currency_id",
         "owner_id.sale_order_ids.invoice_ids.state",
         "owner_id.sale_order_ids.invoice_ids.amount_total",
         "owner_id.sale_order_ids.invoice_ids.move_type",
@@ -645,28 +651,41 @@ class OrganizationalUnit(models.Model):
                 ]
             )
             record.open_orders_count = len(open_orders)
-            record.open_orders_amount = sum(open_orders.mapped("amount_total"))
+            record.open_orders_amount = record._sum_in_currency(
+                open_orders, "amount_total", "date_order"
+            )
 
             to_invoice = 0.0
             late_count = 0
             late_amount = 0.0
             ontime_count = 0
             ontime_amount = 0.0
+            company = record.company_id or record.env.company
+            target = record.currency_id
             for order in open_orders:
+                order_date = order.date_order.date() if order.date_order else today
+                order_amount_converted = order.currency_id._convert(
+                    order.amount_total, target, company, order_date
+                )
                 invoiced = sum(
                     inv.amount_total if inv.move_type == "out_invoice" else -inv.amount_total
                     for inv in order.invoice_ids
                     if inv.state == "posted"
                 )
-                to_invoice += max(0.0, order.amount_total - invoiced)
+                # invoiced amounts from account.move are in the company currency;
+                # subtract in the converted order amount space
+                invoiced_converted = order.currency_id._convert(
+                    invoiced, target, company, order_date
+                ) if invoiced else 0.0
+                to_invoice += max(0.0, order_amount_converted - invoiced_converted)
                 # Late vs on-time: use commitment_date if set, else expected_date
                 due = order.commitment_date or order.expected_date
                 if due and due.date() < today:
                     late_count += 1
-                    late_amount += order.amount_total
+                    late_amount += order_amount_converted
                 else:
                     ontime_count += 1
-                    ontime_amount += order.amount_total
+                    ontime_amount += order_amount_converted
             record.open_orders_to_invoice_amount = to_invoice
             record.open_orders_late_count = late_count
             record.open_orders_late_amount = late_amount
@@ -694,6 +713,7 @@ class OrganizationalUnit(models.Model):
         "owner_id.opportunity_ids.probability",
         "owner_id.opportunity_ids.expected_revenue",
         "owner_id.opportunity_ids.date_closed",
+        "owner_id.opportunity_ids.company_currency",
     )
     def _compute_opportunity_metrics(self):
         for record in self:
@@ -717,7 +737,9 @@ class OrganizationalUnit(models.Model):
                 ]
             )
             record.open_opportunities_count = len(open_opps)
-            record.open_opportunities_amount = sum(open_opps.mapped("expected_revenue"))
+            record.open_opportunities_amount = record._sum_in_currency(
+                open_opps, "expected_revenue", "date_closed"
+            )
 
             # Won opportunities YTD
             won_opps = self.env["crm.lead"].search(
@@ -730,7 +752,9 @@ class OrganizationalUnit(models.Model):
                 ]
             )
             record.won_opportunities_count = len(won_opps)
-            record.won_opportunities_amount = sum(won_opps.mapped("expected_revenue"))
+            record.won_opportunities_amount = record._sum_in_currency(
+                won_opps, "expected_revenue", "date_closed"
+            )
 
     def get_top_products(self, limit=10, date_from=None, date_to=None, sort_by="total_amount"):
         """Get top products purchased by this account.
@@ -1001,6 +1025,53 @@ class OrganizationalUnit(models.Model):
             ],
             "context": {"default_partner_id": self.owner_id.id if self.owner_id else False},
         }
+
+    def _sum_in_currency(self, records, amount_field, date_field):
+        """Sum ``amount_field`` on ``records`` converting each value to ``self.currency_id``.
+
+        For each record its own source currency (``record.currency_id`` for
+        ``sale.order``, ``record.company_currency`` for ``crm.lead``) is used to
+        convert the amount at the exchange rate in effect on the record's
+        ``date_field`` date.  When source and target currencies are the same,
+        ``_convert`` short-circuits to the identity conversion so the helper is
+        safe to call for single-currency sets.
+
+        The conversion date is taken from ``date_field``; if the value is a
+        ``Datetime`` its ``.date()`` is used so the rate lookup is date-granular.
+        When ``date_field`` is absent or falsy, today's date is used as a
+        fallback.
+
+        Note: ``crm.lead.expected_revenue`` is denominated in
+        ``company_currency``, which for Pneumac always equals the OU's
+        ``currency_id`` (CAD).  Routing it through this helper is therefore a
+        no-op in practice but keeps the code path uniform.
+        """
+        self.ensure_one()
+        target = self.currency_id
+        company = self.company_id or self.env.company
+        today = date.today()
+        total = 0.0
+        for record in records:
+            amount = record[amount_field] or 0.0
+            if not amount:
+                continue
+            # Determine source currency: prefer currency_id, fall back to company_currency
+            fields_map = record._fields
+            if "currency_id" in fields_map and record.currency_id:
+                source = record.currency_id
+            elif "company_currency" in fields_map and record.company_currency:
+                source = record.company_currency
+            else:
+                source = target
+            raw_date = record[date_field] if date_field else None
+            if raw_date and hasattr(raw_date, "date"):
+                conv_date = raw_date.date()
+            elif raw_date:
+                conv_date = raw_date
+            else:
+                conv_date = today
+            total += source._convert(amount, target, company, conv_date)
+        return total
 
     def action_view_won_quotations_prior_ytd(self):
         """Open confirmed sale orders (bookings) for the prior fiscal YTD."""

--- a/crm_account_management/tests/__init__.py
+++ b/crm_account_management/tests/__init__.py
@@ -1,6 +1,7 @@
 from . import test_organizational_unit
 from . import test_us01_dashboard
 from . import test_us02_buying_trends
+from . import test_us03_mixed_currency_fx
 from . import test_us04_chatter
 from . import test_us05_auto_create
 from . import test_us08_ou_structure

--- a/crm_account_management/tests/test_us03_mixed_currency_fx.py
+++ b/crm_account_management/tests/test_us03_mixed_currency_fx.py
@@ -1,0 +1,182 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0).
+# Author: Bemade Inc. (Marc Durepos <marc@bemade.org>)
+"""
+US-03: Bookings totals convert mixed-currency orders to the OU currency.
+
+Acceptance criteria
+-------------------
+1. Booking totals convert each won order's amount to a common currency
+   (OU currency_id) before summing when sources are mixed.  No more raw
+   numeric summing of, e.g., USD + CAD into a CAD-only field.
+2. Single-currency accounts are unaffected (no regression from _convert
+   same-currency short-circuit).
+3. Open-orders path (open_orders_amount) uses the same conversion helper.
+"""
+from datetime import date
+
+from odoo.tests import tagged
+
+from odoo.addons.crm_account_management.tests.common import OUTestCommon
+
+
+@tagged("post_install", "-at_install")
+class TestUS03MixedCurrencyFX(OUTestCommon):
+    """
+    US-03: Mixed-currency FX conversion for OU bookings / order metrics.
+
+    Each test uses a known FX rate so expected values can be computed exactly.
+    The company currency (whatever AccountTestInvoicingCommon sets up, typically
+    USD) is used as the OU's ``currency_id``; a second currency (EUR) is set up
+    with a well-known rate so assertions are deterministic.
+
+    Rate setup: 1 EUR = 1.25 company-currency units.
+    The ``rate`` field on ``res.currency.rate`` stores "units of this currency
+    per 1 unit of company currency", so ``rate = 1 / 1.25 = 0.8``.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner_model = cls.env["res.partner"]
+        cls.ou_model = cls.env["organizational.unit"]
+
+        # Create a test product used across all tests
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "FX Test Product",
+                "list_price": 100.0,
+            }
+        )
+
+        # Set up a foreign currency: 1 EUR = 1.25 company-currency units.
+        # rate = 0.8 means 0.8 EUR per 1 unit of company currency, so
+        # inverse_rate = 1/0.8 = 1.25: 1 EUR converts to 1.25 company-currency.
+        cls.foreign_currency = cls.setup_other_currency(
+            "EUR",
+            rates=[
+                ("2000-01-01", 0.8),
+            ],
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _make_company(self, name):
+        """Create a top-level company partner (triggers OU auto-create)."""
+        partner = self.partner_model.create({"name": name, "is_company": True})
+        ou = self.ou_model.search([("owner_id", "=", partner.id)], limit=1)
+        return partner, ou
+
+    def _make_confirmed_order(self, partner, amount, currency=None, order_date=None):
+        """Create and confirm a sale.order with a single line of the given amount."""
+        if order_date is None:
+            order_date = date.today()
+        vals = {
+            "partner_id": partner.id,
+            "date_order": order_date,
+            "order_line": [
+                (
+                    0,
+                    0,
+                    {
+                        "product_id": self.product.id,
+                        "product_uom_qty": 1,
+                        "price_unit": amount,
+                        "tax_ids": [],
+                    },
+                )
+            ],
+        }
+        if currency:
+            vals["currency_id"] = currency.id
+        order = self.env["sale.order"].create(vals)
+        order.action_confirm()
+        return order
+
+    # ------------------------------------------------------------------
+    # Test 1: Mixed-currency won orders convert before summing
+    # ------------------------------------------------------------------
+
+    def test_won_quotations_amount_converts_mixed_currency(self):
+        """
+        AC-1: won_quotations_amount converts each order to the OU currency.
+
+        One order is in the company currency (100 units) and one is in EUR
+        (100 EUR).  With 1 EUR = 1.25 company-currency, the converted total
+        must equal 100 + 125 = 225, NOT the raw numeric sum of 200.
+        """
+        partner, ou = self._make_company("FX Test Partner 1")
+
+        # Order in company currency
+        self._make_confirmed_order(partner, 100.0)
+        # Order in EUR (100 EUR × 1.25 = 125 company-currency)
+        self._make_confirmed_order(partner, 100.0, currency=self.foreign_currency)
+
+        ou.invalidate_recordset()
+        # Raw numeric sum would be 200; correctly converted total is 225.
+        self.assertGreater(
+            ou.won_quotations_amount,
+            200.0,
+            "Mixed-currency bookings must be converted before summing, not added numerically.",
+        )
+        self.assertAlmostEqual(
+            ou.won_quotations_amount,
+            225.0,
+            places=2,
+            msg="100 company-currency + 100 EUR@1.25 must equal 225 company-currency.",
+        )
+
+    # ------------------------------------------------------------------
+    # Test 2: Single-currency total is unchanged
+    # ------------------------------------------------------------------
+
+    def test_single_currency_total_unchanged(self):
+        """
+        AC-2: When all orders share the OU currency, the total equals the raw sum.
+
+        _convert short-circuits to identity when source == target, so no
+        rounding or rate-table errors are introduced for single-currency accounts.
+        """
+        partner, ou = self._make_company("FX Test Partner 2")
+
+        self._make_confirmed_order(partner, 100.0)
+        self._make_confirmed_order(partner, 100.0)
+
+        ou.invalidate_recordset()
+        self.assertAlmostEqual(
+            ou.won_quotations_amount,
+            200.0,
+            places=2,
+            msg="Single-currency bookings must equal the exact sum without rounding deviation.",
+        )
+
+    # ------------------------------------------------------------------
+    # Test 3: Open orders path also converts
+    # ------------------------------------------------------------------
+
+    def test_open_orders_amount_converts_mixed_currency(self):
+        """
+        AC-3: open_orders_amount converts each open order to the OU currency.
+
+        One open order in company currency (100) and one in EUR (100 EUR),
+        both not invoiced.  The reported amount must equal 225, not 200.
+        """
+        partner, ou = self._make_company("FX Test Partner 3")
+
+        # Confirmed but not invoiced → open orders
+        self._make_confirmed_order(partner, 100.0)
+        self._make_confirmed_order(partner, 100.0, currency=self.foreign_currency)
+
+        ou.invalidate_recordset()
+        self.assertGreater(
+            ou.open_orders_amount,
+            200.0,
+            "Mixed-currency open orders must be converted before summing.",
+        )
+        self.assertAlmostEqual(
+            ou.open_orders_amount,
+            225.0,
+            places=2,
+            msg="100 company-currency + 100 EUR@1.25 must equal 225 in open_orders_amount.",
+        )

--- a/crm_account_management/tests/test_us03_mixed_currency_fx.py
+++ b/crm_account_management/tests/test_us03_mixed_currency_fx.py
@@ -69,7 +69,14 @@ class TestUS03MixedCurrencyFX(OUTestCommon):
         return partner, ou
 
     def _make_confirmed_order(self, partner, amount, currency=None, order_date=None):
-        """Create and confirm a sale.order with a single line of the given amount."""
+        """Create and confirm a sale.order with a single line of the given amount.
+
+        In Odoo 18, sale.order.currency_id is a stored computed field driven by the
+        pricelist (``pricelist_id.currency_id``), so the currency cannot be set
+        directly on the order.  When a non-default currency is requested, a throwaway
+        pricelist in that currency is created and attached to the order so that
+        ``_compute_currency_id`` picks it up correctly.
+        """
         if order_date is None:
             order_date = date.today()
         vals = {
@@ -83,13 +90,19 @@ class TestUS03MixedCurrencyFX(OUTestCommon):
                         "product_id": self.product.id,
                         "product_uom_qty": 1,
                         "price_unit": amount,
-                        "tax_ids": [],
+                        "tax_id": False,
                     },
                 )
             ],
         }
         if currency:
-            vals["currency_id"] = currency.id
+            # In Odoo 18, sale.order.currency_id is computed from the pricelist.
+            # Create a pricelist in the requested currency so the order adopts it.
+            pricelist = self.env["product.pricelist"].create({
+                "name": f"Test pricelist {currency.name}",
+                "currency_id": currency.id,
+            })
+            vals["pricelist_id"] = pricelist.id
         order = self.env["sale.order"].create(vals)
         order.action_confirm()
         return order


### PR DESCRIPTION
Fixes the mixed-currency bug in `organizational.unit` bookings metrics: won/open sale-order totals were summed numerically (`sum(mapped('amount_total'))`) into a single-currency (CAD) field with no FX conversion, so a USD + CAD mix was added at face value.

**Fix:** a `_sum_in_currency` helper converts each order's amount to the OU currency via `currency._convert(amount, target, company, date)` at the order's `date_order` (transaction-date FX) before summing. Applied across `_compute_quotation_metrics`, `_compute_order_metrics` (incl. the inline to_invoice/late/ontime accumulators for consistency), and `_compute_opportunity_metrics`; `@api.depends` updated with the source currency.

**Notes:** the opportunity/lead path is a documented no-op (`expected_revenue` is already company-currency-denominated). Two invoice-based sibling computes (`_compute_sales_metrics`, `_compute_rolling_12m_metrics`) carry the same latent bug and are flagged for a **follow-up task** — intentionally out of scope here.

**Tests:** new `test_us03_mixed_currency_fx.py` proves a raw 200 becomes a converted 225, single-currency stays exactly 200, and the open-orders path converts. Full suite **90 passed / 0 failed**.

Shared module → upstream-first. Downstream (Pneumac submodule-pointer bump) follows once this merges. Autonomous /task-worker cycle (burn-in). Artifacts: https://git.bemade.org/bemade/tasks/-/tree/main/task-3747-crm-bookings-mixed-currency-fx

Opened as **Draft** pending review.