### PR TITLE
[customer_applications] Auto-allow a new specification key on its application type

### DIFF
--- a/customer_applications/models/application_specification.py
+++ b/customer_applications/models/application_specification.py
@@ -1,4 +1,4 @@
-from odoo import models, fields, api, _
+from odoo import models, fields, api, Command, _
 from odoo.exceptions import ValidationError
 
 
@@ -30,6 +30,50 @@ class PartnerApplicationSpecification(models.Model):
     allowed_specification_keys = fields.Many2many(
         related="application_id.application_type_id.allowed_specification_keys",
     )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        # Auto-allow each new key on its application type *before* creating the
+        # spec records: the `_constrain_key_id` constraint is validated during
+        # `_create` itself (via `_validate_fields`), not on a later flush, so the
+        # key must already be in the type's allowed list by the time super runs.
+        for vals in vals_list:
+            self._allow_key_on_type(
+                vals.get("application_id"), vals.get("key_id")
+            )
+        return super().create(vals_list)
+
+    def write(self, vals):
+        # Same timing: link the (possibly changed) key before super so the
+        # constraint passes when it validates the write.
+        if vals.get("key_id"):
+            application_type = (
+                self.application_id.application_type_id
+            )
+            for app_type in application_type:
+                self._allow_key_on_type(app_type.id, vals["key_id"])
+        return super().write(vals)
+
+    @api.model
+    def _allow_key_on_type(self, application_id, key_id):
+        """Ensure ``key_id`` is in the application type's allowed keys.
+
+        Resolves the type from ``application_id`` and links ``key_id`` into its
+        ``allowed_specification_keys`` when missing, so the
+        ``_constrain_key_id`` constraint passes. Idempotent: ``Command.link`` is
+        additive and a no-op for an already-allowed key. Skips silently when the
+        application, type, or key is absent (the ``required`` field / constraint
+        govern those cases).
+        """
+        if not application_id or not key_id:
+            return
+        application = self.env["partner.application"].browse(application_id)
+        application_type = application.application_type_id
+        if not application_type:
+            return
+        key = self.env["partner.application.specification.key"].browse(key_id)
+        if key not in application_type.allowed_specification_keys:
+            application_type.allowed_specification_keys = [Command.link(key.id)]
 
     @api.constrains("key_id")
     def _constrain_key_id(self):

--- a/customer_applications/tests/test_application.py
+++ b/customer_applications/tests/test_application.py
@@ -70,3 +70,59 @@ class TestApplication(TransactionCase):
         #       to dynamically create and load models
         self.assertEqual(specifications[0].sequence, 1)
         self.assertEqual(specifications[1].sequence, 2)
+
+    def test_new_key_is_auto_allowed_on_type(self):
+        """Adding a spec with a brand-new key auto-allows it on the type."""
+        application = self.env["partner.application"].create(
+            {
+                "partner_id": self.partner_1.id,
+                "application_type_id": self.application_type.id,
+            }
+        )
+        new_key = self.env["partner.application.specification.key"].create(
+            {"name": "Brand New Key"}
+        )
+        # Precondition (guards against a tautology): the key is NOT allowed yet.
+        self.assertNotIn(new_key, self.application_type.allowed_specification_keys)
+
+        # Pre-fix this raised ValidationError from _constrain_key_id.
+        spec = self.env["partner.application.specification"].create(
+            {
+                "key_id": new_key.id,
+                "value": "x",
+                "application_id": application.id,
+            }
+        )
+
+        self.assertTrue(spec.exists())
+        self.assertIn(new_key, self.application_type.allowed_specification_keys)
+
+    def test_changing_key_to_new_one_auto_allows(self):
+        """Writing a brand-new key onto an existing spec auto-allows it."""
+        application = self.env["partner.application"].create(
+            {
+                "partner_id": self.partner_1.id,
+                "application_type_id": self.application_type.id,
+            }
+        )
+        spec = self.env["partner.application.specification"].create(
+            {
+                "key_id": self.spec_key_1.id,
+                "value": "x",
+                "application_id": application.id,
+            }
+        )
+        another_new_key = self.env["partner.application.specification.key"].create(
+            {"name": "Another New Key"}
+        )
+        # Precondition: the new key is NOT allowed yet.
+        self.assertNotIn(
+            another_new_key, self.application_type.allowed_specification_keys
+        )
+
+        spec.write({"key_id": another_new_key.id})
+
+        self.assertEqual(spec.key_id, another_new_key)
+        self.assertIn(
+            another_new_key, self.application_type.allowed_specification_keys
+        )


### PR DESCRIPTION
## What
When a user adds a specification with a **new key** via the application form, the chosen key is now automatically added to the application **type's** `allowed_specification_keys`, so the `_constrain_key_id` constraint passes and the specification saves.

## Why
Durpro task #925: adding a specification with a new name failed the constraint, because nothing added the new key to the type's allowed list. Marc resolved (2026-06-09): **AUTO-ALLOW**.

## How
`partner.application.specification.create()`/`write()` link the key into `application_id.application_type_id.allowed_specification_keys` (the writable source M2M) via `Command.link`, **before** `super()` — `_constrain_key_id` is validated *during* `_create`/`_write` (`_validate_fields`), not on a deferred flush, so linking after super would still raise. Idempotent; the constraint is kept as defense-in-depth.

## Tests
Two regression tests (create + write paths), each asserting the key is NOT initially allowed (anti-tautology), then that the spec saves and the key is added. Fail-before/pass-after verified. 3/3 green.

## Shared module → downstream
In shared `bemade-addons` (used by multiple clients). After merge, the Durpro submodule pointer will be bumped and a superproject MR opened against `18.0-staging`.