### PR TITLE
[crm_account_management] Reverse partner→OU link: smart button on SO/lead/invoice/picking (#3753)

### DIFF
--- a/crm_account_management/__manifest__.py
+++ b/crm_account_management/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "CRM Account Management",
-    "version": "18.0.4.0.0",
+    "version": "18.0.5.0.0",
     "category": "Sales/CRM",
     "summary": "Customer Account Management with Dashboard and Reporting",
     "description": """
@@ -31,6 +31,10 @@ account visibility:
         "data/cron.xml",
         "views/organizational_unit_views.xml",
         "views/res_partner_views.xml",
+        "views/sale_order_views.xml",
+        "views/crm_lead_views.xml",
+        "views/account_move_views.xml",
+        "views/stock_picking_views.xml",
         "views/menu.xml",
         "report/annual_review_report.xml",
         "report/annual_review_template.xml",

--- a/crm_account_management/models/__init__.py
+++ b/crm_account_management/models/__init__.py
@@ -1,2 +1,7 @@
 from . import organizational_unit
+from . import organizational_unit_mixin
 from . import res_partner
+from . import sale_order
+from . import crm_lead
+from . import account_move
+from . import stock_picking

--- a/crm_account_management/models/account_move.py
+++ b/crm_account_management/models/account_move.py
@@ -1,0 +1,6 @@
+from odoo import models
+
+
+class AccountMove(models.Model):
+    _name = "account.move"
+    _inherit = ["account.move", "organizational.unit.mixin"]

--- a/crm_account_management/models/crm_lead.py
+++ b/crm_account_management/models/crm_lead.py
@@ -1,0 +1,6 @@
+from odoo import models
+
+
+class CrmLead(models.Model):
+    _name = "crm.lead"
+    _inherit = ["crm.lead", "organizational.unit.mixin"]

--- a/crm_account_management/models/organizational_unit_mixin.py
+++ b/crm_account_management/models/organizational_unit_mixin.py
@@ -1,0 +1,71 @@
+from odoo import api, fields, models
+
+
+class OrganizationalUnitMixin(models.AbstractModel):
+    """Reverse-link mixin: gives any partner-bearing model a non-stored link
+    back to the customer account(s) (``organizational.unit``) it belongs to,
+    plus a smart button to navigate there.
+
+    Resolution is delegated to ``res.partner._get_organizational_units()``,
+    which is the exact inverse of ``organizational.unit._get_all_partners()``.
+
+    Inherited (via ``_inherit``) by sale.order, crm.lead, account.move and
+    stock.picking -- all of which expose a ``partner_id``.
+
+    Non-stored (computed on read): a partner maps to 0, 1 or many OUs, and OU
+    membership changes (member_ids edits, OU re-parenting, partner re-parenting)
+    would otherwise require fragile cross-model store invalidation. Lists don't
+    render smart buttons, so the per-form read cost is negligible.
+    """
+
+    _name = "organizational.unit.mixin"
+    _description = "Organizational Unit Reverse-Link Mixin"
+
+    organizational_unit_ids = fields.Many2many(
+        "organizational.unit",
+        string="Customer Accounts",
+        compute="_compute_organizational_unit_ids",
+        store=False,
+        help="Customer accounts (organizational units) this record's partner "
+             "belongs to.",
+    )
+    organizational_unit_count = fields.Integer(
+        string="Customer Account Count",
+        compute="_compute_organizational_unit_ids",
+        store=False,
+    )
+
+    @api.depends("partner_id")
+    def _compute_organizational_unit_ids(self):
+        for record in self:
+            ous = record.partner_id._get_organizational_units()
+            record.organizational_unit_ids = ous
+            record.organizational_unit_count = len(ous)
+
+    def action_view_organizational_units(self):
+        """Smart-button action: open the related customer account(s).
+
+        0 -> close (button is hidden in that case anyway);
+        1 -> open that OU's form;
+        many -> a filtered list/form of those OUs.
+        """
+        self.ensure_one()
+        ous = self.organizational_unit_ids
+        if not ous:
+            return {"type": "ir.actions.act_window_close"}
+        if len(ous) == 1:
+            return {
+                "type": "ir.actions.act_window",
+                "res_model": "organizational.unit",
+                "res_id": ous.id,
+                "view_mode": "form",
+                "target": "current",
+            }
+        return {
+            "type": "ir.actions.act_window",
+            "name": "Customer Accounts",
+            "res_model": "organizational.unit",
+            "domain": [("id", "in", ous.ids)],
+            "view_mode": "list,form",
+            "target": "current",
+        }

--- a/crm_account_management/models/res_partner.py
+++ b/crm_account_management/models/res_partner.py
@@ -41,6 +41,56 @@ class ResPartner(models.Model):
                         ou.sudo().write({"name": partner.name})
         return res
 
+    def _get_organizational_units(self):
+        """Return every organizational.unit this partner belongs to.
+
+        This is the EXACT inverse of
+        ``organizational.unit._get_all_partners()`` (organizational_unit.py).
+
+        Invariant (the correctness contract):
+            P in ou._get_all_partners()  <=>  ou in P._get_organizational_units()
+
+        Forward membership predicate -- ``P in ou._get_all_partners()`` holds iff
+        at least one of:
+            (a) ou.owner_id == P
+            (b) ou.owner_id == P.parent_id   (P is a DIRECT child contact of the
+                owner company; mirrors the one-level ``owner_id.child_ids``, NOT
+                commercial_partner_id which would climb to the topmost ancestor)
+            (c) P in ou.member_ids
+            (d) the same predicate holds for some DESCENDANT OU of ou
+                (the forward recursion into child_ids).
+
+        Inverting it:
+            1. direct = OUs satisfying (a) OR (b) OR (c).
+            2. result = direct PLUS all ancestors of direct (climb parent_id up the
+               organizational.unit tree -- the inverse of the downward recursion).
+        """
+        OU = self.env["organizational.unit"]
+        if not self:
+            return OU
+        result = OU
+        for partner in self:
+            # 1. Direct matches: branches (a), (b), (c).
+            #    (a) owner_id == partner       -- also == partner.owned_organizational_unit_ids
+            #    (b) owner_id == partner.parent_id  (one level, mirroring owner_id.child_ids)
+            #    (c) partner in member_ids
+            owner_candidates = partner | partner.parent_id
+            direct = OU.search([
+                "|", "|",
+                ("owner_id", "in", owner_candidates.ids),
+                ("member_ids", "in", partner.ids),
+                ("id", "in", partner.owned_organizational_unit_ids.ids),
+            ])
+            # 2. Ancestors: climb parent_id until no new OUs appear
+            #    (bounded -- _check_parent_recursion forbids cycles).
+            partner_result = direct
+            frontier = direct.parent_id
+            while frontier - partner_result:
+                partner_result |= frontier
+                frontier = frontier.parent_id
+            result |= partner_result
+        return result
+
     def action_view_organizational_unit(self):
         """Navigate to the partner's organizational unit."""
         self.ensure_one()

--- a/crm_account_management/models/sale_order.py
+++ b/crm_account_management/models/sale_order.py
@@ -1,0 +1,6 @@
+from odoo import models
+
+
+class SaleOrder(models.Model):
+    _name = "sale.order"
+    _inherit = ["sale.order", "organizational.unit.mixin"]

--- a/crm_account_management/models/stock_picking.py
+++ b/crm_account_management/models/stock_picking.py
@@ -1,0 +1,6 @@
+from odoo import models
+
+
+class StockPicking(models.Model):
+    _name = "stock.picking"
+    _inherit = ["stock.picking", "organizational.unit.mixin"]

--- a/crm_account_management/tests/__init__.py
+++ b/crm_account_management/tests/__init__.py
@@ -6,5 +6,6 @@ from . import test_us04_chatter
 from . import test_us05_auto_create
 from . import test_us08_ou_structure
 from . import test_us09_partner_ous
+from . import test_us10_reverse_links
 from . import test_us19_annual_review
 from . import test_us20_top_products

--- a/crm_account_management/tests/test_us10_reverse_links.py
+++ b/crm_account_management/tests/test_us10_reverse_links.py
@@ -1,0 +1,224 @@
+from odoo.tests import Form, tagged
+from odoo.fields import Command
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+
+
+@tagged("post_install", "-at_install")
+class TestUS10ReverseLinks(AccountTestInvoicingCommon):
+    """
+    US-10 (task 3753): reverse link from sale.order / crm.lead / account.move /
+    stock.picking back to the customer account (organizational.unit).
+
+    The resolution helper res.partner._get_organizational_units() must be the
+    EXACT inverse of organizational.unit._get_all_partners():
+
+        P in ou._get_all_partners()  <=>  ou in P._get_organizational_units()
+
+    The correctness-critical tests assert against the FORWARD _get_all_partners()
+    oracle, not the helper's own output, so they cannot pass under buggy inverse
+    logic (e.g. a commercial_partner_id over-report).
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.Partner = cls.env["res.partner"]
+        cls.OU = cls.env["organizational.unit"]
+
+    # ------------------------------------------------------------------ #
+    # helpers
+    # ------------------------------------------------------------------ #
+    def _ou_of(self, company):
+        """The auto-created OU owned by a top-level company partner."""
+        return self.OU.search([("owner_id", "=", company.id)])
+
+    def _forward_truth(self, partner):
+        """The forward oracle: every OU whose _get_all_partners() contains
+        ``partner``. This is the ground truth the inverse must reproduce."""
+        return self.OU.search([]).filtered(
+            lambda ou: partner in ou._get_all_partners()
+        )
+
+    # ------------------------------------------------------------------ #
+    # 1. 0 OUs
+    # ------------------------------------------------------------------ #
+    def test_01_zero_ous(self):
+        contact = self.Partner.create({"name": "Lonely Contact", "is_company": False})
+        self.assertFalse(
+            contact._get_organizational_units(),
+            "A standalone contact owning/membering nothing belongs to no OU.",
+        )
+        # a sale.order for it -> count 0
+        so = self.env["sale.order"].create({"partner_id": contact.id})
+        self.assertEqual(so.organizational_unit_count, 0)
+        self.assertFalse(so.organizational_unit_ids)
+        # and an account.move (invoice) for it -> count 0 (safe vendor-bill outcome)
+        move = self.env["account.move"].create(
+            {"move_type": "out_invoice", "partner_id": contact.id}
+        )
+        self.assertEqual(move.organizational_unit_count, 0)
+
+    # ------------------------------------------------------------------ #
+    # 2. 1 OU via owner
+    # ------------------------------------------------------------------ #
+    def test_02_one_ou_via_owner(self):
+        company = self.Partner.create({"name": "Owner Co", "is_company": True})
+        ou = self._ou_of(company)
+        self.assertTrue(ou, "Top company auto-creates its OU.")
+
+        so = self.env["sale.order"].create({"partner_id": company.id})
+        self.assertEqual(so.organizational_unit_ids, ou)
+        self.assertEqual(so.organizational_unit_count, 1)
+
+    # ------------------------------------------------------------------ #
+    # 3. 1 OU via owner's DIRECT contact (branch b)
+    # ------------------------------------------------------------------ #
+    def test_03_one_ou_via_direct_contact(self):
+        company = self.Partner.create({"name": "Branch-B Co", "is_company": True})
+        ou = self._ou_of(company)
+        contact = self.Partner.create(
+            {"name": "Direct Contact", "parent_id": company.id}
+        )
+        # forward oracle pins the (b) branch
+        self.assertIn(
+            contact, ou._get_all_partners(),
+            "Forward: direct child of owner company is in the OU.",
+        )
+        self.assertEqual(
+            contact._get_organizational_units(), self._forward_truth(contact),
+            "Inverse must equal the forward oracle.",
+        )
+        self.assertEqual(contact._get_organizational_units(), ou)
+
+    # ------------------------------------------------------------------ #
+    # 4. 2-LEVEL HIERARCHY -- the defect-closing test
+    # ------------------------------------------------------------------ #
+    def test_04_two_level_hierarchy_no_over_report(self):
+        # top company C (owns ou_c)
+        c = self.Partner.create({"name": "Top C", "is_company": True})
+        ou_c = self._ou_of(c)
+        # intermediate NON-company contact D, direct child of C. Because D is not
+        # a company, commercial_partner_id keeps climbing past it to C.
+        d = self.Partner.create(
+            {"name": "Dept D", "is_company": False, "parent_id": c.id}
+        )
+        # deep contact P, child of D -> commercial_partner_id == C but parent_id == D.
+        # This is exactly the case the buggy commercial_partner_id inverse over-reported.
+        p = self.Partner.create({"name": "Deep P", "parent_id": d.id})
+        self.assertEqual(
+            p.commercial_partner_id, c,
+            "Sanity: P's commercial partner climbs past non-company D to C.",
+        )
+        self.assertEqual(p.parent_id, d, "Sanity: P's direct parent is D, not C.")
+
+        forward = self._forward_truth(p)
+        # the invariant, by construction
+        self.assertEqual(p._get_organizational_units(), forward)
+        # owner_id.child_ids is ONE level -> P is NOT a direct child of C ->
+        # P not in ou_c._get_all_partners() -> ou_c must NOT be reported.
+        self.assertNotIn(
+            p, ou_c._get_all_partners(),
+            "Forward: P is not a direct child of C, so not in C's OU.",
+        )
+        self.assertNotIn(
+            ou_c, p._get_organizational_units(),
+            "Inverse must NOT over-report ou_c (the commercial_partner_id bug).",
+        )
+
+    def test_04b_two_level_hierarchy_d_owns_ou(self):
+        # Same shape, but D is top-level so it owns its own ou_d -> P IS its direct
+        # child, so ou_d is correctly in the forward set and the inverse must match.
+        d = self.Partner.create({"name": "Owner D", "is_company": True})
+        ou_d = self._ou_of(d)
+        p = self.Partner.create({"name": "Child of D", "parent_id": d.id})
+        forward = self._forward_truth(p)
+        self.assertIn(ou_d, forward)
+        self.assertEqual(p._get_organizational_units(), forward)
+
+    # ------------------------------------------------------------------ #
+    # 5. 1 OU via explicit member (branch c)
+    # ------------------------------------------------------------------ #
+    def test_05_one_ou_via_member(self):
+        company = self.Partner.create({"name": "Member Owner Co", "is_company": True})
+        ou = self._ou_of(company)
+        # a partner that is neither owner nor child of owner
+        member = self.Partner.create({"name": "Explicit Member", "is_company": True})
+        ou.write({"member_ids": [Command.link(member.id)]})
+
+        self.assertIn(
+            member, ou._get_all_partners(), "Forward: explicit member is in the OU."
+        )
+        self.assertIn(ou, member._get_organizational_units())
+        self.assertEqual(member._get_organizational_units(), self._forward_truth(member))
+
+    # ------------------------------------------------------------------ #
+    # 6. Many OUs
+    # ------------------------------------------------------------------ #
+    def test_06_many_ous(self):
+        # company owns ou_a; member of ou_b
+        company = self.Partner.create({"name": "Multi Co", "is_company": True})
+        ou_a = self._ou_of(company)
+        other = self.Partner.create({"name": "Other Co", "is_company": True})
+        ou_b = self._ou_of(other)
+        ou_b.write({"member_ids": [Command.link(company.id)]})
+
+        ous = company._get_organizational_units()
+        self.assertEqual(ous, ou_a | ou_b)
+        self.assertEqual(company._get_organizational_units(), self._forward_truth(company))
+
+        so = self.env["sale.order"].create({"partner_id": company.id})
+        self.assertEqual(so.organizational_unit_count, 2)
+        action = so.action_view_organizational_units()
+        self.assertEqual(action["res_model"], "organizational.unit")
+        self.assertIn("list", action["view_mode"])
+        self.assertEqual(set(action["domain"][0][2]), set((ou_a | ou_b).ids))
+
+    # ------------------------------------------------------------------ #
+    # 7. Ancestry (recursion is downward; inverse climbs up)
+    # ------------------------------------------------------------------ #
+    def test_07_ancestry(self):
+        parent_company = self.Partner.create({"name": "Parent OU Co", "is_company": True})
+        p_ou = self._ou_of(parent_company)
+        child_company = self.Partner.create({"name": "Child OU Co", "is_company": True})
+        c_ou = self._ou_of(child_company)
+        c_ou.write({"parent_id": p_ou.id})
+
+        # a member of the CHILD OU only
+        member = self.Partner.create({"name": "Child Member", "is_company": True})
+        c_ou.write({"member_ids": [Command.link(member.id)]})
+
+        # forward: member is in c_ou AND (via downward recursion) in p_ou
+        self.assertIn(member, c_ou._get_all_partners())
+        self.assertIn(member, p_ou._get_all_partners())
+        # inverse returns both ancestor and direct
+        ous = member._get_organizational_units()
+        self.assertIn(c_ou, ous)
+        self.assertIn(p_ou, ous)
+        self.assertEqual(ous, self._forward_truth(member))
+
+        # negative direction: a member of the PARENT only must NOT pull in the child
+        parent_only = self.Partner.create({"name": "Parent Member", "is_company": True})
+        p_ou.write({"member_ids": [Command.link(parent_only.id)]})
+        self.assertNotIn(
+            parent_only, c_ou._get_all_partners(),
+            "Forward recursion is downward only -- parent member not in child OU.",
+        )
+        self.assertNotIn(c_ou, parent_only._get_organizational_units())
+        self.assertIn(p_ou, parent_only._get_organizational_units())
+
+    # ------------------------------------------------------------------ #
+    # 8. Form smoke + single-OU action
+    # ------------------------------------------------------------------ #
+    def test_08_form_smoke_and_single_action(self):
+        company = self.Partner.create({"name": "Form Co", "is_company": True})
+        ou = self._ou_of(company)
+        with Form(self.env["sale.order"]) as form:
+            form.partner_id = company
+            # count field is present and computed without error
+            self.assertEqual(form.organizational_unit_count, 1)
+        so = form.save()
+        action = so.action_view_organizational_units()
+        self.assertEqual(action["res_model"], "organizational.unit")
+        self.assertEqual(action["res_id"], ou.id)
+        self.assertEqual(action["view_mode"], "form")

--- a/crm_account_management/views/account_move_views.xml
+++ b/crm_account_management/views/account_move_views.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="account_move_view_form_inherit_crm_account_management" model="ir.ui.view">
+        <field name="name">account.move.form.inherit.crm.account.management</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button name="action_view_organizational_units"
+                        type="object"
+                        class="oe_stat_button"
+                        icon="fa-building-o"
+                        invisible="organizational_unit_count == 0">
+                    <field name="organizational_unit_count" widget="statinfo"
+                           string="Customer Accounts"/>
+                </button>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/crm_account_management/views/crm_lead_views.xml
+++ b/crm_account_management/views/crm_lead_views.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="crm_lead_view_form_inherit_crm_account_management" model="ir.ui.view">
+        <field name="name">crm.lead.form.inherit.crm.account.management</field>
+        <field name="model">crm.lead</field>
+        <field name="inherit_id" ref="crm.crm_lead_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button name="action_view_organizational_units"
+                        type="object"
+                        class="oe_stat_button"
+                        icon="fa-building-o"
+                        invisible="organizational_unit_count == 0">
+                    <field name="organizational_unit_count" widget="statinfo"
+                           string="Customer Accounts"/>
+                </button>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/crm_account_management/views/sale_order_views.xml
+++ b/crm_account_management/views/sale_order_views.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="sale_order_view_form_inherit_crm_account_management" model="ir.ui.view">
+        <field name="name">sale.order.form.inherit.crm.account.management</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button name="action_view_organizational_units"
+                        type="object"
+                        class="oe_stat_button"
+                        icon="fa-building-o"
+                        invisible="organizational_unit_count == 0">
+                    <field name="organizational_unit_count" widget="statinfo"
+                           string="Customer Accounts"/>
+                </button>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/crm_account_management/views/stock_picking_views.xml
+++ b/crm_account_management/views/stock_picking_views.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="stock_picking_view_form_inherit_crm_account_management" model="ir.ui.view">
+        <field name="name">stock.picking.form.inherit.crm.account.management</field>
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="stock.view_picking_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button name="action_view_organizational_units"
+                        type="object"
+                        class="oe_stat_button"
+                        icon="fa-building-o"
+                        invisible="organizational_unit_count == 0">
+                    <field name="organizational_unit_count" widget="statinfo"
+                           string="Customer Accounts"/>
+                </button>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Adds a reverse link from `sale.order`, `crm.lead`, `account.move`, and `stock.picking` back to the customer account(s) (`organizational.unit`) they belong to — the inverse of the forward dashboard actions.

**Approach (purely additive):**
- New `res.partner._get_organizational_units()` — the EXACT inverse of `organizational.unit._get_all_partners()`. Owner-match uses `parent_id` (one-level, mirroring `owner_id.child_ids`) — NOT `commercial_partner_id` — plus `member_ids`/owned, then climbs `parent_id` up the OU tree (inverse of the forward downward recursion). Invariant: `P ∈ ou._get_all_partners() ⟺ ou ∈ P._get_organizational_units()`.
- New abstract `organizational.unit.mixin` — non-stored computed `organizational_unit_ids` + count + `action_view_organizational_units` smart button (0 → hidden, 1 → form, many → filtered list). Inherited by the 4 models (all expose `partner_id`).
- Smart button in each form's button_box (4 view files); manifest registers them + version bump.

**Tests:** `tests/test_us10_reverse_links.py` — 9 tests, including a multi-level-hierarchy case asserted against the forward `_get_all_partners()` oracle (catches the commercial_partner_id over-report). Full module suite: 96 passed, 0 failed.

Shared module → upstream-first. Downstream Pneumac submodule-pointer bump follows on merge.

Bemade task #3753 (Pneumac, project 33). Branched/tested against the 18.0 line.