### PR TITLE
[3751] crm_account_management: rolling-12m on confirmed-order bookings basis

### DIFF
--- a/crm_account_management/models/organizational_unit.py
+++ b/crm_account_management/models/organizational_unit.py
@@ -482,9 +482,23 @@ class OrganizationalUnit(models.Model):
             else:
                 record.ytd_sales_change_pct = 0.0 if not record.ytd_sales else 1.0
 
-    @api.depends("owner_id", "member_ids", "child_ids")
+    @api.depends(
+        "owner_id",
+        "member_ids",
+        "child_ids",
+        "owner_id.sale_order_ids.state",
+        "owner_id.sale_order_ids.amount_total",
+        "owner_id.sale_order_ids.date_order",
+        "owner_id.sale_order_ids.currency_id",
+    )
     def _compute_rolling_12m_metrics(self):
-        """Rolling 12M metrics - not stored since date range shifts daily."""
+        """Rolling 12M bookings metrics - not stored since date range shifts daily.
+
+        Bookings = confirmed ``sale.order`` (``state == "sale"``) aggregated by
+        ``date_order`` via ``_sum_in_currency`` (which converts mixed currencies
+        at each order's ``date_order`` rate). Windows are half-open
+        (``> start`` / ``<= end``) so the 12-month seam is never double-counted.
+        """
         for record in self:
             partners = record._get_all_partners()
             if not partners:
@@ -495,43 +509,31 @@ class OrganizationalUnit(models.Model):
 
             today = date.today()
             rolling_12m_start = today - relativedelta(months=12)
-            rolling_12m_invoices = self.env["account.move"].search(
+            rolling_12m_orders = self.env["sale.order"].search(
                 [
                     ("partner_id", "in", partners.ids),
-                    ("move_type", "in", ["out_invoice", "out_refund"]),
-                    ("state", "=", "posted"),
-                    ("invoice_date", ">", rolling_12m_start),
-                    ("invoice_date", "<=", today),
+                    ("state", "=", "sale"),
+                    ("date_order", ">", rolling_12m_start),
+                    ("date_order", "<=", today),
                 ]
             )
-            record.rolling_12m_sales = sum(
-                (
-                    inv.amount_total
-                    if inv.move_type == "out_invoice"
-                    else -inv.amount_total
-                )
-                for inv in rolling_12m_invoices
+            record.rolling_12m_sales = record._sum_in_currency(
+                rolling_12m_orders, "amount_total", "date_order"
             )
 
             # Prior rolling 12 months (12-24 months ago)
             rolling_prior_start = today - relativedelta(months=24)
             rolling_prior_end = today - relativedelta(months=12)
-            rolling_prior_invoices = self.env["account.move"].search(
+            rolling_prior_orders = self.env["sale.order"].search(
                 [
                     ("partner_id", "in", partners.ids),
-                    ("move_type", "in", ["out_invoice", "out_refund"]),
-                    ("state", "=", "posted"),
-                    ("invoice_date", ">", rolling_prior_start),
-                    ("invoice_date", "<=", rolling_prior_end),
+                    ("state", "=", "sale"),
+                    ("date_order", ">", rolling_prior_start),
+                    ("date_order", "<=", rolling_prior_end),
                 ]
             )
-            record.rolling_12m_sales_prior = sum(
-                (
-                    inv.amount_total
-                    if inv.move_type == "out_invoice"
-                    else -inv.amount_total
-                )
-                for inv in rolling_prior_invoices
+            record.rolling_12m_sales_prior = record._sum_in_currency(
+                rolling_prior_orders, "amount_total", "date_order"
             )
 
             # Calculate rolling 12m change percentage
@@ -987,25 +989,45 @@ class OrganizationalUnit(models.Model):
         ])
 
     def action_view_orders_rolling_12m(self):
-        """Open posted invoices for this account from the last 12 months."""
+        """Open confirmed sale orders (bookings) for this account from the last 12 months."""
+        self.ensure_one()
+        partners = self._get_all_partners()
         today = date.today()
         date_from = today - relativedelta(months=12)
-        return self._get_invoice_action(_("Invoices (Last 12 Months)"), [
-            ("state", "=", "posted"),
-            ("invoice_date", ">", date_from),
-            ("invoice_date", "<=", today),
-        ])
+        return {
+            "type": "ir.actions.act_window",
+            "name": _("Bookings (Last 12 Months)"),
+            "res_model": "sale.order",
+            "view_mode": "list,form",
+            "domain": [
+                ("partner_id", "in", partners.ids),
+                ("state", "=", "sale"),
+                ("date_order", ">", date_from),
+                ("date_order", "<=", today),
+            ],
+            "context": {"default_partner_id": self.owner_id.id if self.owner_id else False},
+        }
 
     def action_view_orders_prior_rolling_12m(self):
-        """Open posted invoices for this account from 13–24 months ago."""
+        """Open confirmed sale orders (bookings) for this account from 13–24 months ago."""
+        self.ensure_one()
+        partners = self._get_all_partners()
         today = date.today()
         date_from = today - relativedelta(months=24)
         date_to = today - relativedelta(months=12)
-        return self._get_invoice_action(_("Invoices (Prior 12 Months)"), [
-            ("state", "=", "posted"),
-            ("invoice_date", ">", date_from),
-            ("invoice_date", "<=", date_to),
-        ])
+        return {
+            "type": "ir.actions.act_window",
+            "name": _("Bookings (Prior 12 Months)"),
+            "res_model": "sale.order",
+            "view_mode": "list,form",
+            "domain": [
+                ("partner_id", "in", partners.ids),
+                ("state", "=", "sale"),
+                ("date_order", ">", date_from),
+                ("date_order", "<=", date_to),
+            ],
+            "context": {"default_partner_id": self.owner_id.id if self.owner_id else False},
+        }
 
     def action_view_won_quotations_ytd(self):
         """Open confirmed sale orders (bookings) for the current fiscal YTD."""

--- a/crm_account_management/tests/__init__.py
+++ b/crm_account_management/tests/__init__.py
@@ -7,5 +7,6 @@ from . import test_us05_auto_create
 from . import test_us08_ou_structure
 from . import test_us09_partner_ous
 from . import test_us10_reverse_links
+from . import test_us11_rolling_12m_bookings
 from . import test_us19_annual_review
 from . import test_us20_top_products

--- a/crm_account_management/tests/test_us11_rolling_12m_bookings.py
+++ b/crm_account_management/tests/test_us11_rolling_12m_bookings.py
@@ -1,0 +1,144 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0).
+# Author: Bemade Inc. (Marc Durepos <marc@bemade.org>)
+"""
+US-11 (task 3751): Rolling-12m dashboard figure reflects confirmed-order bookings.
+
+Acceptance criteria
+-------------------
+1. rolling_12m_sales shows confirmed-order bookings for the trailing 12 months
+   (today - 12 months -> today), measured by date_order.
+2. rolling_12m_sales_prior covers the full prior window (today - 24 months ->
+   today - 12 months), measured by date_order.
+3. The figures reconcile against confirmed sale.order amounts in each window
+   (a tester can cross-check the dashboard number against the sum of confirmed
+   orders), and unconfirmed (draft) orders are excluded from both windows.
+4. rolling_12m_change_pct == (trailing - prior) / prior.
+"""
+from datetime import date
+
+from dateutil.relativedelta import relativedelta
+
+from odoo.tests import tagged
+
+from odoo.addons.crm_account_management.tests.common import OUTestCommon
+
+
+@tagged("post_install", "-at_install")
+class TestUS11Rolling12mBookings(OUTestCommon):
+    """Rolling-12m metrics aggregate confirmed sale.order by date_order."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner_model = cls.env["res.partner"]
+        cls.ou_model = cls.env["organizational.unit"]
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Rolling12m Test Product",
+                "list_price": 100.0,
+            }
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _make_company(self, name):
+        """Create a top-level company partner (triggers OU auto-create)."""
+        partner = self.partner_model.create({"name": name, "is_company": True})
+        ou = self.ou_model.search([("owner_id", "=", partner.id)], limit=1)
+        return partner, ou
+
+    def _make_order(self, partner, amount, order_date, confirm=True):
+        """Create a sale.order, confirm it, then force date_order into the window.
+
+        ``action_confirm()`` resets ``date_order`` to now, so the desired date
+        is written *after* confirmation (the established test_us02 pattern) —
+        otherwise every order lands in the trailing window and the windowing
+        assertions become meaningless.
+        """
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": partner.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product.id,
+                            "product_uom_qty": 1,
+                            "price_unit": amount,
+                            "tax_id": False,
+                        },
+                    )
+                ],
+            }
+        )
+        if confirm:
+            order.action_confirm()
+        order.date_order = order_date
+        return order
+
+    # ------------------------------------------------------------------
+    # Test
+    # ------------------------------------------------------------------
+
+    def test_rolling_12m_bookings_windows_and_change(self):
+        """AC1-4: trailing/prior windows, draft exclusion, change percentage."""
+        partner, ou = self._make_company("Rolling12m Partner")
+        today = date.today()
+
+        # Trailing window (today-12m, today]: order ~6 months ago.
+        trailing_date = today - relativedelta(months=6)
+        self._make_order(partner, 300.0, trailing_date)
+
+        # Prior window (today-24m, today-12m]: order ~18 months ago.
+        prior_date = today - relativedelta(months=18)
+        self._make_order(partner, 200.0, prior_date)
+
+        # Draft control inside the trailing window — must be excluded (not confirmed).
+        self._make_order(partner, 999.0, trailing_date, confirm=False)
+
+        ou.invalidate_recordset()
+
+        # AC1 + AC3: trailing figure equals the single confirmed trailing order,
+        # and the draft order is excluded.
+        self.assertAlmostEqual(
+            ou.rolling_12m_sales,
+            300.0,
+            places=2,
+            msg="rolling_12m_sales must equal the confirmed trailing-window booking "
+            "(draft excluded).",
+        )
+        # AC2 + AC3: prior figure equals the single confirmed prior order.
+        self.assertAlmostEqual(
+            ou.rolling_12m_sales_prior,
+            200.0,
+            places=2,
+            msg="rolling_12m_sales_prior must equal the confirmed prior-window booking.",
+        )
+        # AC4: change percentage as a decimal.
+        self.assertAlmostEqual(
+            ou.rolling_12m_change_pct,
+            (300.0 - 200.0) / 200.0,
+            places=4,
+            msg="rolling_12m_change_pct must be (trailing - prior) / prior.",
+        )
+
+    def test_rolling_12m_excludes_out_of_window_orders(self):
+        """Confirmed orders older than 24 months are excluded from both windows."""
+        partner, ou = self._make_company("Rolling12m Out-Of-Window Partner")
+        today = date.today()
+
+        # Confirmed order 30 months ago — before the prior window's start.
+        self._make_order(partner, 500.0, today - relativedelta(months=30))
+
+        ou.invalidate_recordset()
+        self.assertAlmostEqual(
+            ou.rolling_12m_sales, 0.0, places=2,
+            msg="Orders before the 24-month horizon must not count toward trailing.",
+        )
+        self.assertAlmostEqual(
+            ou.rolling_12m_sales_prior, 0.0, places=2,
+            msg="Orders before the 24-month horizon must not count toward prior.",
+        )


### PR DESCRIPTION
## Task 3751 — Dashboard rolling-12m on a confirmed-order bookings basis (Pneumac CRM 2.3)

Repoints the customer-account dashboard's **rolling-12-month** figure (and its prior-12-month comparison) from posted-invoice revenue onto the module's **confirmed-order "bookings" basis**:

- `_compute_rolling_12m_metrics` now sums confirmed `sale.order` (`state='sale'`) by `date_order` via the existing `_sum_in_currency` helper (mixed-currency correct), **preserving the half-open window comparators** (trailing `(today-12m, today]`, prior `(today-24m, today-12m]` — no seam double-count).
- Previous-12m covers the **full prior window** using the SAP-imported history (no missing-data special-casing).
- The two rolling-12m **drill-down actions** are repointed to confirmed `sale.order` so the card buttons reconcile against the figure (AC3).
- `@api.depends` widened to mirror `_compute_quotation_metrics`; `rolling_12m_*` stay non-stored.

**Tests:** 2 new (`TestUS11Rolling12mBookings`), full module suite **110 passing / 0 fail**.

Odoo task: https://odoo.bemade.org/odoo/project/33/tasks/3751
Pipeline artifacts: https://git.bemade.org/bemade/tasks/-/tree/main/task-3751-crm-rolling12m-bookings

_Downstream `pneumac/odoo` submodule-pointer bump follows automatically once this merges. Touches the same file as #137 (different compute) — rebase the two in sequence._
