### PR TITLE
[purchase_customer_requisition] Consolidate merged PO lines for the same product regardless of date

### DIFF
--- a/purchase_customer_requisition/__manifest__.py
+++ b/purchase_customer_requisition/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Purchase Customer Requisition",
-    "version": "1.0",
+    "version": "1.1",
     "category": "Purchase",
     "summary": "Link customer requisition references to purchase orders",
     "description": """\

--- a/purchase_customer_requisition/models/purchase_order.py
+++ b/purchase_customer_requisition/models/purchase_order.py
@@ -1,21 +1,74 @@
+from datetime import datetime
+
 from odoo import models
+
 
 class PurchaseOrder(models.Model):
     _inherit = 'purchase.order'
 
     def action_merge(self):
-        """Override to clear requisition_id before merging multiple POs"""
+        """Override to clear requisition_id before merging multiple POs, then
+        consolidate the resulting lines for the same product regardless of their
+        ``date_planned`` (core only merges lines whose dates are within 24h).
+        """
         if len(self) > 1:
             # Check if all POs have the same requisition_id
             unique_requisitions = set(order.requisition_id.id for order in self if order.requisition_id)
-            
+
             # Only clear requisition_ids if they are different
             if len(unique_requisitions) > 1:
                 self.write({'requisition_id': False})
-            
-            # Call parent method to perform merge
-            result = super().action_merge()
-            
-            return result
-            
-        return super().action_merge()
+
+        result = super().action_merge()
+
+        # Post-pass: consolidate same-product lines whose dates differ by >24h
+        # (core's matcher requires dates within 24h; we relax only that clause).
+        for order in self.filtered(lambda o: o.state in ('draft', 'sent')):
+            order._consolidate_lines_ignoring_date()
+
+        return result
+
+    def _consolidate_lines_ignoring_date(self):
+        """Merge this order's lines that match on core's matching tuple MINUS the
+        24h date clause: (product_id, product_uom, product_packaging_id,
+        product_packaging_qty, analytic_distribution, discount).
+
+        For each group of >1 line: the earliest-dated line is the survivor; every
+        other line is merged into it via ``_merge_po_line`` (which, through the
+        ``purchase_stock`` override, also transfers ``move_dest_ids`` -- preserving
+        the MTO/MPS procurement chain), the survivor's ``date_planned`` is set to
+        the earliest date, then the non-survivor lines are unlinked.
+        """
+        self.ensure_one()
+        _SENTINEL = datetime.max
+        groups = {}
+        for line in self.order_line:
+            if line.display_type in ('line_note', 'line_section'):
+                continue
+            key = (
+                line.product_id.id,
+                line.product_uom.id,
+                line.product_packaging_id.id,
+                line.product_packaging_qty,
+                tuple(sorted((line.analytic_distribution or {}).items())),
+                line.discount,
+            )
+            groups.setdefault(key, self.env['purchase.order.line'])
+            groups[key] += line
+
+        for group in groups.values():
+            if len(group) <= 1:
+                continue
+            # Capture the earliest date BEFORE merging: _merge_po_line bumps
+            # product_qty, which is a dependency of the date_planned stored
+            # compute, so reading date_planned afterwards would recompute it to
+            # the seller-derived date and lose the earliest value.
+            earliest = min(
+                (l.date_planned for l in group if l.date_planned), default=False
+            )
+            survivor = min(group, key=lambda l: l.date_planned or _SENTINEL)
+            for other in group - survivor:
+                survivor._merge_po_line(other)
+            if earliest:
+                survivor.date_planned = earliest
+            (group - survivor).unlink()

--- a/purchase_customer_requisition/tests/test_purchase_order.py
+++ b/purchase_customer_requisition/tests/test_purchase_order.py
@@ -1,6 +1,6 @@
 from odoo.tests import TransactionCase, tagged, Form
 from odoo import Command, fields
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 
 @tagged("post_install", "-at_install")
@@ -291,4 +291,149 @@ class TestPurchaseOrder(TransactionCase):
             purchase_line.requisition_id,
             future_agreement,
             "Future agreement should not be selected",
+        )
+
+    # ------------------------------------------------------------------
+    # Task 3421: consolidate same-product lines on merge regardless of date
+    # ------------------------------------------------------------------
+    def _make_draft_po(self, product, qty, date_planned, packaging=False):
+        """Create a one-line draft PO for ``supplier``.
+
+        ``date_planned`` is written AFTER creation: on create it is a stored
+        compute (``_compute_price_unit_and_date_planned_and_name``) that derives
+        the date from the seller and would clobber a value passed in vals. A
+        direct write sticks (the compute only re-fires on product/qty/uom
+        changes, not on ``date_planned`` itself).
+        """
+        line_vals = {
+            "product_id": product.id,
+            "product_qty": qty,
+        }
+        if packaging:
+            line_vals["product_packaging_id"] = packaging.id
+        order = self.env["purchase.order"].create(
+            {
+                "partner_id": self.supplier.id,
+                "order_line": [Command.create(line_vals)],
+            }
+        )
+        order.order_line.date_planned = date_planned
+        return order
+
+    def _real_lines(self, order, product):
+        return order.order_line.filtered(
+            lambda l: l.display_type not in ("line_note", "line_section")
+            and l.product_id == product
+        )
+
+    def test_merge_consolidates_same_product_different_dates(self):
+        now = datetime(2026, 6, 12, 12, 0, 0)
+        later = now + timedelta(days=5)  # > 24h apart -> core keeps separate
+        po_a = self._make_draft_po(self.product_1, 10, now)
+        po_b = self._make_draft_po(self.product_1, 7, later)
+
+        # Precondition: two separate draft orders, each one line, dates >24h apart.
+        self.assertEqual(po_a.state, "draft")
+        self.assertEqual(po_b.state, "draft")
+        self.assertEqual(po_a.order_line.product_qty, 10)
+        self.assertEqual(po_b.order_line.product_qty, 7)
+        self.assertGreater(
+            abs((po_a.order_line.date_planned - po_b.order_line.date_planned).total_seconds()),
+            86400,
+            "Precondition: the two lines' dates must be >24h apart",
+        )
+
+        (po_a + po_b).action_merge()
+
+        survivor_order = po_a if po_a.state in ("draft", "sent") else po_b
+        lines = self._real_lines(survivor_order, self.product_1)
+        self.assertEqual(
+            len(lines), 1, "Same-product lines must consolidate into ONE line"
+        )
+        self.assertEqual(lines.product_qty, 17, "Quantities must be summed (10 + 7)")
+        self.assertEqual(
+            lines.date_planned, now, "Consolidated line must keep the EARLIEST date"
+        )
+        self.assertEqual(
+            survivor_order.date_planned, now, "Header date_planned must be the earliest"
+        )
+
+    def test_merge_preserves_move_dest_ids(self):
+        now = datetime(2026, 6, 12, 12, 0, 0)
+        later = now + timedelta(days=5)
+        po_a = self._make_draft_po(self.product_1, 10, now)
+        po_b = self._make_draft_po(self.product_1, 7, later)
+
+        # Populate move_dest_ids on each line with a distinct draft stock.move.
+        customer_loc = self.env.ref("stock.stock_location_customers")
+        stock_loc = self.env.ref("stock.stock_location_stock")
+        move_a = self.env["stock.move"].create(
+            {
+                "name": "demand A",
+                "product_id": self.product_1.id,
+                "product_uom_qty": 10,
+                "product_uom": self.product_1.uom_id.id,
+                "location_id": stock_loc.id,
+                "location_dest_id": customer_loc.id,
+            }
+        )
+        move_b = self.env["stock.move"].create(
+            {
+                "name": "demand B",
+                "product_id": self.product_1.id,
+                "product_uom_qty": 7,
+                "product_uom": self.product_1.uom_id.id,
+                "location_id": stock_loc.id,
+                "location_dest_id": customer_loc.id,
+            }
+        )
+        po_a.order_line.move_dest_ids = [Command.set([move_a.id])]
+        po_b.order_line.move_dest_ids = [Command.set([move_b.id])]
+
+        # Precondition: each line carries one distinct downstream move.
+        self.assertEqual(po_a.order_line.move_dest_ids, move_a)
+        self.assertEqual(po_b.order_line.move_dest_ids, move_b)
+        expected = po_a.order_line.move_dest_ids | po_b.order_line.move_dest_ids
+        self.assertEqual(len(expected), 2, "Precondition: two distinct downstream moves")
+
+        (po_a + po_b).action_merge()
+
+        survivor_order = po_a if po_a.state in ("draft", "sent") else po_b
+        lines = self._real_lines(survivor_order, self.product_1)
+        self.assertEqual(len(lines), 1, "Lines must consolidate into ONE line")
+        self.assertEqual(
+            lines.move_dest_ids,
+            expected,
+            "Consolidated line must keep BOTH downstream moves "
+            "(procurement chain preserved) -- fails if consolidation open-codes unlink",
+        )
+
+    def test_merge_keeps_distinct_packaging_separate(self):
+        now = datetime(2026, 6, 12, 12, 0, 0)
+        later = now + timedelta(days=5)
+        pack_a = self.env["product.packaging"].create(
+            {"name": "Box of 5", "product_id": self.product_1.id, "qty": 5}
+        )
+        pack_b = self.env["product.packaging"].create(
+            {"name": "Box of 10", "product_id": self.product_1.id, "qty": 10}
+        )
+        po_a = self._make_draft_po(self.product_1, 10, now, packaging=pack_a)
+        po_b = self._make_draft_po(self.product_1, 7, later, packaging=pack_b)
+
+        # Precondition: same product, dates >24h apart, but DIFFERENT packaging.
+        self.assertEqual(po_a.order_line.product_packaging_id, pack_a)
+        self.assertEqual(po_b.order_line.product_packaging_id, pack_b)
+        self.assertNotEqual(
+            po_a.order_line.product_packaging_id, po_b.order_line.product_packaging_id
+        )
+
+        (po_a + po_b).action_merge()
+
+        survivor_order = po_a if po_a.state in ("draft", "sent") else po_b
+        lines = self._real_lines(survivor_order, self.product_1)
+        self.assertEqual(
+            len(lines),
+            2,
+            "Lines with different packaging must stay SEPARATE "
+            "(only the date clause is relaxed)",
         )


### PR DESCRIPTION
## What
On PO merge, lines for the same product/uom/packaging now consolidate into **one** line (summed qty) **regardless of `date_planned` differences**, keeping the **earliest** `date_planned`. Core only merges lines whose dates are within 24h.

## Why
Pneumac task #3421 (N.Drapeau): MPS planning generates multiple PO lines for the same product across different scheduled dates; merging POs left one line per date — risking supplier ordering errors and manual consolidation.

## How
Extend the existing `action_merge` override with a post-pass after `super()`: group the merged order's lines by core's matching tuple **minus the 24h date clause** (product, uom, packaging, packaging_qty, analytic_distribution, discount); for each group consolidate into the earliest-dated survivor via `survivor._merge_po_line(other)`. Using `_merge_po_line` (not an open-coded qty-sum + unlink) is critical: through the `purchase_stock` override it also transfers `move_dest_ids`, **preserving the MTO/MPS procurement chain**. The earliest `date_planned` is captured *before* the merge loop (since `_merge_po_line` bumps `product_qty`, a dependency of the `date_planned` compute). Different packaging/analytic/discount lines stay separate.

## Tests
- consolidates same-product different-date lines → 1 line, summed qty, earliest date
- **preserves `move_dest_ids`** on the survivor (guards the chain-loss regression)
- keeps distinct-packaging lines separate

All green.

> Pre-existing note (not introduced here): PCR's existing SO tests reference `sale.order.delivery_billing_mode` from `delivery_carrier_partner_account`, which PCR doesn't list in `depends` — those pre-existing tests error unless that module is co-installed. Worth a follow-up (manifest dep or decouple), out of scope for this PR.

## Shared module → downstream
In shared `bemade-addons`. After merge, the Pneumac submodule pointer will be bumped and a superproject MR opened against `18.0-staging`.