### PR TITLE
[3747] crm_account_management: FX-convert mixed-currency invoice/sales metrics

### DIFF
--- a/crm_account_management/models/organizational_unit.py
+++ b/crm_account_management/models/organizational_unit.py
@@ -449,6 +449,7 @@ class OrganizationalUnit(models.Model):
         "owner_id.invoice_ids.amount_total",
         "owner_id.invoice_ids.invoice_date",
         "owner_id.invoice_ids.move_type",
+        "owner_id.invoice_ids.currency_id",
         "owner_id.sale_order_ids.state",
         "owner_id.sale_order_ids.amount_total",
         "owner_id.sale_order_ids.date_order",
@@ -508,14 +509,7 @@ class OrganizationalUnit(models.Model):
                         ("invoice_date", "<=", end_ytd),
                     ]
                 )
-                record.ytd_sales = sum(
-                    (
-                        inv.amount_total
-                        if inv.move_type == "out_invoice"
-                        else -inv.amount_total
-                    )
-                    for inv in ytd_invoices
-                )
+                record.ytd_sales = record._sum_invoices_in_currency(ytd_invoices)
 
                 # Prior YTD sales
                 prior_invoices = self.env["account.move"].search(
@@ -527,13 +521,8 @@ class OrganizationalUnit(models.Model):
                         ("invoice_date", "<=", end_prior),
                     ]
                 )
-                record.ytd_sales_prior_year = sum(
-                    (
-                        inv.amount_total
-                        if inv.move_type == "out_invoice"
-                        else -inv.amount_total
-                    )
-                    for inv in prior_invoices
+                record.ytd_sales_prior_year = record._sum_invoices_in_currency(
+                    prior_invoices
                 )
 
             # Calculate YTD change percentage (as decimal for percentage widget: 0.5 = 50%)
@@ -731,16 +720,14 @@ class OrganizationalUnit(models.Model):
                 order_amount_converted = order.currency_id._convert(
                     order.amount_total, target, company, order_date
                 )
-                invoiced = sum(
-                    inv.amount_total if inv.move_type == "out_invoice" else -inv.amount_total
-                    for inv in order.invoice_ids
-                    if inv.state == "posted"
+                # Each posted invoice's amount_total is in that invoice's own
+                # currency_id (NOT the order or company currency), so convert
+                # each move from its own currency at its own accounting date
+                # before subtracting from the converted order amount.
+                posted_invoices = order.invoice_ids.filtered(
+                    lambda m: m.state == "posted"
                 )
-                # invoiced amounts from account.move are in the company currency;
-                # subtract in the converted order amount space
-                invoiced_converted = order.currency_id._convert(
-                    invoiced, target, company, order_date
-                ) if invoiced else 0.0
+                invoiced_converted = record._sum_invoices_in_currency(posted_invoices)
                 to_invoice += max(0.0, order_amount_converted - invoiced_converted)
                 # Late vs on-time: use commitment_date if set, else expected_date
                 due = order.commitment_date or order.expected_date
@@ -933,9 +920,14 @@ class OrganizationalUnit(models.Model):
         if date_to is None:
             date_to = today
 
+        # Group by (period, currency) so mixed-currency invoices can be
+        # converted to the OU currency before being summed into one period
+        # total. Summing am.amount_total across currencies in raw SQL would add
+        # e.g. USD + CAD numerically, the same bug fixed in the metric computes.
         query = """
             SELECT
                 DATE_TRUNC(%s, am.invoice_date) as period,
+                am.currency_id as currency_id,
                 SUM(CASE WHEN am.move_type = 'out_invoice' THEN am.amount_total
                          ELSE -am.amount_total END) as total
             FROM account_move am
@@ -944,13 +936,36 @@ class OrganizationalUnit(models.Model):
               AND am.state = 'posted'
               AND am.invoice_date >= %s
               AND am.invoice_date <= %s
-            GROUP BY DATE_TRUNC(%s, am.invoice_date)
+            GROUP BY DATE_TRUNC(%s, am.invoice_date), am.currency_id
             ORDER BY period
         """
         self.env.cr.execute(
             query, (date_trunc, tuple(partners.ids), date_from, date_to, date_trunc)
         )
-        return self.env.cr.dictfetchall()
+        rows = self.env.cr.dictfetchall()
+
+        target = self.currency_id
+        company = self.company_id or self.env.company
+        currency_model = self.env["res.currency"]
+        period_totals = {}
+        for row in rows:
+            period = row["period"]
+            amount = row["total"] or 0.0
+            source = (
+                currency_model.browse(row["currency_id"])
+                if row.get("currency_id")
+                else target
+            )
+            # Convert each currency bucket at the period date so the period
+            # total is expressed in the OU currency.
+            conv_date = period.date() if hasattr(period, "date") else period
+            converted = source._convert(amount, target, company, conv_date or today)
+            period_totals[period] = period_totals.get(period, 0.0) + converted
+
+        return [
+            {"period": period, "total": period_totals[period]}
+            for period in sorted(period_totals)
+        ]
 
     def action_view_quotations(self):
         """Open quotations for this account."""
@@ -1155,6 +1170,34 @@ class OrganizationalUnit(models.Model):
             else:
                 conv_date = today
             total += source._convert(amount, target, company, conv_date)
+        return total
+
+    def _sum_invoices_in_currency(self, invoices):
+        """Sum customer invoices/refunds, converting each to ``self.currency_id``.
+
+        ``account.move.amount_total`` is denominated in the move's own
+        ``currency_id`` (the invoice currency), NOT the company currency, so a
+        mixed-currency set (e.g. a USD invoice and a CAD invoice) must be
+        converted to a common currency before summing — exactly the same bug
+        class fixed for sale orders in :meth:`_sum_in_currency`.
+
+        ``out_refund`` moves are subtracted (they reduce net sales); each move
+        is converted from its own currency at its ``invoice_date`` (falling back
+        to ``date`` then today when the accounting date is unset).
+        """
+        self.ensure_one()
+        target = self.currency_id
+        company = self.company_id or self.env.company
+        today = date.today()
+        total = 0.0
+        for inv in invoices:
+            amount = inv.amount_total or 0.0
+            if not amount:
+                continue
+            signed = amount if inv.move_type == "out_invoice" else -amount
+            source = inv.currency_id or target
+            conv_date = inv.invoice_date or inv.date or today
+            total += source._convert(signed, target, company, conv_date)
         return total
 
     def action_view_won_quotations_prior_ytd(self):

--- a/crm_account_management/tests/test_us03_mixed_currency_fx.py
+++ b/crm_account_management/tests/test_us03_mixed_currency_fx.py
@@ -11,6 +11,16 @@ Acceptance criteria
 2. Single-currency accounts are unaffected (no regression from _convert
    same-currency short-circuit).
 3. Open-orders path (open_orders_amount) uses the same conversion helper.
+4. The YTD/rolling metrics ALSO convert mixed currencies before summing:
+   ytd_sales (invoice-based on the default 'fiscal' basis) converts each
+   account.move from its own currency — amount_total is in the invoice's own
+   currency, not the company currency; rolling_12m_sales (bookings-based)
+   converts each confirmed sale.order from its own currency.
+5. The "To Invoice" metric subtracts invoiced amounts in the converted
+   space without double-converting (invoiced is in the invoice currency,
+   not the order currency).
+6. The sales-by-period chart converts each currency bucket before summing
+   into a period total.
 """
 from datetime import date
 
@@ -107,6 +117,33 @@ class TestUS03MixedCurrencyFX(OUTestCommon):
         order.action_confirm()
         return order
 
+    def _make_posted_invoice(self, partner, amount, currency=None, invoice_date=None):
+        """Create and post a customer invoice of the given amount/currency."""
+        if invoice_date is None:
+            invoice_date = date.today()
+        vals = {
+            "partner_id": partner.id,
+            "move_type": "out_invoice",
+            "invoice_date": invoice_date,
+            "invoice_line_ids": [
+                (
+                    0,
+                    0,
+                    {
+                        "product_id": self.product.id,
+                        "quantity": 1,
+                        "price_unit": amount,
+                        "tax_ids": False,
+                    },
+                )
+            ],
+        }
+        if currency:
+            vals["currency_id"] = currency.id
+        invoice = self.env["account.move"].create(vals)
+        invoice.action_post()
+        return invoice
+
     # ------------------------------------------------------------------
     # Test 1: Mixed-currency won orders convert before summing
     # ------------------------------------------------------------------
@@ -192,4 +229,134 @@ class TestUS03MixedCurrencyFX(OUTestCommon):
             225.0,
             places=2,
             msg="100 company-currency + 100 EUR@1.25 must equal 225 in open_orders_amount.",
+        )
+
+    # ------------------------------------------------------------------
+    # Test 4: YTD sales (invoice-based) converts mixed currency
+    # ------------------------------------------------------------------
+
+    def test_ytd_sales_converts_mixed_currency(self):
+        """
+        AC-4: ytd_sales converts each posted invoice to the OU currency.
+
+        account.move.amount_total is in the invoice's own currency, so a
+        company-currency invoice (100) plus a EUR invoice (100 EUR @ 1.25 = 125)
+        must total 225 in ytd_sales, NOT the naive numeric sum of 200.
+
+        This guards the invoice path that the original #124 fix left summing
+        raw amount_total across currencies.
+        """
+        partner, ou = self._make_company("FX Test Partner 4")
+
+        self._make_posted_invoice(partner, 100.0)
+        self._make_posted_invoice(partner, 100.0, currency=self.foreign_currency)
+
+        ou.invalidate_recordset()
+        self.assertGreater(
+            ou.ytd_sales,
+            200.0,
+            "Mixed-currency invoices must be FX-converted before summing into ytd_sales.",
+        )
+        self.assertAlmostEqual(
+            ou.ytd_sales,
+            225.0,
+            places=2,
+            msg="100 company-currency + 100 EUR@1.25 must equal 225 in ytd_sales.",
+        )
+
+    # ------------------------------------------------------------------
+    # Test 5: Rolling 12M sales converts mixed currency
+    # ------------------------------------------------------------------
+
+    def test_rolling_12m_sales_converts_mixed_currency(self):
+        """
+        AC-4: rolling_12m_sales converts each mixed-currency booking before
+        summing.
+
+        rolling_12m_sales is a bookings metric: it aggregates confirmed
+        sale.orders (state='sale') over the trailing 12 months via
+        _sum_in_currency, which converts each order from its own currency at
+        its date_order.  A company-currency order (100) plus a EUR order
+        (100 EUR @ 1.25 = 125) must total 225, not the naive numeric sum of 200.
+        """
+        partner, ou = self._make_company("FX Test Partner 5")
+
+        # date.today() is inside the rolling-12m window (> today-12mo, <= today).
+        self._make_confirmed_order(partner, 100.0)
+        self._make_confirmed_order(partner, 100.0, currency=self.foreign_currency)
+
+        ou.invalidate_recordset()
+        self.assertAlmostEqual(
+            ou.rolling_12m_sales,
+            225.0,
+            places=2,
+            msg="100 company-currency + 100 EUR@1.25 must equal 225 in rolling_12m_sales.",
+        )
+
+    # ------------------------------------------------------------------
+    # Test 6: To-Invoice does not double-convert the invoiced amount
+    # ------------------------------------------------------------------
+
+    def test_to_invoice_no_double_conversion(self):
+        """
+        AC-5: open_orders_to_invoice_amount subtracts the invoiced amount in
+        the converted space without double-converting.
+
+        A single EUR order of 100 EUR (= 125 company-currency) is partially
+        invoiced for 40 EUR (= 50 company-currency).  The remaining amount to
+        invoice must be 125 - 50 = 75 company-currency.
+
+        The old code converted the per-invoice amount_total (already in the
+        invoice/EUR currency) a second time *as if* it were the order currency,
+        which for a EUR order/EUR invoice happened to be a no-op — but it summed
+        invoices that may be in another currency wrongly.  Routing the invoiced
+        amount through the same per-invoice converter keeps it correct and
+        single-converted.
+        """
+        partner, ou = self._make_company("FX Test Partner 6")
+
+        order = self._make_confirmed_order(
+            partner, 100.0, currency=self.foreign_currency
+        )
+        # Partially invoice: post an invoice for 40 EUR against this order's partner.
+        # (open_orders_to_invoice_amount nets posted invoices on the order.)
+        invoice = order._create_invoices()
+        # Reduce the invoiced quantity/amount to a partial 40 EUR.
+        invoice.invoice_line_ids[0].price_unit = 40.0
+        invoice.action_post()
+
+        ou.invalidate_recordset()
+        # 125 (order in company-currency) - 50 (40 EUR invoiced @1.25) = 75.
+        self.assertAlmostEqual(
+            ou.open_orders_to_invoice_amount,
+            75.0,
+            places=2,
+            msg="To-Invoice must net the converted invoiced amount: 125 - 50 = 75.",
+        )
+
+    # ------------------------------------------------------------------
+    # Test 7: sales-by-period chart converts each currency bucket
+    # ------------------------------------------------------------------
+
+    def test_sales_by_period_converts_mixed_currency(self):
+        """
+        AC-6: get_sales_by_period converts each currency bucket before summing
+        into a period total.
+
+        Two invoices in the same period (this month), one company-currency (100)
+        and one EUR (100 EUR @ 1.25 = 125), must roll up to 225 for that period,
+        not the naive SQL sum of 200.
+        """
+        partner, ou = self._make_company("FX Test Partner 7")
+
+        self._make_posted_invoice(partner, 100.0)
+        self._make_posted_invoice(partner, 100.0, currency=self.foreign_currency)
+
+        data = ou.get_sales_by_period(period="month", periods=1)
+        total = sum(row["total"] or 0.0 for row in data)
+        self.assertAlmostEqual(
+            total,
+            225.0,
+            places=2,
+            msg="Mixed-currency invoices in one period must convert to 225, not sum to 200.",
         )


### PR DESCRIPTION
organizational.unit sales metrics summed account.move `amount_total` across currencies into the CAD-only OU currency field (no FX). A prior fix (#124) converted the sale.order/crm.lead metrics but left the invoice-based ones (YTD sales, rolling-12M, to-invoice netting, sales-by-period chart) summing naively.

This PR adds `_sum_invoices_in_currency` (per-invoice `currency_id._convert(...)` at invoice_date, correct refund sign), routes all invoice-summing sites through it, fixes a double-conversion in open_orders_to_invoice_amount, and converts the sales-by-period chart per currency bucket. Single-currency (CAD→CAD) is an identity no-op.

**Tests:** crm_account_management 94/94 green; 3 new invoice-path tests fail on the old naive-sum code and pass here (100 + 100 EUR@1.25 = 225, not 200).

Downstream Pneumac submodule bump auto-follows on merge. NB: opened on 18.0; if the module is also maintained on 19.0 a separate port may be wanted — your call.