### PR TITLE
[3611] bemade_fsm: inline template_id on subtask list (full-subtree create/write override)

### DIFF
--- a/bemade_fsm/models/task.py
+++ b/bemade_fsm/models/task.py
@@ -57,6 +57,55 @@ class Task(models.Model):
         recursive=True,
     )
 
+    template_id = fields.Many2one(
+        comodel_name="project.task.template",
+        string="From Template",
+        store=False,
+        copy=False,
+    )
+
+    def _apply_template_to_self(self):
+        """Apply the template pointed to by template_id to this task record.
+
+        Fills the task with the template's field values (name, description,
+        assignees, tags, hours, equipment, …) IN PLACE, then instantiates
+        only the template's child templates as subtasks (grandchildren are
+        created recursively by create_task_from_self). The row's own template
+        is NOT passed to create_task_from_self — the row was already created by
+        super().create; we merely populate it and hang children beneath it.
+
+        After applying, template_id is cleared (it is non-stored, so this is
+        merely a cache-reset) to prevent re-instantiation on subsequent writes.
+        """
+        self.ensure_one()
+        template = self.template_id
+        if not template:
+            return
+
+        # Resolve project: prefer the row's own project_id, fall back to parent's.
+        project = self.project_id or self.parent_id.project_id
+        if not project:
+            # Cannot instantiate without a project; skip defensively.
+            return
+
+        # Build the template's value dict, then strip structural keys that the
+        # row already has set correctly (per design-reviewer refinement #1).
+        vals = template._prepare_new_task_values_from_self(
+            project, parent_id=self.parent_id.id or False
+        )
+        vals.pop("parent_id", None)
+        vals.pop("project_id", None)
+
+        self.write(vals)
+
+        # Instantiate only the child templates; recursion to grandchildren is
+        # handled inside create_task_from_self (task_template.py:120).
+        if template.subtasks:
+            template.subtasks.create_task_from_self(project, parent_id=self.id)
+
+        # Clear template_id from the record cache for idempotency.
+        self.template_id = False
+
     def _compute_is_closed(self):
         for rec in self:
             rec.is_closed = rec.state in CLOSED_STATES
@@ -65,6 +114,8 @@ class Task(models.Model):
     def create(self, vals_list):
         res = super().create(vals_list)
         for rec in res:
+            if rec.template_id:
+                rec._apply_template_to_self()
             if rec.parent_id and rec.is_fsm:
                 # Always ensure FSM subtasks have a partner_id set from their parent
                 rec.partner_id = rec.parent_id.partner_id
@@ -106,6 +157,11 @@ class Task(models.Model):
         res = super().write(vals)
         if not self:  # End recursion on empty RecordSet
             return res
+        if vals.get("template_id"):
+            # template_id was set on one or more existing rows — apply it to each.
+            for rec in self:
+                if rec.template_id:
+                    rec._apply_template_to_self()
         if "propagate_assignment" in vals:
             # When a user sets propagate assignment, it should propagate that setting all the way down the chain
             self.child_ids.write({"propagate_assignment": vals["propagate_assignment"]})

--- a/bemade_fsm/models/task.py
+++ b/bemade_fsm/models/task.py
@@ -64,8 +64,8 @@ class Task(models.Model):
         copy=False,
     )
 
-    def _apply_template_to_self(self):
-        """Apply the template pointed to by template_id to this task record.
+    def _apply_template_to_self(self, template=None):
+        """Apply a task template to this task record.
 
         Fills the task with the template's field values (name, description,
         assignees, tags, hours, equipment, …) IN PLACE, then instantiates
@@ -74,11 +74,15 @@ class Task(models.Model):
         is NOT passed to create_task_from_self — the row was already created by
         super().create; we merely populate it and hang children beneath it.
 
-        After applying, template_id is cleared (it is non-stored, so this is
-        merely a cache-reset) to prevent re-instantiation on subsequent writes.
+        :param template: the project.task.template to apply. When omitted, the
+            value carried on ``self.template_id`` is used. The create/write
+            overrides pass the template explicitly because ``template_id`` is a
+            non-stored field, so the ORM does not retain its value in the record
+            cache after ``super().create()`` / ``super().write()``.
         """
         self.ensure_one()
-        template = self.template_id
+        if template is None:
+            template = self.template_id
         if not template:
             return
 
@@ -103,19 +107,22 @@ class Task(models.Model):
         if template.subtasks:
             template.subtasks.create_task_from_self(project, parent_id=self.id)
 
-        # Clear template_id from the record cache for idempotency.
-        self.template_id = False
-
     def _compute_is_closed(self):
         for rec in self:
             rec.is_closed = rec.state in CLOSED_STATES
 
     @api.model_create_multi
     def create(self, vals_list):
+        # Capture template_id from the incoming vals: it is a non-stored field,
+        # so the ORM drops it from the record cache after super().create() and
+        # we cannot read it back off the created record.
+        template_ids = [vals.get("template_id") for vals in vals_list]
         res = super().create(vals_list)
-        for rec in res:
-            if rec.template_id:
-                rec._apply_template_to_self()
+        for rec, template_id in zip(res, template_ids):
+            if template_id:
+                rec._apply_template_to_self(
+                    self.env["project.task.template"].browse(template_id)
+                )
             if rec.parent_id and rec.is_fsm:
                 # Always ensure FSM subtasks have a partner_id set from their parent
                 rec.partner_id = rec.parent_id.partner_id
@@ -158,10 +165,11 @@ class Task(models.Model):
         if not self:  # End recursion on empty RecordSet
             return res
         if vals.get("template_id"):
-            # template_id was set on one or more existing rows — apply it to each.
+            # template_id was set on one or more existing rows — apply it to
+            # each. Read the id from vals (non-stored field, dropped from cache).
+            template = self.env["project.task.template"].browse(vals["template_id"])
             for rec in self:
-                if rec.template_id:
-                    rec._apply_template_to_self()
+                rec._apply_template_to_self(template)
         if "propagate_assignment" in vals:
             # When a user sets propagate assignment, it should propagate that setting all the way down the chain
             self.child_ids.write({"propagate_assignment": vals["propagate_assignment"]})

--- a/bemade_fsm/tests/__init__.py
+++ b/bemade_fsm/tests/__init__.py
@@ -4,6 +4,7 @@ from . import test_sale_order
 from . import test_fsm_contact_setting
 from . import test_fsm_visit
 from . import test_task
+from . import test_task_inline_template
 from . import test_task_report
 from . import test_settings
 from . import test_equipment

--- a/bemade_fsm/tests/test_task_inline_template.py
+++ b/bemade_fsm/tests/test_task_inline_template.py
@@ -1,0 +1,175 @@
+from .test_bemade_fsm_common import BemadeFSMBaseTest
+from odoo.tests import tagged, Form
+from odoo import Command
+
+
+@tagged("post_install", "-at_install")
+class TaskInlineTemplateTest(BemadeFSMBaseTest):
+    """Acceptance tests for task 3611 — inline template_id expansion.
+
+    Acceptance criteria (01-requirements.md):
+      1. project.task subtask list exposes a template_id field.
+      2. On create/write, a subtask row with template_id set is populated from
+         the template (name, description, assignees, tags, planned_hours, …),
+         reusing the wizard's value-prep logic.
+      3. A template with child templates expands the full subtree (grandchildren
+         included).
+      4. The existing modal-wizard flow continues to work unchanged.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.project = cls.env.ref("industry_fsm.fsm_project")
+        cls.assignee = cls._generate_project_user("Alice", "alice")
+        cls.customer = cls._generate_partner(name="Inline Customer")
+
+    def _new_parent_task(self):
+        return self.env["project.task"].create(
+            {
+                "name": "Parent Task",
+                "project_id": self.project.id,
+                "partner_id": self.customer.id,
+            }
+        )
+
+    def test_inline_template_id_populates_subtask(self):
+        """AC 2: a subtask row carrying template_id is populated from the
+        template on create — name, tags, assignees, planned_hours — and the
+        transient template_id is cleared afterwards."""
+        parent = self._new_parent_task()
+        tag = self.env["project.tags"].create({"name": "Inline Tag"})
+        template = self._generate_task_template(names=["Tmpl"], planned_hours=5)
+        template.write(
+            {
+                "assignees": [Command.set(self.assignee.ids)],
+                "tags": [Command.set(tag.ids)],
+                "description": "<p>Tmpl description</p>",
+            }
+        )
+
+        child = self.env["project.task"].create(
+            {
+                "parent_id": parent.id,
+                "project_id": self.project.id,
+                "name": "placeholder",
+                "template_id": template.id,
+            }
+        )
+
+        self.assertEqual(child.name, template.name)
+        self.assertEqual(child.tag_ids, tag)
+        self.assertEqual(child.user_ids, self.assignee)
+        self.assertEqual(child.allocated_hours, template.planned_hours)
+        # Transient template_id cleared after instantiation (idempotency).
+        self.assertFalse(child.template_id)
+
+    def test_inline_template_expands_full_subtree(self):
+        """AC 3: a template with child templates (and a grandchild) expands the
+        full subtree via the inline create path — something a plain onchange
+        could not do."""
+        parent = self._new_parent_task()
+        template = self._generate_task_template(
+            names=["Tmpl", "Child", "Grandchild"], structure=[2, 1]
+        )
+
+        child = self.env["project.task"].create(
+            {
+                "parent_id": parent.id,
+                "project_id": self.project.id,
+                "name": "placeholder",
+                "template_id": template.id,
+            }
+        )
+
+        # The row got the two child templates as subtasks.
+        self.assertEqual(len(child.child_ids), len(template.subtasks))
+        # The first child template had one grandchild template — created too.
+        self.assertEqual(
+            len(child.child_ids[0].child_ids),
+            len(template.subtasks[0].subtasks),
+        )
+        self.assertEqual(len(child.child_ids[0].child_ids), 1)
+        # Names propagated from the templates.
+        self.assertEqual(
+            sorted(child.child_ids.mapped("name")),
+            sorted(template.subtasks.mapped("name")),
+        )
+        # Every created task lives in the same project.
+        self.assertTrue(
+            all(
+                t.project_id == self.project
+                for t in child | child._get_all_subtasks()
+            )
+        )
+
+    def test_inline_template_form_path(self):
+        """AC 1 + 2 + 3: exercise the real x2many one2many write a user performs
+        in the subtask list via the form view — set template_id on a new line and
+        save the parent. Catches missing view field / context-default issues."""
+        parent = self._new_parent_task()
+        tag = self.env["project.tags"].create({"name": "Form Tag"})
+        template = self._generate_task_template(
+            names=["FormTmpl", "FormChild"], structure=[1]
+        )
+        template.write({"tags": [Command.set(tag.ids)]})
+
+        with Form(parent, view="project.view_task_form2") as form:
+            with form.child_ids.new() as line:
+                line.name = "placeholder"
+                line.template_id = template
+
+        subtask = parent.child_ids[-1]
+        self.assertEqual(subtask.name, template.name)
+        self.assertEqual(subtask.tag_ids, tag)
+        # Child template was instantiated under the inline subtask.
+        self.assertEqual(len(subtask.child_ids), len(template.subtasks))
+        self.assertFalse(subtask.template_id)
+
+    def test_inline_template_idempotent_on_later_edit(self):
+        """AC 2 (idempotency): after instantiation, editing the subtask (e.g.
+        renaming it) does not re-instantiate the template subtree."""
+        parent = self._new_parent_task()
+        template = self._generate_task_template(
+            names=["Tmpl", "Child"], structure=[1]
+        )
+
+        child = self.env["project.task"].create(
+            {
+                "parent_id": parent.id,
+                "project_id": self.project.id,
+                "name": "placeholder",
+                "template_id": template.id,
+            }
+        )
+        n_children = len(child.child_ids)
+        self.assertEqual(n_children, len(template.subtasks))
+
+        child.write({"name": "renamed"})
+
+        self.assertEqual(child.name, "renamed")
+        # No re-instantiation: the child count is unchanged.
+        self.assertEqual(len(child.child_ids), n_children)
+
+    def test_wizard_flow_still_works(self):
+        """AC 4: the existing modal-wizard instantiation path
+        (create_task_from_self) still produces the full subtree — the additive
+        change did not regress the shared helpers."""
+        template = self._generate_task_template(
+            names=["Task", "Child", "Grandchild"], structure=[2, 1]
+        )
+
+        task = template.create_task_from_self(self.project, "My new task")
+
+        self.assertEqual(task.name, "My new task")
+        self.assertEqual(len(task.child_ids), len(template.subtasks))
+        self.assertEqual(
+            len(task.child_ids[0].child_ids),
+            len(template.subtasks[0].subtasks),
+        )
+        self.assertTrue(
+            all(
+                t.project_id == self.project
+                for t in task | task._get_all_subtasks()
+            )
+        )

--- a/bemade_fsm/views/task_views.xml
+++ b/bemade_fsm/views/task_views.xml
@@ -62,6 +62,7 @@
         position="after"
       >
                 <field name="description" string="Description/Comments" />
+                <field name="template_id" string="From Template" optional="show" />
             </xpath>
             <field name="user_ids" position="after">
                 <field name="propagate_assignment" />


### PR DESCRIPTION
## What

Adds an inline way to instantiate a task template from a parent task's **subtask list** — a `template_id` column on `child_ids`; on create/write the row is populated from the chosen `project.task.template` and the template's **full subtree (children + grandchildren)** is created, matching the existing modal-wizard behaviour. Purely additive — the wizard flow is unchanged.

Resolves Durpro task #3611 (Marc consolidated #3361 into it: "go with the inline `template_id`, more like a create/write override"). The create/write override (over a plain onchange) is required so a template with its own child templates expands the whole subtree.

## How

- `project.task.template_id` — non-stored (`store=False`), `copy=False` m2o → `project.task.template`. No schema/migration; never persisted on existing rows; duplicating a task never re-triggers.
- `create`/`write` overrides in `bemade_fsm/models/task.py` capture the template id from the **incoming vals** (not the record cache — a non-stored, non-computed field is dropped from cache across the `super()` boundary) and call `_apply_template_to_self(template=...)`, which applies `template._prepare_new_task_values_from_self(...)` to the row in place and instantiates `template.subtasks.create_task_from_self(parent_id=self.id)` (recurses to grandchildren). It never calls `create_task_from_self` on the row's own template (would create a second root). Re-entrant-safe: instantiated descendants carry no `template_id`, so the override never re-fires.
- `template_id` column added to the subtask list in `view_task_form2_inherit` (`optional="show"`).

## Tests (new — `bemade_fsm/tests/test_task_inline_template.py`, 5 cases)

- `test_inline_template_id_populates_subtask` — create path copies name/tags/assignees/allocated_hours from the template.
- `test_inline_template_expands_full_subtree` — `structure=[2,1]`: asserts 2 children + 1 grandchild under the right child (discriminating: only one child has a grandchild).
- `test_inline_template_form_path` — `Form(parent, view='project.view_task_form2')`, set `template_id` on a new subtask line, save → proves the view column exists and the write path instantiates the subtree.
- `test_inline_template_idempotent_on_later_edit` — a later `write({'name': ...})` creates no new children.
- `test_wizard_flow_still_works` — smoke on the unchanged wizard path.

Full `bemade_fsm` suite **70/70** post-install green.

> Shipped upstream-first by the autonomous task-worker. The Durpro `.repos/bemade-addons` submodule-pointer bump (and the bemade-addons 19.0 port for Durpro's 18→19 migration) follow on merge.
