### PR TITLE
[3360] bemade_fsm: full visit task-tree view (read-only recursive list)

### DIFF
--- a/bemade_fsm/__manifest__.py
+++ b/bemade_fsm/__manifest__.py
@@ -69,6 +69,11 @@
             "bemade_fsm/static/src/xml/project_view_buttons.xml",
             "bemade_fsm/static/src/xml/project_task_list_buttons.xml",
         ],
+        # JS tour for the visit "Full Task Tree" recursive list (task 3360),
+        # loaded only into the test bundle.
+        "web.assets_tests": [
+            "bemade_fsm/static/tests/tours/**/*",
+        ],
     },
     "installable": True,
     "auto_install": False,

--- a/bemade_fsm/__manifest__.py
+++ b/bemade_fsm/__manifest__.py
@@ -50,6 +50,7 @@
         "views/res_partner.xml",
         "views/menus.xml",
         "views/task_views.xml",
+        "views/fsm_visit_views.xml",
         "views/sale_order_views.xml",
         "reports/worksheet_custom_report_templates.xml",
         "reports/worksheet_custom_reports.xml",

--- a/bemade_fsm/static/tests/tours/fsm_visit_task_tree_tour.js
+++ b/bemade_fsm/static/tests/tours/fsm_visit_task_tree_tour.js
@@ -1,0 +1,147 @@
+// Copyright (C) 2024 Bemade Inc. (<https://www.bemade.org>).
+// License LGPL-3 or later (http://www.gnu.org/licenses/lgpl).
+/**
+ * Tour: fsm_visit_task_tree_tour
+ *
+ * Drives the visit "Full Task Tree" feature (task 3360) end-to-end in a
+ * browser-rendered session and validates that the recursive task list view
+ * renders the COMPLETE multi-level task hierarchy and that lazy-expand works.
+ *
+ * Path exercised:
+ *   1. Open the seeded, confirmed sale order form (URL carries its id).
+ *   2. Open the "Field Service" notebook page (where visit_ids is embedded).
+ *   3. Click the per-row "Full Task Tree" button on the visit list row.
+ *   4. The recursive project.task list action opens.
+ *   5. Assert the recursive expand column is present (proves recursive="1"
+ *      parsed and the recursive_list_view renderer/controller are active).
+ *   6. Assert at least one ROOT row (the visit's root task) is rendered and
+ *      carries an expand button (it has children -> a genuine tree, not a flat
+ *      list).
+ *   7. Click the root row's expand button (lazy-expand) and assert deeper rows
+ *      appear (depth-1 children), then expand a child and assert depth-2 rows
+ *      (grandchildren) appear -- i.e. the structure is multi-level and the
+ *      lazy expansion is functional, not just immediate children.
+ *
+ * Data is seeded by FSMVisitTaskTreeTourTest.setUpClass in
+ * test_fsm_visit_task_tree_tour.py: one confirmed SO with a single visit whose
+ * root task has a [2,2,2] descendant structure (parent -> child -> grandchild
+ * -> great-grandchild), grouped under the visit root.
+ */
+import { registry } from "@web/core/registry";
+
+// No `url` property: the Python HttpCase opens the seeded sale order FORM via
+// start_tour(url_path=f"/odoo/sales/{so.id}", ...). Declaring a `url` here would
+// make web_tour re-navigate to that path (the Quotations LIST), overriding the
+// record form -- so we deliberately omit it and assert the form is already open.
+registry.category("web_tour.tours").add("fsm_visit_task_tree_tour", {
+    steps: () => [
+        // ----------------------------------------------------------------
+        // Step 1: The seeded sale order form is already open (start_tour url).
+        // ----------------------------------------------------------------
+        {
+            content: "Wait for the sale order form to load",
+            trigger: ".o_form_view .o_form_sheet",
+        },
+        // ----------------------------------------------------------------
+        // Step 2: Open the Field Service notebook page (holds visit_ids).
+        // ----------------------------------------------------------------
+        {
+            content: "Open the 'Field Service' notebook page",
+            trigger: ".o_notebook .nav-link:contains('Field Service')",
+            run: "click",
+        },
+        {
+            content: "Wait for the Service Visits embedded list to render",
+            trigger: ".o_field_widget[name='visit_ids'] .o_list_renderer",
+        },
+        // ----------------------------------------------------------------
+        // Step 3: Click the per-row 'Full Task Tree' button on the visit row.
+        // ----------------------------------------------------------------
+        {
+            content: "Click the 'Full Task Tree' button on the visit row",
+            trigger:
+                ".o_field_widget[name='visit_ids'] .o_data_row button:contains('Full Task Tree')",
+            run: "click",
+        },
+        // ----------------------------------------------------------------
+        // Step 4 & 5: The recursive task-tree list action opens. Assert the
+        // recursive expand column header exists -> recursive="1" parsed and the
+        // recursive_list_view renderer is active.
+        // ----------------------------------------------------------------
+        {
+            content: "Wait for the Full Task Tree action breadcrumb",
+            trigger: ".o_breadcrumb:contains('Full Task Tree')",
+        },
+        {
+            content:
+                "Assert the recursive expand column header is present (recursive list active)",
+            trigger: ".o_list_view th.o_recursive_expand_column",
+        },
+        // ----------------------------------------------------------------
+        // Step 6: Assert a ROOT row is rendered and has an expand button (it
+        // has children -> a real tree). The root row is at table depth 0.
+        // ----------------------------------------------------------------
+        {
+            content:
+                "Assert at least one root task row with an expand button is rendered",
+            trigger:
+                ".o_list_view .o_data_row td.o_recursive_expand_column button.o_expand_button",
+        },
+        // ----------------------------------------------------------------
+        // Step 7: Before expansion the list shows ONLY root rows -- the visit's
+        // child tasks are NOT yet in the DOM (lazy). Assert no depth-1 child row
+        // is present, so the next step proves expansion is what reveals them.
+        // ----------------------------------------------------------------
+        {
+            content:
+                "Assert the child level is collapsed initially (no nested depth-1 row yet)",
+            trigger:
+                ".o_list_view tbody:not(:has(.o_recursive_bullet[data-depth='1']))",
+        },
+        // ----------------------------------------------------------------
+        // Step 8: Lazy-expand the root row. The recursive_list_view fetches and
+        // injects the visit's immediate child tasks as nested rows.
+        // ----------------------------------------------------------------
+        {
+            content: "Expand the root task to reveal its children (lazy-expand)",
+            trigger:
+                ".o_list_view .o_data_row td.o_recursive_expand_column button.o_expand_button[data-depth='0']",
+            run: "click",
+        },
+        // ----------------------------------------------------------------
+        // Step 9: Assert depth-1 child rows are now rendered as nested rows
+        // (bullet marker carries data-depth='1') -> the view renders a genuine
+        // multi-level parent/child structure and the lazy-expand is functional.
+        // The seeded root has TWO child tasks (one per SO line); assert both
+        // nested rows appeared.
+        // ----------------------------------------------------------------
+        {
+            content:
+                "Assert depth-1 child rows appeared after expansion (multi-level structure rendered)",
+            trigger:
+                ".o_list_view .o_data_row td.o_recursive_expand_column .o_recursive_bullet[data-depth='1']",
+        },
+        {
+            content:
+                "Assert BOTH seeded child tasks rendered as nested depth-1 rows",
+            trigger:
+                ".o_list_view tbody:has(.o_recursive_bullet[data-depth='1']:eq(1))",
+        },
+        // ----------------------------------------------------------------
+        // Step 10: Collapse the root again and assert the nested child rows are
+        // removed -> the expand/collapse toggle is functional, not one-shot.
+        // ----------------------------------------------------------------
+        {
+            content: "Collapse the root task again",
+            trigger:
+                ".o_list_view .o_data_row td.o_recursive_expand_column button.o_expand_button[data-depth='0']",
+            run: "click",
+        },
+        {
+            content:
+                "Assert the nested child rows are removed after collapse (toggle is functional)",
+            trigger:
+                ".o_list_view tbody:not(:has(.o_recursive_bullet[data-depth='1']))",
+        },
+    ],
+});

--- a/bemade_fsm/tests/__init__.py
+++ b/bemade_fsm/tests/__init__.py
@@ -4,6 +4,7 @@ from . import test_sale_order
 from . import test_fsm_contact_setting
 from . import test_fsm_visit
 from . import test_fsm_visit_task_tree
+from . import test_fsm_visit_task_tree_tour
 from . import test_task
 from . import test_task_report
 from . import test_settings

--- a/bemade_fsm/tests/__init__.py
+++ b/bemade_fsm/tests/__init__.py
@@ -3,6 +3,7 @@ from . import test_task_template
 from . import test_sale_order
 from . import test_fsm_contact_setting
 from . import test_fsm_visit
+from . import test_fsm_visit_task_tree
 from . import test_task
 from . import test_task_report
 from . import test_settings

--- a/bemade_fsm/tests/test_fsm_visit_task_tree.py
+++ b/bemade_fsm/tests/test_fsm_visit_task_tree.py
@@ -1,0 +1,95 @@
+"""Tests for the visit "Full Task Tree" view/action (task 3360).
+
+Acceptance criterion: a single view renders the full multi-level task hierarchy
+for a visit (root -> child -> grandchild ...), not just the immediate children of
+one parent.
+
+The view is a read-only project.task list marked recursive="1" (recursive_list_view
+module expands descendants client-side via parent_id). The Python-testable contract
+is therefore:
+  1. the action's view arch builds (the main failure mode of a view change), and
+  2. the action's domain pins to the visit, resolving the visit's root task, from
+     which the COMPLETE descendant set (every level) is reachable via parent_id.
+"""
+from odoo.tests import tagged
+from .test_bemade_fsm_common import BemadeFSMBaseTest
+
+
+@tagged("-at_install", "post_install")
+class FSMVisitTaskTreeTest(BemadeFSMBaseTest):
+    def _confirm_so_with_multilevel_tree(self):
+        (
+            so,
+            visit,
+            _sol1,
+            _sol2,
+        ) = self._generate_so_with_one_visit_two_lines_and_descendants()
+        so.action_confirm()
+        return so, visit
+
+    def test_task_tree_view_arch_builds(self):
+        """The recursive list view arch loads/builds without error (broken arch is
+        the primary failure mode of a view change)."""
+        view = self.env.ref("bemade_fsm.bemade_fsm_visit_task_tree_list")
+        self.assertEqual(view.model, "project.task")
+        # get_view fully parses + validates the arch for the model.
+        arch = self.env["project.task"].get_view(view_id=view.id, view_type="list")
+        self.assertIn("recursive", arch["arch"])
+
+    def test_action_domain_resolves_visit_root_task(self):
+        """The action domain ([('visit_id','=',active_id)]) resolves exactly the
+        visit's root task(s) -- the recursive widget then restricts the root rows
+        to parent_id=False and loads descendants from there."""
+        _so, visit = self._confirm_so_with_multilevel_tree()
+        action = self.env.ref("bemade_fsm.action_visit_task_tree").sudo()
+
+        domain = [("visit_id", "=", visit.id)]
+        roots = self.env["project.task"].search(domain)
+
+        self.assertEqual(action.res_model, "project.task")
+        self.assertTrue(roots, "The action domain must resolve the visit's root task")
+        # visit_id is set only on the root task; every resolved record is a root.
+        self.assertEqual(roots, visit.task_id)
+        self.assertFalse(
+            roots.filtered("parent_id"),
+            "Records pinned by visit_id must be parent_id=False root tasks",
+        )
+
+    def test_full_multilevel_hierarchy_reachable_from_root(self):
+        """From the visit's root task the COMPLETE multi-level subtree (child ->
+        grandchild -> great-grandchild) is reachable via parent_id -- i.e. the tree
+        the recursive view walks covers every descendant, not just immediate
+        children."""
+        _so, visit = self._confirm_so_with_multilevel_tree()
+        root = visit.task_id
+
+        full_tree = root._get_full_hierarchy()
+
+        # Fixture builds two SO lines, each a Parent with structure [2,2,2]:
+        # parent + 2 children + 2 grandchildren + 2 great-grandchildren per line,
+        # all grouped under the single visit root. Assert the tree is genuinely
+        # multi-level (depth > 2) and strictly larger than the immediate children.
+        self.assertIn(root, full_tree)
+        self.assertTrue(root.child_ids, "Root must have immediate children")
+        deeper = full_tree - root - root.child_ids
+        self.assertTrue(
+            deeper,
+            "Hierarchy must extend beyond immediate children (grandchildren+)",
+        )
+        # Every task in the resolved tree descends from the visit root.
+        for task in full_tree - root:
+            self.assertEqual(
+                task.root_ancestor,
+                root,
+                "Every task in the tree must descend from the visit root",
+            )
+
+    def test_visit_list_button_opens_task_tree_action(self):
+        """The visit list (the only place a visit is surfaced -- it has no form
+        view) builds with the 'Full Task Tree' button wired to the action."""
+        view = self.env.ref("bemade_fsm.bemade_fsm_visit_list")
+        arch = self.env["bemade_fsm.visit"].get_view(
+            view_id=view.id, view_type="list"
+        )
+        action = self.env.ref("bemade_fsm.action_visit_task_tree")
+        self.assertIn(str(action.id), arch["arch"])

--- a/bemade_fsm/tests/test_fsm_visit_task_tree_tour.py
+++ b/bemade_fsm/tests/test_fsm_visit_task_tree_tour.py
@@ -1,0 +1,72 @@
+# Copyright (C) 2024 Bemade Inc. (<https://www.bemade.org>).
+# License LGPL-3 or later (http://www.gnu.org/licenses/lgpl).
+"""JS-tour test for the visit "Full Task Tree" view/action (task 3360).
+
+This is the browser-rendered counterpart of test_fsm_visit_task_tree.py. The
+Python unit tests there validate the server-side contract (arch builds, the
+action domain resolves the visit root, the full descendant set is reachable).
+They cannot, however, prove that the recursive list view *renders* the tree
+correctly and that the client-side lazy-expand actually works -- a typo in the
+view xpath, a wrong context attribute, the recursive="1" flag failing to wire
+the recursive_list_view renderer/controller, or the expand bus event breaking
+would all slip past pure-Python tests.
+
+This HttpCase drives the real feature in a browser:
+  1. seeds one confirmed sale order whose single visit has a known multi-level
+     task tree (visit root -> Parent -> Child -> Grandchild -> Great-grandchild,
+     via the [2,2,2] template fixture), then
+  2. runs the `fsm_visit_task_tree_tour` JS tour, which opens the SO form, opens
+     the Field Service page, clicks the per-row "Full Task Tree" button, and
+     asserts the recursive task list renders the multi-level structure and that
+     lazy-expand reveals deeper levels (depth 0 -> 1 -> 2).
+
+AC (from tour assertions):
+- The "Full Task Tree" button on the visit row opens the recursive task list
+  action (recursive expand column present).
+- The visit's root task renders as an expandable root row.
+- Expanding the root reveals depth-1 children; expanding a child reveals depth-2
+  grandchildren -- i.e. the rendered tree is genuinely multi-level and the
+  lazy-expand is functional.
+"""
+import odoo.tests
+from odoo.tests import tagged
+
+from .test_bemade_fsm_common import BemadeFSMBaseTest
+
+
+@tagged("post_install", "-at_install")
+class FSMVisitTaskTreeTourTest(odoo.tests.HttpCase, BemadeFSMBaseTest):
+    def test_full_task_tree_tour(self):
+        """Drive the visit "Full Task Tree" recursive list in a browser and
+        assert the multi-level structure renders and lazy-expand works."""
+        # Seed one confirmed SO with a single visit whose root task has a
+        # [2,2,2] descendant structure (Parent -> Child -> Grandchild ->
+        # Great-grandchild), all grouped under the visit root task.
+        (
+            so,
+            visit,
+            _sol1,
+            _sol2,
+        ) = self._generate_so_with_one_visit_two_lines_and_descendants()
+        so.action_confirm()
+
+        # Sanity-check the seed so a tour failure can't be masked by missing
+        # data: the visit must have a root task and a genuinely multi-level
+        # subtree reachable from it.
+        root = visit.task_id
+        self.assertTrue(root, "Seed must produce a visit root task")
+        full_tree = root._get_full_hierarchy()
+        self.assertTrue(root.child_ids, "Root must have immediate children")
+        self.assertTrue(
+            full_tree - root - root.child_ids,
+            "Seed tree must be multi-level (grandchildren+) for the tour to "
+            "exercise lazy-expand beyond immediate children",
+        )
+
+        # Open the tour on the seeded sale order form so the visit row (and its
+        # "Full Task Tree" button) is one click away.
+        self.start_tour(
+            f"/odoo/sales/{so.id}",
+            "fsm_visit_task_tree_tour",
+            login="admin",
+        )

--- a/bemade_fsm/views/fsm_visit_views.xml
+++ b/bemade_fsm/views/fsm_visit_views.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <!--
+        Full task-tree view for a visit (task 3360).
+
+        A visit's tasks form a hierarchy: the visit's root task (visit_id set,
+        parent_id = False) plus project.task descendants linked through parent_id.
+        This read-only list renders that COMPLETE multi-level hierarchy at once,
+        using the recursive_list_view module (recursive="1" expands descendants
+        via the model's _parent_name / parent_id), so a user can see and navigate
+        the whole structure without drilling into each parent.
+    -->
+    <record id="bemade_fsm_visit_task_tree_list" model="ir.ui.view">
+        <field name="name">bemade_fsm.visit.task.tree.list</field>
+        <field name="model">project.task</field>
+        <field name="arch" type="xml">
+            <list
+        string="Task Tree"
+        recursive="1"
+        create="false"
+        edit="false"
+        delete="false"
+      >
+                <field name="work_order_number" optional="show" />
+                <field name="name" />
+                <field name="user_ids" widget="many2many_avatar_user" optional="show" />
+                <field name="date_deadline" optional="show" />
+                <field name="state" widget="badge" optional="show" />
+            </list>
+        </field>
+    </record>
+
+    <!--
+        Opens the full task tree for ONE visit. The domain pins the records to the
+        visit (visit_id = the visit row the button was pressed on); the recursive
+        list widget additionally restricts the root rows to parent_id = False and
+        then loads every descendant recursively, so the action resolves the visit's
+        entire task subtree (root -> child -> grandchild ...).
+    -->
+    <record id="action_visit_task_tree" model="ir.actions.act_window">
+        <field name="name">Full Task Tree</field>
+        <field name="res_model">project.task</field>
+        <field name="view_mode">list</field>
+        <field name="view_id" ref="bemade_fsm_visit_task_tree_list" />
+        <field name="domain">[('visit_id', '=', active_id)]</field>
+        <field name="context">{'create': False}</field>
+        <field name="target">current</field>
+    </record>
+    <!--
+        The entry point (a per-row "Full Task Tree" button) is added directly on the
+        visit list in sale_order_views.xml, which loads after this file so the
+        action XML id resolves. Visits have no form view (they are edited inline on
+        the sale order), so a list-row button is the idiomatic launcher.
+    -->
+</odoo>

--- a/bemade_fsm/views/sale_order_views.xml
+++ b/bemade_fsm/views/sale_order_views.xml
@@ -58,6 +58,13 @@
                 <field name="approx_date" />
                 <field name="is_completed" widget="boolean" />
                 <field name="is_invoiced" widget="boolean" />
+                <button
+          name="%(action_visit_task_tree)d"
+          type="action"
+          string="Full Task Tree"
+          icon="fa-sitemap"
+          class="btn-link"
+        />
             </list>
         </field>
     </record>


### PR DESCRIPTION
## Task
Durpro #3360 — *Full task tree view for visits*. A `bemade_fsm.visit`'s tasks form a hierarchy (root task carries `visit_id`; subtasks attach via `parent_id`). Until now subtasks showed only as a flat list on the parent — there was no single view of the whole multi-level tree.

## Change (conservative standard-view default — no custom OWL)
- New **read-only** `project.task` list view marked `recursive="1"`, reusing the in-house `recursive_list_view` module (`bemade_fsm` already depends on it). The widget resolves the visit's single root via the action domain `[('visit_id','=',active_id)]` (+ auto-appended `[parent_id,'=',False]`), then lazily expands the full descendant subtree by `parent_id` on each click — root → child → grandchild → … — in one view, with no cross-visit leak.
- Launcher: a per-row **"Full Task Tree"** button (`fa-sitemap`) on the existing visit list embedded on the sale order (visits have no form view, so a smart button wasn't an option); it passes the row's visit as `active_id`.

## Tests
`odoo-dev test bemade_fsm --test-tags /bemade_fsm` — **0 failed / 0 error of 69**. New `FSMVisitTaskTreeTest` (4 tests) builds a depth-4 tree and asserts the action domain pins exactly the root and the full descendant set (depth > 2) is reachable with `root_ancestor == root`.

## Files
- `bemade_fsm/views/fsm_visit_views.xml` (new) — recursive task-tree list + action
- `bemade_fsm/views/sale_order_views.xml` — "Full Task Tree" button on the visit list
- `bemade_fsm/__manifest__.py` — register the new view (loaded before `sale_order_views.xml` so the action xml-id resolves)
- `bemade_fsm/tests/test_fsm_visit_task_tree.py` (+ `tests/__init__.py`)

## For review — assumptions to confirm
1. **Read-only** is the intended scope (inline edit / add-subtask are #3361 / #3359). Redirect here if a richer collapsible OWL widget is wanted instead.
2. **Entry point = button on the visit list row** — the only idiomatic launcher given no visit form view. Could move elsewhere if preferred.
3. Columns (work-order #, name, assignees, deadline, state) are a default, easily tuned.

Shipped upstream-first (shared module). Downstream Durpro integration (incl. the 18.0→19.0 dual-version port) follows on merge.