### PR TITLE
[3422] bemade_mail_follower_cc: drop stray 'Undisclosed recipients' email on queue send

### DIFF
--- a/bemade_mail_follower_cc/models/mail_mail.py
+++ b/bemade_mail_follower_cc/models/mail_mail.py
@@ -15,6 +15,39 @@ class MailMail(models.Model):
             mail_server=mail_server,
             recipients_follower_status=recipients_follower_status,
         )
+
+        # Drop the stray "Undisclosed recipients" email.
+        #
+        # When a Cc is set on the mail (e.g. mail_composer_cc_bcc puts the
+        # composer's manual Cc partners into mail.email_cc) but the mail has no
+        # mail.email_to, core's _prepare_outgoing_list emits an extra entry with
+        # an EMPTY To and only a Cc (see odoo commit 46bad8f0) — the email
+        # client then renders "Undisclosed recipients" in the To field.
+        # mail_composer_cc_bcc removes that entry, but only on the inline
+        # composer send path (its pop is gated on the is_from_composer context),
+        # so the stray entry survives whenever the mail is sent from the queue /
+        # cron (a fresh mail.mail recordset where that context is gone).
+        # Strip it here, but only when every Cc-only recipient already has its
+        # own personalised To entry, so no recipient loses their delivery.
+        # SMTP envelope recipients (RCPT TO) of the entries that DO have a To.
+        deliver_to = set()
+        for entry in res:
+            if entry.get("email_to"):
+                deliver_to.update(entry.get("email_to_normalized") or [])
+        kept = []
+        for entry in res:
+            # The stray entry has no To header at all; its SMTP recipients live
+            # in email_to_normalized (derived by core from mail.email_cc).
+            if not entry.get("email_to"):
+                stray_rcpts = set(entry.get("email_to_normalized") or [])
+                if stray_rcpts and stray_rcpts <= deliver_to:
+                    # Every recipient of this Cc-only entry already receives a
+                    # personalised To email — the entry is redundant. Drop it so
+                    # no "Undisclosed recipients" email goes out.
+                    continue
+            kept.append(entry)
+        res = kept
+
         if not self.email_cc_display_only:
             return res
 

--- a/bemade_mail_follower_cc/tests/__init__.py
+++ b/bemade_mail_follower_cc/tests/__init__.py
@@ -2,3 +2,4 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 from . import test_mail_follower_cc
+from . import test_composer_cc_no_stray

--- a/bemade_mail_follower_cc/tests/test_composer_cc_no_stray.py
+++ b/bemade_mail_follower_cc/tests/test_composer_cc_no_stray.py
@@ -1,0 +1,155 @@
+# -*- coding: utf-8 -*-
+# Copyright 2025 Bemade Inc.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+"""Case 2 (task #3422): a composer send with a manual Cc must not produce a
+stray "Undisclosed recipients" email (empty To header, only a Cc).
+
+The defect only surfaces when the queued mail is actually delivered from the
+queue / cron — a fresh ``mail.mail`` recordset on which the transient composer's
+``is_from_composer`` context no longer exists, so ``mail_composer_cc_bcc`` skips
+the de-duplication that removes core's Cc-only "Undisclosed recipients" entry
+(core ``mail.mail._prepare_outgoing_list`` adds it because ``mail.email_cc`` is
+set while ``mail.email_to`` is empty). These tests reproduce that delivery path
+and assert the stray email is gone while every recipient is still delivered to.
+"""
+from odoo.addons.mail.tests.common import MailCommon, mail_new_test_user
+from odoo.tests import tagged
+from odoo.tools import mute_logger
+from odoo.tools.mail import email_normalize
+
+
+@tagged("post_install", "-at_install", "bemade_mail_follower_cc")
+class TestComposerCcNoStray(MailCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.composer_cc_installed = bool(
+            cls.env["ir.module.module"].search([
+                ("name", "=", "mail_composer_cc_bcc"),
+                ("state", "=", "installed"),
+            ])
+        )
+        cls.author = mail_new_test_user(
+            cls.env, login="cc_author", name="Author",
+            email="author@test.example.com",
+            groups="base.group_user,base.group_partner_manager",
+            notification_type="email",
+        )
+        # Two EXTERNAL followers (no user -> customer notification by email).
+        cls.ext1 = cls.env["res.partner"].create({
+            "name": "External One", "email": "ext1@customer.example.com",
+        })
+        cls.ext2 = cls.env["res.partner"].create({
+            "name": "External Two", "email": "ext2@customer.example.com",
+        })
+        # The manually-added Cc partner (Marc's noilish@gmail.com analogue).
+        cls.manual_cc = cls.env["res.partner"].create({
+            "name": "Manual Cc", "email": "manualcc@external.example.com",
+        })
+
+    def _make_record(self):
+        rec = self.env["res.partner"].create({
+            "name": "Thread Record", "email": "thread@test.example.com",
+        })
+        rec.message_subscribe(partner_ids=[self.ext1.id, self.ext2.id])
+        return rec
+
+    def _deliver_from_queue(self, record, manual_cc=True):
+        """Post via the composer, then deliver from a FRESH mail.mail recordset
+        (the queue / cron path), capturing each outgoing email at build_email.
+        Returns the list of captured outgoing emails for this message."""
+        vals = {"body": "<p>Case test</p>", "subject": "CaseX"}
+        if manual_cc:
+            vals["partner_cc_ids"] = [(6, 0, [self.manual_cc.id])]
+        composer = self.env["mail.compose.message"].with_user(self.author).with_context(
+            default_model="res.partner",
+            default_res_ids=record.ids,
+            default_partner_ids=[(6, 0, [self.ext1.id, self.ext2.id])],
+        ).create(vals)
+        with self.mock_mail_gateway():
+            composer._action_send_mail()
+        mails = self.env["mail.mail"].sudo().search(
+            [("mail_message_id", "in", record.message_ids.ids)]
+        )
+        self.assertTrue(mails, "no mail.mail created")
+        # Re-queue and deliver from a fresh recordset -> drops the composer ctx,
+        # exactly like the real outgoing-mail cron does.
+        mails.write({"state": "outgoing"})
+        fresh = self.env["mail.mail"].sudo().browse(mails.ids)
+        with self.mock_mail_gateway():
+            fresh.send()
+            return list(self._mails)
+
+    @mute_logger("odoo.addons.mail.models.mail_mail", "odoo.models.unlink")
+    def test_no_undisclosed_email_on_queue_send(self):
+        """No outgoing email may have an empty To header (Undisclosed recipients)."""
+        if not self.composer_cc_installed:
+            self.skipTest("mail_composer_cc_bcc not installed")
+
+        sent = self._deliver_from_queue(self._make_record())
+        self.assertTrue(sent, "no emails were sent")
+        for mail in sent:
+            self.assertTrue(
+                mail.get("email_to"),
+                "Stray 'Undisclosed recipients' email: an outgoing email has "
+                "an empty To header. email_to=%r email_cc=%r"
+                % (mail.get("email_to"), mail.get("email_cc")),
+            )
+
+    @mute_logger("odoo.addons.mail.models.mail_mail", "odoo.models.unlink")
+    def test_all_recipients_still_delivered(self):
+        """Stripping the stray entry must not lose the manual Cc recipient:
+        the 2 externals AND the manual Cc partner each still get exactly one
+        email addressed To them."""
+        if not self.composer_cc_installed:
+            self.skipTest("mail_composer_cc_bcc not installed")
+
+        sent = self._deliver_from_queue(self._make_record())
+        expected = {
+            email_normalize(self.ext1.email),
+            email_normalize(self.ext2.email),
+            email_normalize(self.manual_cc.email),
+        }
+        delivered = set()
+        for mail in sent:
+            for addr in (mail.get("email_to") or []):
+                n = email_normalize(addr)
+                if n:
+                    delivered.add(n)
+        self.assertEqual(
+            delivered, expected,
+            "Every recipient (2 externals + manual Cc) must still receive a "
+            "personalised email. delivered=%r" % (delivered,),
+        )
+        self.assertEqual(
+            len(sent), len(expected),
+            "Expected exactly one email per recipient (%d), got %d: %r"
+            % (len(expected), len(sent),
+               [(m.get("email_to"), m.get("email_cc")) for m in sent]),
+        )
+
+    @mute_logger("odoo.addons.mail.models.mail_mail", "odoo.models.unlink")
+    def test_case1_followers_only_unaffected(self):
+        """Case 1 (no manual composer Cc): no email_cc is set on the mail, so
+        core never creates a Cc-only entry — the strip must be a no-op and each
+        follower still gets exactly one personalised email."""
+        if not self.composer_cc_installed:
+            self.skipTest("mail_composer_cc_bcc not installed")
+
+        sent = self._deliver_from_queue(self._make_record(), manual_cc=False)
+        expected = {
+            email_normalize(self.ext1.email),
+            email_normalize(self.ext2.email),
+        }
+        delivered = set()
+        for mail in sent:
+            self.assertTrue(
+                mail.get("email_to"),
+                "Case 1 produced an empty-To email: %r" % (mail,),
+            )
+            for addr in (mail.get("email_to") or []):
+                n = email_normalize(addr)
+                if n:
+                    delivered.add(n)
+        self.assertEqual(delivered, expected)


### PR DESCRIPTION
Fixes Case 2 (composer send + manual Cc): the queue/cron delivery path emitted an extra email with empty To ("Undisclosed recipients"). Root cause: core `mail.mail._prepare_outgoing_list` appends a Cc-only entry with empty email_to when email_cc is set; OCA `mail_composer_cc_bcc` strips it ONLY when `is_from_composer` is in context (inline send), so on the queue path (fresh recordset, no composer context) the stray survives and is sent.

Fix: in this module's `_prepare_outgoing_list` override, drop any empty-To entry whose SMTP recipients (`email_to_normalized`) are already covered by another entry's personalised To — removing the stray with a provable no-recipient-loss guarantee (a genuinely Cc-only recipient with no matching To entry is kept).

**How to test (staging.durpro.com, mailpit; basic-auth = odoo-dev admin creds):** on picking 57121, Case 2 = send via composer with noilish@gmail.com in Cc → 3 emails, none 'Undisclosed', noilish receives one; re-confirm Case 1 (followers-only) still shows 2 clean emails.

**Tests:** bemade_mail_follower_cc 8/8 (3 new reproduce the queue/cron path), mail_composer_cc_bcc 7/7 (no inline regression).

Downstream Durpro submodule bump auto-follows on merge. Notes for you: (1) the cleaner long-term home is an OCA patch to mail_composer_cc_bcc (its pop is context-gated) — upstreamable; (2) Durpro is mid 18→19 migration — if this module is maintained on bemade-addons 19.0, a companion 19.0 port may be wanted.