### PR TITLE
[bemade_reordering_rules_chatter] Add Cost Supplier + Cost Sub-Total columns to Replenishment

### DIFF
--- a/bemade_reordering_rules_chatter/__manifest__.py
+++ b/bemade_reordering_rules_chatter/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     "name": "Chatter on the Reordering Rules",
-    "version": "18.0.0.0.1",
+    "version": "18.0.1.0.0",
     "category": "Extra Tools",
     "license": "GPL-3",
     "summary": "Add chatter on the reordering rules",

--- a/bemade_reordering_rules_chatter/models/stock_warehouse_orderpoint.py
+++ b/bemade_reordering_rules_chatter/models/stock_warehouse_orderpoint.py
@@ -1,4 +1,4 @@
-from odoo import models, fields
+from odoo import models, fields, api
 
 class StockWarehouseOrderpoint(models.Model):
     _name = 'stock.warehouse.orderpoint'
@@ -17,3 +17,35 @@ class StockWarehouseOrderpoint(models.Model):
     group_id = fields.Many2one(tracking=True)
     company_id = fields.Many2one(tracking=True)
     route_id = fields.Many2one(tracking=True)
+
+    cost_supplier = fields.Float(
+        string="Cost Supplier",
+        compute="_compute_cost_supplier",
+        store=False,
+        help="The primary (first) vendor's price for this product, "
+             "taken from the Purchase tab (product.supplierinfo).",
+    )
+    cost_subtotal = fields.Float(
+        string="Cost Sub-Total",
+        compute="_compute_cost_subtotal",
+        store=False,
+        aggregator="sum",
+        help="To-Order quantity multiplied by the primary vendor's price.",
+    )
+
+    @api.depends(
+        "product_tmpl_id.seller_ids",
+        "product_tmpl_id.seller_ids.sequence",
+        "product_tmpl_id.seller_ids.price",
+    )
+    def _compute_cost_supplier(self):
+        for orderpoint in self:
+            sellers = orderpoint.product_tmpl_id.seller_ids
+            orderpoint.cost_supplier = sellers[0].price if sellers else 0.0
+
+    @api.depends("qty_to_order", "cost_supplier")
+    def _compute_cost_subtotal(self):
+        for orderpoint in self:
+            orderpoint.cost_subtotal = (
+                (orderpoint.qty_to_order or 0.0) * orderpoint.cost_supplier
+            )

--- a/bemade_reordering_rules_chatter/tests/__init__.py
+++ b/bemade_reordering_rules_chatter/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_replenishment_cost

--- a/bemade_reordering_rules_chatter/tests/test_replenishment_cost.py
+++ b/bemade_reordering_rules_chatter/tests/test_replenishment_cost.py
@@ -1,0 +1,87 @@
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestReplenishmentCost(TransactionCase):
+    """Regression tests for the replenishment cost columns
+    (cost_supplier / cost_subtotal) on stock.warehouse.orderpoint.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.warehouse = cls.env["stock.warehouse"].search([], limit=1)
+        cls.vendor_a = cls.env["res.partner"].create({"name": "Vendor A"})
+        cls.vendor_b = cls.env["res.partner"].create({"name": "Vendor B"})
+
+    def _make_product(self, name, sellers=None):
+        """sellers: list of (partner, sequence, price)."""
+        vals = {
+            "name": name,
+            "is_storable": True,
+        }
+        if sellers:
+            vals["seller_ids"] = [
+                (0, 0, {
+                    "partner_id": partner.id,
+                    "sequence": sequence,
+                    "price": price,
+                })
+                for (partner, sequence, price) in sellers
+            ]
+        return self.env["product.product"].create(vals)
+
+    def _make_orderpoint(self, product, qty_to_order=None):
+        op = self.env["stock.warehouse.orderpoint"].create({
+            "product_id": product.id,
+            "warehouse_id": self.warehouse.id,
+            "location_id": self.warehouse.lot_stock_id.id,
+        })
+        if qty_to_order is not None:
+            # Deterministic To-Order qty independent of live forecast.
+            op.qty_to_order_manual = qty_to_order
+            op.invalidate_recordset(["qty_to_order"])
+        return op
+
+    def test_cost_supplier_primary_seller(self):
+        """Primary (lowest-sequence) seller wins, NOT the cheapest."""
+        product = self._make_product(
+            "Two-vendor product",
+            sellers=[
+                (self.vendor_a, 1, 10.0),  # primary by sequence
+                (self.vendor_b, 2, 7.0),   # cheaper but not primary
+            ],
+        )
+        op = self._make_orderpoint(product)
+        self.assertEqual(
+            op.cost_supplier, 10.0,
+            "cost_supplier must be the first seller by sequence (10.0), "
+            "not the cheapest (7.0).",
+        )
+
+    def test_cost_supplier_no_seller(self):
+        """No seller -> cost_supplier is 0.0."""
+        product = self._make_product("No-vendor product")
+        op = self._make_orderpoint(product)
+        self.assertEqual(op.cost_supplier, 0.0)
+
+    def test_cost_subtotal(self):
+        """cost_subtotal == qty_to_order * cost_supplier."""
+        product = self._make_product(
+            "Single-vendor product",
+            sellers=[(self.vendor_a, 1, 5.0)],
+        )
+        op = self._make_orderpoint(product, qty_to_order=3.0)
+        self.assertEqual(op.qty_to_order, 3.0)
+        self.assertEqual(op.cost_supplier, 5.0)
+        self.assertEqual(op.cost_subtotal, 15.0)
+        self.assertEqual(
+            op.cost_subtotal,
+            op.qty_to_order * op.cost_supplier,
+        )
+
+    def test_cost_subtotal_zero_when_no_seller(self):
+        """No seller + a To-Order qty -> cost_subtotal is 0.0."""
+        product = self._make_product("No-vendor product 2")
+        op = self._make_orderpoint(product, qty_to_order=4.0)
+        self.assertEqual(op.cost_subtotal, 0.0)

--- a/bemade_reordering_rules_chatter/views/stock_warehouse_orderpoint.xml
+++ b/bemade_reordering_rules_chatter/views/stock_warehouse_orderpoint.xml
@@ -9,6 +9,10 @@
             <xpath expr="//list" position="attributes">
                 <attribute name="editable"/>
             </xpath>
+            <xpath expr="//field[@name='qty_to_order']" position="after">
+                <field name="cost_supplier" optional="show"/>
+                <field name="cost_subtotal" optional="show" sum="Total"/>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
## What
Adds two columns to the **Replenishment** list (`stock.warehouse.orderpoint`):
- **Cost Supplier** — the product's primary (first-by-sequence) vendor price (`product_tmpl_id.seller_ids[0].price`; `0.0` if no vendor), distinct from the standard Cost.
- **Cost Sub-Total** — `To-Order qty × Cost Supplier`, with a **grand total** in the list footer.

## Why
Pneumac task #2847 (N.Drapeau): planners need to see purchase cost while planning replenishment. Studio can only expose the standard Cost, not the vendor/supplier price. Marc resolved (2026-06-11): primary (first) vendor price × To-Order qty.

## How
Two **non-stored** computed Floats on the orderpoint (storing is unsound — `qty_to_order` is itself non-stored/demand-driven). The footer grand total uses `sum="Total"` on the column, which Odoo 18 aggregates client-side for a non-stored computed Float (same pattern as core `product.product.qty_available` / `stock.quant.available_quantity`). Columns added to the module's existing orderpoint list inherit, `optional="show"`. No `purchase` dependency needed (`seller_ids` resolves via `product`).

## Tests
`TestReplenishmentCost` (4): primary-seller-by-**sequence** (not cheapest), no-seller → 0.0, and `cost_subtotal == qty_to_order × cost_supplier`. All green.

## Shared module → downstream
This is in shared `bemade-addons` (used by Pneumac + Durpro). After merge, the Pneumac (`pneumac/odoo`) submodule pointer will be bumped and a superproject MR opened against `18.0-staging`.

## UAT note
Worth an eyeball on staging: open **Inventory → Operations → Replenishment**, confirm the two columns appear and the **Cost Sub-Total** footer shows a grand total.