### PR TITLE
[3750] crm_account_management: system-wide YTD basis (fiscal sales vs calendar bookings)

### DIFF
--- a/crm_account_management/__manifest__.py
+++ b/crm_account_management/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "CRM Account Management",
-    "version": "18.0.5.0.0",
+    "version": "18.0.5.1.0",
     "category": "Sales/CRM",
     "summary": "Customer Account Management with Dashboard and Reporting",
     "description": """
@@ -29,6 +29,7 @@ account visibility:
         "security/ir.model.access.csv",
         "data/init_data.xml",
         "data/cron.xml",
+        "views/res_config_settings_views.xml",
         "views/organizational_unit_views.xml",
         "views/res_partner_views.xml",
         "views/sale_order_views.xml",

--- a/crm_account_management/models/__init__.py
+++ b/crm_account_management/models/__init__.py
@@ -1,5 +1,6 @@
 from . import organizational_unit
 from . import organizational_unit_mixin
+from . import res_config_settings
 from . import res_partner
 from . import sale_order
 from . import crm_lead

--- a/crm_account_management/models/organizational_unit.py
+++ b/crm_account_management/models/organizational_unit.py
@@ -414,6 +414,32 @@ class OrganizationalUnit(models.Model):
         start_of_prior_fiscal_year = self._get_fiscal_year_start(same_day_prior_year)
         return start_of_prior_fiscal_year, same_day_prior_year
 
+    def _get_calendar_ytd_dates(self):
+        """Return (Jan 1 of the current calendar year, today) for calendar-YTD."""
+        today = date.today()
+        return date(today.year, 1, 1), today
+
+    def _get_prior_calendar_ytd_dates(self):
+        """Return (Jan 1 of the prior calendar year, same month/day last year)."""
+        today = date.today()
+        same_day_prior_year = today - relativedelta(years=1)
+        return date(today.year - 1, 1, 1), same_day_prior_year
+
+    @api.model
+    def _get_ytd_metric_basis(self):
+        """Return the system-wide dashboard YTD basis ('fiscal' or 'bookings').
+
+        Stored as the ``ir.config_parameter``
+        ``crm_account_management.ytd_metric_basis``; absent/empty is treated as
+        ``'fiscal'`` (the default, no-regression behaviour).
+        """
+        return (
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param("crm_account_management.ytd_metric_basis", "fiscal")
+            or "fiscal"
+        )
+
     @api.depends(
         "owner_id",
         "member_ids",
@@ -423,8 +449,13 @@ class OrganizationalUnit(models.Model):
         "owner_id.invoice_ids.amount_total",
         "owner_id.invoice_ids.invoice_date",
         "owner_id.invoice_ids.move_type",
+        "owner_id.sale_order_ids.state",
+        "owner_id.sale_order_ids.amount_total",
+        "owner_id.sale_order_ids.date_order",
+        "owner_id.sale_order_ids.currency_id",
     )
     def _compute_sales_metrics(self):
+        basis = self._get_ytd_metric_basis()
         for record in self:
             partners = record._get_all_partners()
             if not partners:
@@ -433,46 +464,77 @@ class OrganizationalUnit(models.Model):
                 record.ytd_sales_change_pct = 0.0
                 continue
 
-            start_ytd, end_ytd = record._get_ytd_dates()
-            start_prior, end_prior = record._get_prior_ytd_dates()
+            if basis == "bookings":
+                # Calendar-YTD bookings: confirmed sale orders (state='sale')
+                # over the calendar window, FX-converted via _sum_in_currency
+                # (the same aggregation _compute_quotation_metrics uses).
+                start_ytd, end_ytd = record._get_calendar_ytd_dates()
+                start_prior, end_prior = record._get_prior_calendar_ytd_dates()
 
-            # YTD sales from confirmed invoices
-            ytd_invoices = self.env["account.move"].search(
-                [
-                    ("partner_id", "in", partners.ids),
-                    ("move_type", "in", ["out_invoice", "out_refund"]),
-                    ("state", "=", "posted"),
-                    ("invoice_date", ">=", start_ytd),
-                    ("invoice_date", "<=", end_ytd),
-                ]
-            )
-            record.ytd_sales = sum(
-                (
-                    inv.amount_total
-                    if inv.move_type == "out_invoice"
-                    else -inv.amount_total
+                ytd_orders = self.env["sale.order"].search(
+                    [
+                        ("partner_id", "in", partners.ids),
+                        ("state", "=", "sale"),
+                        ("date_order", ">=", start_ytd),
+                        ("date_order", "<=", end_ytd),
+                    ]
                 )
-                for inv in ytd_invoices
-            )
+                record.ytd_sales = record._sum_in_currency(
+                    ytd_orders, "amount_total", "date_order"
+                )
 
-            # Prior YTD sales
-            prior_invoices = self.env["account.move"].search(
-                [
-                    ("partner_id", "in", partners.ids),
-                    ("move_type", "in", ["out_invoice", "out_refund"]),
-                    ("state", "=", "posted"),
-                    ("invoice_date", ">=", start_prior),
-                    ("invoice_date", "<=", end_prior),
-                ]
-            )
-            record.ytd_sales_prior_year = sum(
-                (
-                    inv.amount_total
-                    if inv.move_type == "out_invoice"
-                    else -inv.amount_total
+                prior_orders = self.env["sale.order"].search(
+                    [
+                        ("partner_id", "in", partners.ids),
+                        ("state", "=", "sale"),
+                        ("date_order", ">=", start_prior),
+                        ("date_order", "<=", end_prior),
+                    ]
                 )
-                for inv in prior_invoices
-            )
+                record.ytd_sales_prior_year = record._sum_in_currency(
+                    prior_orders, "amount_total", "date_order"
+                )
+            else:
+                start_ytd, end_ytd = record._get_ytd_dates()
+                start_prior, end_prior = record._get_prior_ytd_dates()
+
+                # YTD sales from confirmed invoices
+                ytd_invoices = self.env["account.move"].search(
+                    [
+                        ("partner_id", "in", partners.ids),
+                        ("move_type", "in", ["out_invoice", "out_refund"]),
+                        ("state", "=", "posted"),
+                        ("invoice_date", ">=", start_ytd),
+                        ("invoice_date", "<=", end_ytd),
+                    ]
+                )
+                record.ytd_sales = sum(
+                    (
+                        inv.amount_total
+                        if inv.move_type == "out_invoice"
+                        else -inv.amount_total
+                    )
+                    for inv in ytd_invoices
+                )
+
+                # Prior YTD sales
+                prior_invoices = self.env["account.move"].search(
+                    [
+                        ("partner_id", "in", partners.ids),
+                        ("move_type", "in", ["out_invoice", "out_refund"]),
+                        ("state", "=", "posted"),
+                        ("invoice_date", ">=", start_prior),
+                        ("invoice_date", "<=", end_prior),
+                    ]
+                )
+                record.ytd_sales_prior_year = sum(
+                    (
+                        inv.amount_total
+                        if inv.move_type == "out_invoice"
+                        else -inv.amount_total
+                    )
+                    for inv in prior_invoices
+                )
 
             # Calculate YTD change percentage (as decimal for percentage widget: 0.5 = 50%)
             if record.ytd_sales_prior_year:

--- a/crm_account_management/models/res_config_settings.py
+++ b/crm_account_management/models/res_config_settings.py
@@ -1,0 +1,33 @@
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    ytd_metric_basis = fields.Selection(
+        selection=[
+            ("fiscal", "Fiscal-YTD sales"),
+            ("bookings", "Calendar-YTD bookings"),
+        ],
+        string="Dashboard YTD Metric",
+        default="fiscal",
+        config_parameter="crm_account_management.ytd_metric_basis",
+        help="Basis for the customer-account dashboard's headline YTD sales "
+        "figure. 'Fiscal-YTD sales' (default) sums posted customer invoices "
+        "over the fiscal year to date. 'Calendar-YTD bookings' sums confirmed "
+        "sale orders (bookings) over the current calendar year to date, "
+        "compared against the same calendar window last year.",
+    )
+
+    def set_values(self):
+        """Persist the config parameter, then recompute the stored dashboard
+        YTD fields on all organizational units.
+
+        ``ytd_metric_basis`` is stored as an ``ir.config_parameter`` (via the
+        ``config_parameter`` shorthand), which is outside the ORM dependency
+        graph, so changing it does not auto-invalidate the stored ``ytd_sales``
+        fields. Recompute them here so the dashboard reflects the new basis
+        immediately rather than only after the nightly ``_cron_refresh_metrics``.
+        """
+        super().set_values()
+        self.env["organizational.unit"].search([])._compute_sales_metrics()

--- a/crm_account_management/tests/__init__.py
+++ b/crm_account_management/tests/__init__.py
@@ -10,3 +10,4 @@ from . import test_us10_reverse_links
 from . import test_us11_rolling_12m_bookings
 from . import test_us19_annual_review
 from . import test_us20_top_products
+from . import test_us2x_ytd_basis

--- a/crm_account_management/tests/test_us2x_ytd_basis.py
+++ b/crm_account_management/tests/test_us2x_ytd_basis.py
@@ -1,0 +1,262 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0).
+# Author: Bemade Inc. (Marc Durepos <marc@bemade.org>)
+"""
+Task 3750 — Dashboard YTD metric basis: fiscal-YTD sales vs calendar-YTD bookings.
+
+Acceptance criteria
+-------------------
+1. A res.config.settings selection (ytd_metric_basis) selects the dashboard YTD
+   metric: fiscal-YTD sales (current behaviour) vs calendar-YTD bookings.
+2. In bookings mode, ytd_sales is the confirmed-order (state='sale') amount from
+   Jan 1 of the current calendar year to today; ytd_sales_prior_year is the same
+   calendar window last year (Jan 1 prior year -> same month/day prior year).
+3. The basis is stored system-wide (ir.config_parameter) and respected by the
+   stored dashboard computation.
+4. Default (fiscal) leaves the dashboard behaving exactly as today (no regression).
+"""
+from datetime import date
+
+from dateutil.relativedelta import relativedelta
+
+from odoo.tests import Form, tagged
+
+from odoo.addons.crm_account_management.tests.common import OUTestCommon
+
+
+@tagged("post_install", "-at_install")
+class TestYTDMetricBasis(OUTestCommon):
+    """Branch coverage for _compute_sales_metrics on ytd_metric_basis."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner_model = cls.env["res.partner"]
+        cls.ou_model = cls.env["organizational.unit"]
+        cls.param = cls.env["ir.config_parameter"].sudo()
+        cls.param_key = "crm_account_management.ytd_metric_basis"
+
+        cls.product = cls.env["product.product"].create(
+            {"name": "YTD Basis Test Product", "list_price": 100.0}
+        )
+
+        # Foreign currency for the mixed-currency bookings test:
+        # 1 EUR = 1.25 company-currency (rate stored as 1/1.25 = 0.8).
+        cls.foreign_currency = cls.setup_other_currency(
+            "EUR", rates=[("2000-01-01", 0.8)]
+        )
+
+    def setUp(self):
+        super().setUp()
+        # Each test owns the global basis; reset to the default afterwards so
+        # tests don't leak the config param into one another.
+        self.addCleanup(self.param.set_param, self.param_key, "fiscal")
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _make_company(self, name):
+        partner = self.partner_model.create({"name": name, "is_company": True})
+        ou = self.ou_model.search([("owner_id", "=", partner.id)], limit=1)
+        return partner, ou
+
+    def _make_confirmed_order(self, partner, amount, currency=None, order_date=None):
+        """Create and confirm a sale.order with one line of ``amount``.
+
+        In Odoo 18, sale.order.currency_id is computed from the pricelist, so a
+        non-default currency is applied via a throwaway pricelist.
+
+        ``action_confirm()`` resets ``date_order`` to now, so the desired date is
+        written *after* confirmation (the established test_us02/test_us11
+        pattern) — otherwise every order lands in the current window and the
+        calendar-window assertions become meaningless.
+        """
+        if order_date is None:
+            order_date = date.today()
+        vals = {
+            "partner_id": partner.id,
+            "order_line": [
+                (
+                    0,
+                    0,
+                    {
+                        "product_id": self.product.id,
+                        "product_uom_qty": 1,
+                        "price_unit": amount,
+                        "tax_id": False,
+                    },
+                )
+            ],
+        }
+        if currency:
+            pricelist = self.env["product.pricelist"].create(
+                {"name": f"PL {currency.name}", "currency_id": currency.id}
+            )
+            vals["pricelist_id"] = pricelist.id
+        order = self.env["sale.order"].create(vals)
+        order.action_confirm()
+        order.date_order = order_date
+        return order
+
+    def _make_posted_invoice(self, partner, amount, invoice_date=None):
+        if invoice_date is None:
+            invoice_date = date.today()
+        invoice = self.env["account.move"].create(
+            {
+                "partner_id": partner.id,
+                "move_type": "out_invoice",
+                "invoice_date": invoice_date,
+                "invoice_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product.id,
+                            "quantity": 1,
+                            "price_unit": amount,
+                            "tax_ids": False,
+                        },
+                    )
+                ],
+            }
+        )
+        invoice.action_post()
+        return invoice
+
+    # ------------------------------------------------------------------
+    # AC-4: default (fiscal) is unchanged — invoice-driven figure
+    # ------------------------------------------------------------------
+
+    def test_default_fiscal_uses_invoices(self):
+        """With the param unset (default fiscal), ytd_sales is the posted-invoice
+        total and ignores confirmed sale orders."""
+        self.param.set_param(self.param_key, "")  # absent => fiscal
+        partner, ou = self._make_company("Fiscal Default Co")
+
+        self._make_posted_invoice(partner, 1000.0)
+        # A confirmed SO of a different amount must NOT contribute in fiscal mode.
+        self._make_confirmed_order(partner, 7777.0)
+
+        ou.invalidate_recordset()
+        self.assertAlmostEqual(
+            ou.ytd_sales,
+            1000.0,
+            places=2,
+            msg="Fiscal default must equal the posted-invoice total, not the SO booking.",
+        )
+
+    # ------------------------------------------------------------------
+    # AC-1/AC-2: bookings mode switches the figure to confirmed SOs
+    # ------------------------------------------------------------------
+
+    def test_bookings_uses_confirmed_orders_not_invoices(self):
+        """In bookings mode, ytd_sales equals the confirmed-SO total, NOT the
+        posted-invoice total — proving the branch is live and SO-driven."""
+        self.param.set_param(self.param_key, "bookings")
+        partner, ou = self._make_company("Bookings Co")
+
+        # Invoice and SO of clearly different amounts.
+        self._make_posted_invoice(partner, 1000.0)
+        self._make_confirmed_order(partner, 2500.0)
+
+        ou.invalidate_recordset()
+        self.assertAlmostEqual(
+            ou.ytd_sales,
+            2500.0,
+            places=2,
+            msg="Bookings mode must report the confirmed-SO amount, not invoices.",
+        )
+
+    # ------------------------------------------------------------------
+    # AC-2: calendar window boundary (current vs prior split)
+    # ------------------------------------------------------------------
+
+    def test_bookings_calendar_window_boundary(self):
+        """Jan-1-this-year SO is current YTD; Dec-31-last-year SO is excluded
+        from current and (being outside the prior Jan1->same-day window) also
+        excluded from prior. A clearly-in-prior-window SO lands in prior."""
+        self.param.set_param(self.param_key, "bookings")
+        partner, ou = self._make_company("Calendar Boundary Co")
+        today = date.today()
+
+        # In current calendar window (Jan 1 this year .. today)
+        self._make_confirmed_order(partner, 300.0, order_date=date(today.year, 1, 1))
+        # Just outside current window, below the prior window's start too
+        # (prior window = Jan 1 last year .. same day last year), so excluded both.
+        self._make_confirmed_order(
+            partner, 999.0, order_date=date(today.year - 1, 12, 31)
+        )
+        # Clearly inside the prior calendar window.
+        prior_in_window = today - relativedelta(years=1)
+        self._make_confirmed_order(partner, 400.0, order_date=prior_in_window)
+
+        ou.invalidate_recordset()
+        self.assertAlmostEqual(
+            ou.ytd_sales,
+            300.0,
+            places=2,
+            msg="Only the Jan-1-this-year SO belongs to the current calendar YTD.",
+        )
+        self.assertAlmostEqual(
+            ou.ytd_sales_prior_year,
+            400.0,
+            places=2,
+            msg="Only the in-window prior-year SO belongs to prior calendar YTD; "
+            "Dec-31-last-year is excluded.",
+        )
+
+    # ------------------------------------------------------------------
+    # AC-2 (reuse path): mixed-currency bookings convert via _sum_in_currency
+    # ------------------------------------------------------------------
+
+    def test_bookings_mixed_currency_converts(self):
+        """Two confirmed SOs in different currencies sum into ytd_sales converted
+        to the OU currency (guards reuse of _sum_in_currency, not raw summing)."""
+        self.param.set_param(self.param_key, "bookings")
+        partner, ou = self._make_company("Bookings FX Co")
+
+        self._make_confirmed_order(partner, 100.0)  # company currency
+        self._make_confirmed_order(
+            partner, 100.0, currency=self.foreign_currency
+        )  # 100 EUR @1.25 = 125
+
+        ou.invalidate_recordset()
+        self.assertAlmostEqual(
+            ou.ytd_sales,
+            225.0,
+            places=2,
+            msg="100 company-currency + 100 EUR@1.25 must convert to 225, not 200.",
+        )
+
+    # ------------------------------------------------------------------
+    # AC-1/AC-3: settings round-trip + recompute trigger via the wizard
+    # ------------------------------------------------------------------
+
+    def test_settings_form_persists_and_recomputes(self):
+        """Saving ytd_metric_basis='bookings' through the res.config.settings
+        Form persists the ir.config_parameter AND leaves ytd_sales reflecting
+        bookings afterward (confirms set_values fired the recompute)."""
+        partner, ou = self._make_company("Settings RoundTrip Co")
+        self._make_posted_invoice(partner, 1000.0)
+        self._make_confirmed_order(partner, 4242.0)
+
+        # Default fiscal first.
+        ou.invalidate_recordset()
+        self.assertAlmostEqual(ou.ytd_sales, 1000.0, places=2)
+
+        settings = Form(self.env["res.config.settings"])
+        settings.ytd_metric_basis = "bookings"
+        settings.save().execute()
+
+        self.assertEqual(
+            self.param.get_param(self.param_key),
+            "bookings",
+            "Wizard save must persist the ir.config_parameter.",
+        )
+        ou.invalidate_recordset()
+        self.assertAlmostEqual(
+            ou.ytd_sales,
+            4242.0,
+            places=2,
+            msg="set_values must recompute stored ytd_sales to the bookings figure.",
+        )

--- a/crm_account_management/views/res_config_settings_views.xml
+++ b/crm_account_management/views/res_config_settings_views.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.crm_account_management</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="crm.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//app[@name='crm']" position="inside">
+                <block title="Customer Account Dashboard" name="crm_account_management_dashboard_setting_container">
+                    <setting string="Dashboard YTD Metric"
+                             help="Choose how the customer-account dashboard's headline YTD sales figure is computed.">
+                        <field name="ytd_metric_basis" widget="radio"/>
+                    </setting>
+                </block>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Task 3750 — Dashboard YTD: fiscal sales vs calendar bookings (Pneumac CRM 2.3)

Adds a **system-wide setting** (`res.config.settings` → "Customer Account Dashboard") to switch the customer-account dashboard's headline **YTD** figure between:

- **Fiscal-YTD sales** (current behaviour — default, no regression), and
- **Calendar-YTD bookings**: confirmed-order amount (`sale.order` `state='sale'`) from **Jan 1 → today** vs the **same calendar window last year**, FX-converted via the existing `_sum_in_currency` helper.

Stored as `ir.config_parameter crm_account_management.ytd_metric_basis` (default `fiscal`). `_compute_sales_metrics` branches on it; the fiscal path is unchanged. `set_values` recomputes the stored YTD fields on save (they are `store=True`); `@api.depends` widened so bookings figures also react to SO changes.

**Tests:** 5 new (`TestYTDMetricBasis`), full module suite **110 passing / 0 fail**.

Odoo task: https://odoo.bemade.org/odoo/project/33/tasks/3750
Pipeline artifacts: https://git.bemade.org/bemade/tasks/-/tree/main/task-3750-crm-ytd-calendar-bookings

_Downstream `pneumac/odoo` submodule-pointer bump follows automatically once this merges._
