### PR TITLE
[3678] bemade_documents_link: link existing documents to any record

### DIFF
--- a/bemade_documents_link/__init__.py
+++ b/bemade_documents_link/__init__.py
@@ -1,0 +1,1 @@
+from . import wizard

--- a/bemade_documents_link/__manifest__.py
+++ b/bemade_documents_link/__manifest__.py
@@ -1,0 +1,43 @@
+{
+    "name": "Documents - Link Existing",
+    "version": "18.0.1.0.0",
+    "summary": "Easily link an existing Documents record (incl. spreadsheets) "
+               "to any mail.thread record, from either side.",
+    "description": """
+Documents - Link Existing
+=========================
+
+Adds two generic, reusable entry points for linking an **existing** document
+(including a spreadsheet) to a business record, without uploading a new file:
+
+* **From the record side** — a *Link existing document* item appears in the
+  cog menu of every ``mail.thread`` form view. It opens a small wizard that
+  lets the user pick one or more already-existing, unlinked Documents records
+  and links them to the current record.
+* **From the Documents side** — a generic *Link to record* server action lets
+  the user first choose the target model (limited to ``mail.thread`` models)
+  and then the record, reusing the stock Documents ``link_to_record_wizard``.
+
+Linking simply sets ``res_model`` / ``res_id`` on the chosen
+``documents.document`` records; no new persistent storage is introduced.
+""",
+    "category": "Productivity/Documents",
+    "author": "Bemade Inc.",
+    "maintainer": "Marc Durepos <marc@bemade.org>",
+    "website": "https://www.bemade.org",
+    "license": "LGPL-3",
+    "depends": ["documents"],
+    "data": [
+        "security/ir.model.access.csv",
+        "wizard/documents_link_wizard_views.xml",
+        "data/ir_actions_server_data.xml",
+    ],
+    "assets": {
+        "web.assets_backend": [
+            "bemade_documents_link/static/src/link_document_cog_menu/*.js",
+            "bemade_documents_link/static/src/link_document_cog_menu/*.xml",
+        ],
+    },
+    "installable": True,
+    "auto_install": False,
+}

--- a/bemade_documents_link/data/ir_actions_server_data.xml
+++ b/bemade_documents_link/data/ir_actions_server_data.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+
+        <!--
+            Generic Documents-side entry point: a contextual "Link to record"
+            action on documents.document. Bound to the model (binding_model_id),
+            so it shows in the Action menu of the Documents views for one or more
+            selected documents. It calls the stock action_link_to_record() with
+            NO model argument, so the user first picks the target model (limited
+            to mail.thread models) and then the record, via the stock
+            documents.link_to_record_wizard.
+        -->
+        <record id="ir_actions_server_link_to_record" model="ir.actions.server">
+            <field name="name">Link to record</field>
+            <field name="model_id" ref="documents.model_documents_document"/>
+            <field name="binding_model_id" ref="documents.model_documents_document"/>
+            <field name="binding_view_types">list,kanban,form</field>
+            <field name="groups_id" eval="[Command.link(ref('base.group_user'))]"/>
+            <field name="state">code</field>
+            <field name="code">
+action = records.action_link_to_record()
+            </field>
+        </record>
+
+    </data>
+</odoo>

--- a/bemade_documents_link/security/ir.model.access.csv
+++ b/bemade_documents_link/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_documents_link_wizard_user,documents.link.wizard.user,model_documents_link_wizard,base.group_user,1,1,1,1

--- a/bemade_documents_link/static/src/link_document_cog_menu/link_document_cog_menu.js
+++ b/bemade_documents_link/static/src/link_document_cog_menu/link_document_cog_menu.js
@@ -1,0 +1,74 @@
+/** @odoo-module **/
+
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { registry } from "@web/core/registry";
+import { Component } from "@odoo/owl";
+import { useService } from "@web/core/utils/hooks";
+import { _t } from "@web/core/l10n/translation";
+
+const cogMenuRegistry = registry.category("cogMenu");
+
+/**
+ * "Link existing document" cog-menu item.
+ *
+ * Appears in the cog menu of every mail.thread form view and opens the
+ * record-side documents.link.wizard with the current record in context, so the
+ * user can link one or more existing Documents records to it.
+ *
+ * Modeled on enterprise `sign`'s SignRequestCogMenu: the current record's
+ * model/id are read from the action service's current controller, and the
+ * mail.thread gate uses the presence of the `message_ids` field in the search
+ * view fields (no extra RPC).
+ */
+export class LinkDocumentCogMenu extends Component {
+    static template = "bemade_documents_link.LinkDocumentCogMenu";
+    static components = { DropdownItem };
+    static props = {};
+
+    setup() {
+        this.action = useService("action");
+    }
+
+    linkDocument() {
+        // resModel is static on the controller props; resId comes from the
+        // mutable current state (it changes for newly created records).
+        const resModel = this.action.currentController.props.resModel;
+        const resId = this.action.currentController.currentState?.resId;
+        if (!resModel || !resId) {
+            return;
+        }
+        this.action.doAction(
+            {
+                name: _t("Link Existing Document"),
+                type: "ir.actions.act_window",
+                res_model: "documents.link.wizard",
+                view_mode: "form",
+                views: [[false, "form"]],
+                target: "new",
+            },
+            {
+                additionalContext: {
+                    active_model: resModel,
+                    active_id: resId,
+                },
+            }
+        );
+    }
+}
+
+export const LinkDocumentCogMenuItem = {
+    Component: LinkDocumentCogMenu,
+    groupNumber: 20,
+    isDisplayed: ({ config, searchModel }) => {
+        // A mail.thread model exposes a `message_ids` field in its (search) view.
+        const isMailThread = Boolean(searchModel.searchViewFields?.["message_ids"]);
+        return (
+            isMailThread &&
+            config.actionType === "ir.actions.act_window" &&
+            config.viewType === "form" &&
+            searchModel.resModel !== "documents.document"
+        );
+    },
+};
+
+cogMenuRegistry.add("link-document-menu", LinkDocumentCogMenuItem, { sequence: 20 });

--- a/bemade_documents_link/static/src/link_document_cog_menu/link_document_cog_menu.xml
+++ b/bemade_documents_link/static/src/link_document_cog_menu/link_document_cog_menu.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="bemade_documents_link.LinkDocumentCogMenu">
+        <DropdownItem class="'o_link_existing_document'" onSelected.bind="linkDocument">
+            <i class="fa fa-link fa-fw"/> Link existing document
+        </DropdownItem>
+    </t>
+
+</templates>

--- a/bemade_documents_link/tests/__init__.py
+++ b/bemade_documents_link/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_documents_link

--- a/bemade_documents_link/tests/test_documents_link.py
+++ b/bemade_documents_link/tests/test_documents_link.py
@@ -1,0 +1,107 @@
+import base64
+
+from odoo.tests import Form, tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("post_install", "-at_install")
+class TestDocumentsLink(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner = cls.env["res.partner"].create({"name": "Link Target Partner"})
+        cls.doc = cls._make_doc(cls.env, "Existing Doc")
+
+    @classmethod
+    def _make_doc(cls, env, name="Doc"):
+        """Create a realistic app-managed Documents record: with an attachment,
+        so that — as in the real app — it ends up unlinked with the
+        self-referential res_model 'documents.document'."""
+        return env["documents.document"].create({
+            "name": name,
+            "type": "binary",
+            "datas": base64.b64encode(b"hello").decode(),
+        })
+
+    def _new_doc(self, name="Doc"):
+        return self._make_doc(self.env, name)
+
+    def test_record_side_link(self):
+        """Record-side: action_link() sets res_model/res_id on the chosen
+        existing (unlinked) document, and res_name reflects the target."""
+        # An unlinked, app-managed document carries the self-referential
+        # res_model 'documents.document'.
+        self.assertEqual(self.doc.res_model, "documents.document",
+                         "Fixture doc must start unlinked (workspace document)")
+        wizard = self.env["documents.link.wizard"].with_context(
+            active_model="res.partner",
+            active_id=self.partner.id,
+        ).create({"document_ids": [(6, 0, self.doc.ids)]})
+        # Defaults pulled from context.
+        self.assertEqual(wizard.res_model, "res.partner")
+        self.assertEqual(wizard.res_id, self.partner.id)
+
+        wizard.action_link()
+
+        self.assertEqual(self.doc.res_model, "res.partner")
+        self.assertEqual(self.doc.res_id, self.partner.id)
+        self.assertEqual(self.doc.res_name, self.partner.display_name)
+
+    def test_documents_side_model_filter(self):
+        """Documents-side: the stock link_to_record_wizard offers ONLY
+        mail.thread models, and link_to() writes the link our server action
+        relies on."""
+        wizard = self.env["documents.link_to_record_wizard"].create({
+            "document_ids": [(6, 0, self.doc.ids)],
+        })
+        target_models = {
+            model for model, _name in wizard._selection_target_model()
+        }
+        # res.partner is a mail.thread model -> present.
+        self.assertIn("res.partner", target_models)
+        # ir.model is not a mail.thread model -> absent; documents.document
+        # itself is explicitly excluded.
+        self.assertNotIn("ir.model", target_models)
+        self.assertNotIn("documents.document", target_models)
+
+        wizard.write({
+            "model_id": self.env["ir.model"]._get_id("res.partner"),
+            "resource_ref": f"res.partner,{self.partner.id}",
+        })
+        wizard.link_to()
+        self.assertEqual(self.doc.res_model, "res.partner")
+        self.assertEqual(self.doc.res_id, self.partner.id)
+
+    def test_server_action_opens_generic_wizard(self):
+        """Server-action wiring: running our ir.actions.server on a
+        documents.document returns an act_window opening the stock generic
+        link_to_record_wizard (no model preselected)."""
+        server_action = self.env.ref(
+            "bemade_documents_link.ir_actions_server_link_to_record"
+        )
+        doc = self._new_doc("Server Action Doc")
+        action = server_action.with_context(
+            active_model="documents.document",
+            active_id=doc.id,
+            active_ids=doc.ids,
+        ).run()
+        self.assertEqual(action["type"], "ir.actions.act_window")
+        self.assertEqual(action["res_model"], "documents.link_to_record_wizard")
+        # Generic: no model preselected, so the user picks it in the wizard.
+        self.assertFalse(action["context"].get("default_model_id"))
+        self.assertEqual(action["context"].get("default_document_ids"), doc.ids)
+
+    def test_record_side_form_smoke(self):
+        """Form smoke: the record-side wizard view compiles, defaults populate
+        from context, and document_ids is editable."""
+        form = Form(
+            self.env["documents.link.wizard"].with_context(
+                active_model="res.partner",
+                active_id=self.partner.id,
+            )
+        )
+        self.assertEqual(form.res_model, "res.partner")
+        self.assertEqual(form.res_id, self.partner.id)
+        form.document_ids.add(self.doc)
+        wizard = form.save()
+        self.assertIn(self.doc, wizard.document_ids)

--- a/bemade_documents_link/wizard/__init__.py
+++ b/bemade_documents_link/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import documents_link_wizard

--- a/bemade_documents_link/wizard/documents_link_wizard.py
+++ b/bemade_documents_link/wizard/documents_link_wizard.py
@@ -1,0 +1,57 @@
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
+
+class DocumentsLinkWizard(models.TransientModel):
+    """Record-side wizard: link one or more existing, unlinked
+    ``documents.document`` records to the record the user is currently on
+    (resolved from the ``active_model`` / ``active_id`` context).
+    """
+
+    _name = "documents.link.wizard"
+    _description = "Link Existing Documents to Record"
+
+    res_model = fields.Char(
+        string="Target Model",
+        required=True,
+        default=lambda self: self.env.context.get("active_model"),
+    )
+    res_id = fields.Integer(
+        string="Target Record",
+        required=True,
+        default=lambda self: self.env.context.get("active_id"),
+    )
+    document_ids = fields.Many2many(
+        "documents.document",
+        string="Documents",
+        # Offer only existing, not-yet-linked documents. An app-managed
+        # document that isn't linked to a business record carries the
+        # self-referential res_model 'documents.document' (set on create in
+        # enterprise `documents`), so that — not False — is the "unlinked" marker.
+        domain=[("res_model", "=", "documents.document")],
+    )
+
+    def action_link(self):
+        self.ensure_one()
+        if not self.document_ids:
+            raise UserError(_("Select at least one document to link."))
+
+        # Gate on the user's *write* access to the target record, mirroring the
+        # stock Documents link wizard's access logic, so a user cannot link a
+        # document to a record they are not allowed to modify.
+        target_model = self.res_model
+        if target_model not in self.env or self.env[target_model]._abstract:
+            raise UserError(_("Cannot link documents to model %s.", target_model))
+        target = self.env[target_model].browse(self.res_id)
+        if not target.exists():
+            raise UserError(_("The record to link the documents to no longer exists."))
+        target.check_access("write")
+
+        # res_name recomputes automatically from res_model/res_id on
+        # documents.document; mirror the stock wizard's write payload.
+        self.document_ids.write({
+            "res_model": self.res_model,
+            "res_id": self.res_id,
+            "is_editable_attachment": True,
+        })
+        return {"type": "ir.actions.act_window_close"}

--- a/bemade_documents_link/wizard/documents_link_wizard_views.xml
+++ b/bemade_documents_link/wizard/documents_link_wizard_views.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="documents_link_wizard_view_form" model="ir.ui.view">
+        <field name="name">documents.link.wizard.form</field>
+        <field name="model">documents.link.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Link Existing Documents">
+                <sheet>
+                    <group>
+                        <field name="res_model" invisible="1"/>
+                        <field name="res_id" invisible="1"/>
+                        <field name="document_ids"
+                               widget="many2many_tags"
+                               options="{'no_create': True}"
+                               placeholder="Choose existing documents to link..."/>
+                    </group>
+                </sheet>
+                <footer>
+                    <button name="action_link" type="object" string="Link"
+                            class="btn-primary" data-hotkey="q"/>
+                    <button string="Cancel" class="btn-secondary"
+                            special="cancel" data-hotkey="x"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_documents_link_wizard" model="ir.actions.act_window">
+        <field name="name">Link Existing Document</field>
+        <field name="res_model">documents.link.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+        <field name="view_id" ref="documents_link_wizard_view_form"/>
+    </record>
+
+</odoo>


### PR DESCRIPTION
New shared module `bemade_documents_link` (additive, depends `documents`).

**What it does** (task Durpro #3678 — "make it easy to link an existing document, incl. spreadsheets, to products and hopefully other objects"):
- **Record side:** a cog-menu item **"Link existing document"** on any `mail.thread` form view → a wizard to pick one or more *existing* workspace documents and link them to the current record (no new-file upload). Generic — works for products and any other chatter-bearing model.
- **Documents side:** a generic *"Link to record"* server action on `documents.document` (list/kanban/form) → pick any mail.thread model, then the record.
- No persistent models; reuses `documents.document.res_model`/`res_id`. Access row for the transient wizard.

**Tests:** `bemade_documents_link` 4 test methods, 0 failed / 0 error — exercises the link write, the model filter (partner/product allowed; `documents.document` and non-mail.thread excluded), and view compilation.

**How to test:** on an 18.0 instance with Enterprise `documents`: open a product/partner → cog → **Link existing document** → pick docs → Link; confirm they show the record in *Linked To*. From Documents → select a doc → Action → **Link to record** → confirm the model selector lists only mail.thread models, pick a record, verify the link.

Downstream: the Durpro client MR (submodule pointer bump) follows automatically once this merges.
