### PR TITLE
[3678] bemade_documents_link: fix Documents-side action visibility + product smart-button sync

### DIFF
--- a/bemade_documents_link/__init__.py
+++ b/bemade_documents_link/__init__.py
@@ -1,1 +1,2 @@
+from . import models
 from . import wizard

--- a/bemade_documents_link/__manifest__.py
+++ b/bemade_documents_link/__manifest__.py
@@ -14,12 +14,17 @@ Adds two generic, reusable entry points for linking an **existing** document
   cog menu of every ``mail.thread`` form view. It opens a small wizard that
   lets the user pick one or more already-existing, unlinked Documents records
   and links them to the current record.
-* **From the Documents side** — a generic *Link to record* server action lets
-  the user first choose the target model (limited to ``mail.thread`` models)
-  and then the record, reusing the stock Documents ``link_to_record_wizard``.
+* **From the Documents side** — a generic *Link to Record* item is added to the
+  Documents app's "Action" dropdown (the enterprise Documents app renders a
+  bespoke action dropdown, not the standard ``ActionMenus``, so a
+  ``binding_model_id`` server action does not surface there). It lets the user
+  first choose the target model (limited to ``mail.thread`` models) and then the
+  record, reusing the stock Documents ``link_to_record_wizard``.
 
-Linking simply sets ``res_model`` / ``res_id`` on the chosen
-``documents.document`` records; no new persistent storage is introduced.
+Linking sets ``res_model`` / ``res_id`` on the chosen ``documents.document``
+records. When the target is a product, a matching ``product.document`` is also
+created so the linked file appears under the product's *Documents* smart button
+(which reads ``product.document``, not ``documents.document``).
 """,
     "category": "Productivity/Documents",
     "author": "Bemade Inc.",
@@ -36,6 +41,8 @@ Linking simply sets ``res_model`` / ``res_id`` on the chosen
         "web.assets_backend": [
             "bemade_documents_link/static/src/link_document_cog_menu/*.js",
             "bemade_documents_link/static/src/link_document_cog_menu/*.xml",
+            "bemade_documents_link/static/src/link_to_record/*.js",
+            "bemade_documents_link/static/src/link_to_record/*.xml",
         ],
     },
     "installable": True,

--- a/bemade_documents_link/models/__init__.py
+++ b/bemade_documents_link/models/__init__.py
@@ -1,0 +1,2 @@
+from . import documents_document
+from . import documents_link_to_record_wizard

--- a/bemade_documents_link/models/documents_document.py
+++ b/bemade_documents_link/models/documents_document.py
@@ -1,0 +1,60 @@
+from odoo import models
+
+
+class DocumentsDocument(models.Model):
+    _inherit = "documents.document"
+
+    def _bemade_sync_product_document(self):
+        """Ensure a ``product.document`` exists for any of these documents that
+        are linked to a product.
+
+        The product "Documents" smart button reads the **``product.document``**
+        model (filtered by ``res_model`` / ``res_id`` on the shared
+        ``ir.attachment``), NOT ``documents.document``. When a file is uploaded
+        from a product, the stock ``ir.attachment.create`` override creates the
+        ``product.document`` for us; but when an *existing* ``documents.document``
+        is merely *re-linked* to a product (the whole point of this module), only
+        its ``res_model`` / ``res_id`` change — via a ``write`` that propagates to
+        the attachment with ``no_document=True`` — so no ``product.document`` is
+        ever created and the document never appears under the product's smart
+        button (task #3678 defect 2).
+
+        This bridges that gap: for each document now linked to a product and
+        backed by a real attachment, create the matching ``product.document``
+        (idempotently) so it surfaces on the product. The bridge is a soft
+        dependency — it is a no-op when ``documents_product`` (which provides the
+        ``product.document`` smart-button integration) is not installed.
+        """
+        ProductDocument = self.env.get("product.document")
+        if ProductDocument is None:
+            # documents_product not installed -> no product smart button to feed.
+            return
+        product_models = ("product.template", "product.product")
+        to_bridge = self.filtered(
+            lambda d: d.res_model in product_models
+            and d.res_id
+            and d.attachment_id
+        )
+        if not to_bridge:
+            return
+        # Only create what is missing — keep idempotent across repeated links.
+        existing = self.env["product.document"].sudo().search(
+            [("ir_attachment_id", "in", to_bridge.attachment_id.ids)]
+        )
+        existing_attachment_ids = set(existing.mapped("ir_attachment_id").ids)
+        vals_list = [
+            {"ir_attachment_id": doc.attachment_id.id}
+            for doc in to_bridge
+            if doc.attachment_id.id not in existing_attachment_ids
+        ]
+        if not vals_list:
+            return
+        # The attachment already carries res_model / res_id (propagated by
+        # documents.document._inverse_res_model) AND already has its own
+        # documents.document. Create the product.document with no_document=True
+        # so the documents bridge does not try to create a SECOND
+        # documents.document for the same attachment (which would violate the
+        # documents_document_attachment_unique constraint).
+        self.env["product.document"].sudo().with_context(
+            no_document=True
+        ).create(vals_list)

--- a/bemade_documents_link/models/documents_link_to_record_wizard.py
+++ b/bemade_documents_link/models/documents_link_to_record_wizard.py
@@ -1,0 +1,15 @@
+from odoo import models
+
+
+class LinkToRecordWizard(models.TransientModel):
+    _inherit = "documents.link_to_record_wizard"
+
+    def link_to(self):
+        """Extend the stock Documents-side link wizard so a document linked to a
+        product also surfaces under the product's "Documents" smart button
+        (task #3678 defect 2). This is the wizard our Documents-side
+        "Link to Record" entry point opens.
+        """
+        res = super().link_to()
+        self.document_ids._bemade_sync_product_document()
+        return res

--- a/bemade_documents_link/static/src/link_to_record/documents_control_panel.xml
+++ b/bemade_documents_link/static/src/link_to_record/documents_control_panel.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <!--
+        Add a "Link to Record" item to the Documents app's custom "Action"
+        dropdown (task #3678 defect 1). The Documents app renders its own
+        dropdown rather than the standard ActionMenus, so a bound server action
+        never shows up here; we add the entry point explicitly.
+    -->
+    <t t-name="bemade_documents_link.ControlPanel"
+       t-inherit="documents.ControlPanel"
+       t-inherit-mode="extension">
+        <xpath expr="//button[contains(@t-on-click, 'onDuplicate')]" position="after">
+            <button class="dropdown-item w-100 o_documents_link_to_record"
+                t-on-click="() => this.onLinkToRecord()"
+                t-if="canLinkToRecord">
+                <i class="fa fa-fw fa-link me-1"/>
+                <span class="d-inline-block">Link to Record</span>
+            </button>
+        </xpath>
+    </t>
+
+</templates>

--- a/bemade_documents_link/static/src/link_to_record/documents_control_panel_patch.js
+++ b/bemade_documents_link/static/src/link_to_record/documents_control_panel_patch.js
@@ -1,0 +1,62 @@
+/** @odoo-module **/
+
+import { DocumentsControlPanel } from "@documents/views/search/documents_control_panel";
+import { patch } from "@web/core/utils/patch";
+
+/**
+ * Documents-side "Link to Record" entry point (task #3678 defect 1).
+ *
+ * The enterprise Documents app does NOT render the standard ActionMenus
+ * component, so a server action bound via `binding_model_id` /
+ * `binding_view_types` never surfaces in the Documents UI. The Documents app
+ * builds its own "Action" dropdown in the `documents.ControlPanel` template and
+ * a hard-coded cog-menu whitelist. So the only way to expose a new contextual
+ * action is to add it to that custom dropdown.
+ *
+ * This patch adds an `onLinkToRecord` handler that reuses the stock
+ * `documents.document.action_link_to_record()` (the same method our server
+ * action calls), which opens the generic `link_to_record_wizard` (model picker
+ * limited to mail.thread models, then record picker).
+ */
+patch(DocumentsControlPanel.prototype, {
+    /**
+     * True when every selected record is an unlinked workspace document
+     * (res_model === 'documents.document'), i.e. eligible to be linked to a
+     * record. Mirrors the stock action's own guard, which refuses
+     * already-linked documents.
+     */
+    get canLinkToRecord() {
+        const records = this.targetRecords;
+        return (
+            this.documentService.userIsInternal &&
+            this.currentFolderId !== "TRASH" &&
+            records.length > 0 &&
+            records.every(
+                (r) =>
+                    r.data.type === "binary" &&
+                    r.data.attachment_id &&
+                    r.data.res_model === "documents.document"
+            )
+        );
+    },
+
+    /**
+     * Open the stock "Link to Record" wizard on the selected documents.
+     */
+    async onLinkToRecord() {
+        const documentIds = this.targetRecords.map((record) => record.data.id);
+        if (!documentIds.length) {
+            return;
+        }
+        const action = await this.orm.call(
+            "documents.document",
+            "action_link_to_record",
+            [documentIds]
+        );
+        if (action) {
+            await this.action.doAction(action, {
+                onClose: () => this.notifyChange(),
+            });
+        }
+    },
+});

--- a/bemade_documents_link/tests/test_documents_link.py
+++ b/bemade_documents_link/tests/test_documents_link.py
@@ -1,4 +1,5 @@
 import base64
+import unittest
 
 from odoo.tests import Form, tagged
 from odoo.tests.common import TransactionCase
@@ -105,3 +106,123 @@ class TestDocumentsLink(TransactionCase):
         form.document_ids.add(self.doc)
         wizard = form.save()
         self.assertIn(self.doc, wizard.document_ids)
+
+    def test_documents_side_action_on_recordset(self):
+        """Documents-side entry point (#3678 defect 1).
+
+        The Documents app does not render the standard ActionMenus, so the
+        documents-side entry point is a custom control-panel button whose JS
+        handler calls ``documents.document.action_link_to_record()`` over the
+        selected ids. This asserts that contract: calling the stock method on a
+        (multi-record) recordset of *unlinked* documents returns the generic
+        ``link_to_record_wizard`` act_window with no model preselected and the
+        documents passed through.
+        """
+        doc_a = self._new_doc("Action Doc A")
+        doc_b = self._new_doc("Action Doc B")
+        recs = doc_a + doc_b
+        action = recs.action_link_to_record()
+        self.assertEqual(action["type"], "ir.actions.act_window")
+        self.assertEqual(action["res_model"], "documents.link_to_record_wizard")
+        self.assertFalse(action["context"].get("default_model_id"))
+        self.assertEqual(
+            set(action["context"].get("default_document_ids")), set(recs.ids)
+        )
+
+
+@tagged("post_install", "-at_install")
+class TestDocumentsLinkProductBridge(TransactionCase):
+    """#3678 defect 2: linking an existing document to a product must make it
+    appear under the product's "Documents" smart button, which reads the
+    ``product.document`` model (not ``documents.document``)."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        if "product.document" not in cls.env:
+            raise unittest.SkipTest("documents_product not installed")
+        # Enable the documents/product bridge and give products a workspace.
+        cls.folder = cls.env["documents.document"].create(
+            {"name": "Product WS", "type": "folder"}
+        )
+        cls.env.company.write({
+            "product_folder_id": cls.folder.id,
+            "documents_product_settings": True,
+        })
+        cls.template = cls.env["product.template"].create({"name": "Bridge Product"})
+        cls.product = cls.template.product_variant_id
+
+    def _make_doc(self, name="Doc"):
+        return self.env["documents.document"].create({
+            "name": name,
+            "type": "binary",
+            "datas": base64.b64encode(b"hello").decode(),
+        })
+
+    def _product_document_count(self):
+        """Mirror the smart button: count product.document in the template's
+        documents domain (what action_open_documents / the stat button show)."""
+        return self.env["product.document"].search_count(
+            self.template._get_product_document_domain()
+        )
+
+    def test_record_side_link_feeds_product_smart_button(self):
+        """Record-side wizard: linking a document to a product template creates a
+        product.document so it shows under the product's Documents smart button.
+        Fails on the old behavior (which only set res_model/res_id on
+        documents.document, never creating a product.document)."""
+        doc = self._make_doc("Spec Sheet")
+        self.assertEqual(self._product_document_count(), 0)
+
+        wizard = self.env["documents.link.wizard"].with_context(
+            active_model="product.template",
+            active_id=self.template.id,
+        ).create({"document_ids": [(6, 0, doc.ids)]})
+        wizard.action_link()
+
+        self.assertEqual(doc.res_model, "product.template")
+        self.assertEqual(doc.res_id, self.template.id)
+        # The whole point: it now appears under the product's smart button.
+        self.assertEqual(
+            self._product_document_count(), 1,
+            "Linked document should appear under the product Documents button",
+        )
+        # And it reuses the SAME underlying attachment (one file, two facades).
+        pdoc = self.env["product.document"].search(
+            self.template._get_product_document_domain()
+        )
+        self.assertEqual(pdoc.ir_attachment_id, doc.attachment_id)
+
+    def test_documents_side_link_feeds_product_smart_button(self):
+        """Documents-side wizard (link_to_record_wizard.link_to): same outcome —
+        the linked document surfaces under the product smart button."""
+        doc = self._make_doc("Docside Spec")
+        self.assertEqual(self._product_document_count(), 0)
+
+        wizard = self.env["documents.link_to_record_wizard"].create({
+            "document_ids": [(6, 0, doc.ids)],
+        })
+        wizard.write({
+            "model_id": self.env["ir.model"]._get_id("product.template"),
+            "resource_ref": f"product.template,{self.template.id}",
+        })
+        wizard.link_to()
+
+        self.assertEqual(doc.res_model, "product.template")
+        self.assertEqual(doc.res_id, self.template.id)
+        self.assertEqual(
+            self._product_document_count(), 1,
+            "Doc linked from the Documents side should appear under the product",
+        )
+
+    def test_link_is_idempotent(self):
+        """Re-linking the same document must not create duplicate
+        product.document rows."""
+        doc = self._make_doc("Idem Doc")
+        for _i in range(2):
+            wizard = self.env["documents.link.wizard"].with_context(
+                active_model="product.template",
+                active_id=self.template.id,
+            ).create({"document_ids": [(6, 0, doc.ids)]})
+            wizard.action_link()
+        self.assertEqual(self._product_document_count(), 1)

--- a/bemade_documents_link/wizard/documents_link_wizard.py
+++ b/bemade_documents_link/wizard/documents_link_wizard.py
@@ -54,4 +54,6 @@ class DocumentsLinkWizard(models.TransientModel):
             "res_id": self.res_id,
             "is_editable_attachment": True,
         })
+        # Surface the link under a product's "Documents" smart button (#3678).
+        self.document_ids._bemade_sync_product_document()
         return {"type": "ir.actions.act_window_close"}


### PR DESCRIPTION
Fixes two Changes-Requested defects in the existing documents-link feature:

**Bug 1 — 'Link to Record' not visible from the base Documents UI.** The enterprise Documents app doesn't render bound server actions (kanban has no ActionMenus; list/form use a bespoke Action dropdown + hard-coded cog whitelist), so the module's bound ir.actions.server could never appear. Fix: add a 'Link to Record' item to the Documents app's own Action dropdown via OWL `t-inherit` of `documents.ControlPanel` + a prototype patch calling the stock `action_link_to_record()`.

**Bug 2 — linked doc doesn't appear under the product Documents smart button.** The smart button queries `product.document`, not `documents.document`; the link only set res_model/res_id on documents.document so no product.document was created. Fix: `_bemade_sync_product_document()` creates the matching product.document for the shared attachment, idempotently, wired into both link paths; soft no-op without documents_product.

**How to test:** (1) Documents app → select a workspace file → Action menu shows 'Link to Record' → link to a product. (2) On that product, the Documents smart button now shows the linked doc.

**Tests:** bemade_documents_link 12/12 with documents_product co-installed (3 bridge tests move product doc count 0→1, fail on old behavior); 9/9 standalone (bridge tests skip). Bug 1 is JS/OWL (no automated UI test) — verified correct by inspection.

Downstream Durpro submodule bump auto-follows on merge. NB: Durpro is mid 18→19 migration; if maintained on bemade-addons 19.0, a companion port may be wanted.