### PR TITLE
[FIX] product_uom_packaging: fix InvalidDomainError on PO Packaging column (#3768)

### DIFF
--- a/product_uom_packaging/__manifest__.py
+++ b/product_uom_packaging/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Product UoM Packaging",
     "summary": """
         Link products to UoMs with package type for dimensions""",
-    "version": "19.0.2.0.0",
+    "version": "19.0.2.0.1",
     "development_status": "Alpha",
     "license": "LGPL-3",
     "author": "Bemade Inc.",

--- a/product_uom_packaging/models/purchase_order_line.py
+++ b/product_uom_packaging/models/purchase_order_line.py
@@ -9,6 +9,12 @@ from odoo import api, fields, models
 class PurchaseOrderLine(models.Model):
     _inherit = "purchase.order.line"
 
+    product_template_id = fields.Many2one(
+        "product.template",
+        string="Product Template",
+        related="product_id.product_tmpl_id",
+        help="Template of the ordered product, used to scope packaging domain.",
+    )
     product_packaging_id = fields.Many2one(
         "product.uom.packaging",
         string="Packaging",

--- a/product_uom_packaging/tests/test_uc_purchase_vendor_packaging.py
+++ b/product_uom_packaging/tests/test_uc_purchase_vendor_packaging.py
@@ -163,6 +163,40 @@ class TestUCPurchaseVendorPackaging(TransactionCase):
         self.assertIn(self.pkg_vendor_a, valid)
         self.assertNotIn(self.pkg_vendor_b, valid)
 
+    def test_po_line_form_builds_with_packaging_domain(self):
+        """Form build with a product succeeds and product_packaging_id resolves.
+
+        Regression guard: a malformed view-level domain on product_packaging_id
+        (e.g. referencing product_id.product_tmpl_id instead of
+        product_template_id) causes odoo.tests.Form to raise on build.
+        If this test passes, the domain in purchase_order_views.xml compiles
+        and the invisible product_template_id field is loaded in the list.
+        """
+        po = self._make_po(self.vendor_a)
+        with Form(po) as po_form:
+            with po_form.order_line.new() as line:
+                line.product_id = self.product
+                line.product_qty = 100.0
+                # Auto-selected because exactly one vendor-A packaging exists.
+                self.assertEqual(line.product_packaging_id, self.pkg_vendor_a)
+
+    def test_po_line_form_empty_product_no_error(self):
+        """Form build with no product set raises no error and packaging is empty.
+
+        With the corrected domain referencing product_template_id (which is
+        False when no product is set), the leaf degrades to
+        ('product_tmpl_id','=',False) — valid, returns no packagings.
+        A malformed leaf ('product_tmpl_id','=','') would raise instead.
+        """
+        po = self._make_po(self.vendor_a)
+        with Form(po) as po_form:
+            with po_form.order_line.new() as line:
+                # Deliberately leave product_id unset.
+                self.assertFalse(
+                    line.product_packaging_id,
+                    "No packaging should be auto-selected when product is empty",
+                )
+
     def test_generic_packaging_included_in_vendor_a_domain(self):
         """Generic (partner_id=False) packagings appear in the domain for any vendor."""
         generic_pkg = self.env["product.uom.packaging"].create(

--- a/product_uom_packaging/tests/test_uc_purchase_vendor_packaging.py
+++ b/product_uom_packaging/tests/test_uc_purchase_vendor_packaging.py
@@ -187,15 +187,25 @@ class TestUCPurchaseVendorPackaging(TransactionCase):
         False when no product is set), the leaf degrades to
         ('product_tmpl_id','=',False) — valid, returns no packagings.
         A malformed leaf ('product_tmpl_id','=','') would raise instead.
+
+        Note: we call .new() without a 'with' block to avoid the O2MForm's
+        __exit__() triggering save() — which would raise AssertionError for the
+        required product_id field. The domain is evaluated at new() time, so
+        a malformed domain still surfaces here; we just don't attempt to persist
+        the empty line.
         """
         po = self._make_po(self.vendor_a)
         with Form(po) as po_form:
-            with po_form.order_line.new() as line:
-                # Deliberately leave product_id unset.
-                self.assertFalse(
-                    line.product_packaging_id,
-                    "No packaging should be auto-selected when product is empty",
-                )
+            # Instantiate a new line without setting product_id.
+            # A malformed view-level domain raises here; the corrected domain
+            # should not.
+            line = po_form.order_line.new()
+            self.assertFalse(
+                line.product_packaging_id,
+                "No packaging should be auto-selected when product is empty",
+            )
+            # Do not save the line (product_id is required); the form proxy
+            # will discard it when po_form exits without calling line.save().
 
     def test_generic_packaging_included_in_vendor_a_domain(self):
         """Generic (partner_id=False) packagings appear in the domain for any vendor."""

--- a/product_uom_packaging/views/purchase_order_views.xml
+++ b/product_uom_packaging/views/purchase_order_views.xml
@@ -11,10 +11,13 @@
                 expr="//field[@name='order_line']//list//field[@name='product_qty']"
                 position="after"
             >
+                <!-- product_template_id must be loaded in the list so the
+                     packaging domain below can dereference it client-side. -->
+                <field name="product_template_id" invisible="True" />
                 <field
                     name="product_packaging_id"
                     optional="show"
-                    domain="[('product_tmpl_id', '=', product_id.product_tmpl_id), '|', ('partner_id', '=', False), ('partner_id', '=', parent.partner_id)]"
+                    domain="[('product_tmpl_id', '=', product_template_id), '|', ('partner_id', '=', False), ('partner_id', '=', parent.partner_id)]"
                 />
                 <field
                     name="product_packaging_qty"


### PR DESCRIPTION
## Problem

Clicking into the **Packaging** column on a purchase order line raised
`InvalidDomainError` in the web client:

```
Invalid domain representation: product_tmpl_id,=,,|,partner_id,=,false,partner_id,=,3717
```

The list-view domain on `product_packaging_id` referenced the dotted
`product_id.product_tmpl_id`, which the web client cannot dereference (it
only holds the m2o id/name of `product_id`, not the template behind it), so
the leaf rendered with an empty operand.

## Fix

- Add a `product_template_id` related field
  (`related='product_id.product_tmpl_id'`, non-stored Many2one to
  `product.template`) to the `product_uom_packaging` `purchase.order.line`
  `_inherit` class. (`purchase_product_matrix`, which provides this field
  upstream, is **not** in this addon's `depends`, so we declare it
  ourselves — it merges harmlessly if that module is co-installed.)
- Expose it as an `invisible` field inside the PO `order_line` list view so
  the client loads it, and repoint the `product_packaging_id` domain at
  `product_template_id`.
- Empty-product case now degrades to the valid leaf
  `('product_tmpl_id','=',False)` (no packagings) instead of a malformed
  empty operand.
- Manifest version bump `19.0.2.0.0` → `19.0.2.0.1`.

## Tests

`odoo.tests.Form` smoke tests for the product-set and empty-product cases,
plus existing vendor-scoping tests as semantic guards. **60 tests pass, 0
failures / 0 errors.**

## Reference

- Odoo task #3768 (RWI SAP B1 → Odoo Migration, project 289)
- Pipeline artifacts: https://git.bemade.org/bemade/tasks/-/tree/main/task-3768-packaging-column-domain-error

Downstream: RWI submodule pointer bump follows as a separate cycle once this merges.