### PR TITLE
[ADD] product_uom_factor: product-specific cross-category UoM conversion

### DIFF
--- a/product_uom_factor/README.rst
+++ b/product_uom_factor/README.rst
@@ -35,27 +35,25 @@ Product UoM Conversion Factor
 Odoo 19.0 allows adding UoMs from any category to a product's
 "Packagings" (``uom_ids`` field), enabling users to sell or purchase in
 units from a different category than the product's base UoM (e.g.,
-selling ink by the liter when it is stocked by weight in grams).
+selling ink by the millilitre when it is stocked by count as pails).
 
-However, Odoo's ``_compute_quantity()`` and ``_compute_price()`` methods
-on ``uom.uom`` no longer enforce that the source and destination UoMs
-belong to the same category. When converting between UoMs of different
-categories, the conversion silently produces incorrect results —
-typically a 1:1 ratio between base units of their respective categories
-— because the standard UoM factor is relative to the category's
-reference unit, not to the product.
+However, cross-category quantities require a product-specific conversion
+factor (e.g. 1 pail = 20 000 mL) that Odoo's standard UoM system does
+not provide — standard factors are relative to the category reference
+unit, not to the product.
 
-This module adds a **conversion factor** field to the ``product.uom``
-model (the per-product/per-UoM link table). This factor represents the
-product-specific relationship between the product's base UoM and the
-cross-category UoM. For example, an ink product stocked in grams with a
-density of 1.05 g/mL would have a factor of 1.05 on its liter packaging
-UoM, meaning 1 liter = 1050 grams.
-
-The module overrides ``_compute_quantity()`` and ``_compute_price()`` so
-that when a product is available in context, cross-category conversions
-use the product-specific factor instead of producing potentially
-incoherent results.
+This module introduces ``product.uom.factor``, a **delegation model**
+(``_inherits = {'uom.uom': 'delegate_uom_id'}``). Each factor row
+creates a real ``uom.uom`` record grafted into the product's base-UoM
+tree (``relative_uom_id`` = base UoM, ``relative_factor`` = the factor),
+making it intra-tree with the base. Core ``_compute_quantity()`` and
+``_compute_price()`` then resolve the conversion natively everywhere —
+stock, MRP, purchase, sale, valuation, and PDF reports — with no
+patching. Scoping is enforced by completing Odoo's own
+``allowed_uom_ids`` pattern: factor-UoMs are added to
+``product.uom_ids`` so they appear in each line's dropdown, and an
+``@api.constrains`` on the line scoping mixin rejects a wrong
+cross-tree UoM selection at save with a clear ``ValidationError``.
 
 .. IMPORTANT::
    This is an alpha version, the data model and design can change at any time without warning.

--- a/product_uom_factor/__manifest__.py
+++ b/product_uom_factor/__manifest__.py
@@ -3,8 +3,8 @@
 
 {
     "name": "Product UoM Conversion Factor",
-    "summary": "Product-specific conversion factors for cross-category UoM conversions",
-    "version": "19.0.2.0.0",
+    "summary": "Product-specific conversion factors for cross-category UoM conversions via delegation",
+    "version": "19.0.4.0.0",
     "development_status": "Alpha",
     "license": "LGPL-3",
     "author": "Bemade Inc.",
@@ -17,5 +17,6 @@
         "security/ir.model.access.csv",
         "views/product_product_views.xml",
         "views/product_template_views.xml",
+        "views/res_config_settings_views.xml",
     ],
 }

--- a/product_uom_factor/migrations/19.0.4.0.0/post-migrate.py
+++ b/product_uom_factor/migrations/19.0.4.0.0/post-migrate.py
@@ -1,0 +1,141 @@
+# Copyright 2026 Bemade Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+"""Migration 19.0.4.0.0: Rework product.uom.factor to delegation design.
+
+For each existing product.uom.factor row:
+1. Create a delegated uom.uom record (relative_uom_id=base, relative_factor=factor)
+2. Link it via delegate_uom_id
+3. Ensure the product template's uom_ids includes the delegated UoM (additive)
+
+Also rewrites any existing transaction lines that used the global foreign UoM
+(e.g. the generic mL) for a product that now has a factor-specific delegated UoM.
+This is idempotent: lines already pointing to the delegate are skipped.
+
+On Verajet (greenfield), no transaction lines exist, so the rewrite is trivial.
+"""
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    if not version:
+        # Fresh install — ORM already handled initial creation
+        return
+
+    from odoo import api, SUPERUSER_ID
+    env = api.Environment(cr, SUPERUSER_ID, {})
+
+    Factor = env['product.uom.factor']
+    Uom = env['uom.uom']
+
+    factors = Factor.search([])
+    _logger.info(
+        "product_uom_factor 19.0.4.0.0 migration: processing %d factor rows",
+        len(factors),
+    )
+
+    migrated = 0
+    for factor in factors:
+        # Skip if delegate already exists (idempotent)
+        if factor.delegate_uom_id and factor.delegate_uom_id.id:
+            _logger.debug("Factor %d already has delegate %d, skipping", factor.id, factor.delegate_uom_id.id)
+            continue
+
+        base_uom = factor.product_tmpl_id.uom_id
+        foreign_uom = factor.foreign_uom_id  # renamed from uom_id
+        if not base_uom or not foreign_uom:
+            _logger.warning("Factor %d missing base_uom or foreign_uom, skipping", factor.id)
+            continue
+
+        # Create the delegated uom.uom
+        delegate = Uom.create({
+            'name': foreign_uom.name,
+            'relative_uom_id': base_uom.id,
+            'relative_factor': factor.factor,
+        })
+        # Write directly to the column to bypass the _inherits create path
+        cr.execute(
+            "UPDATE product_uom_factor SET delegate_uom_id = %s WHERE id = %s",
+            (delegate.id, factor.id),
+        )
+        factor.invalidate_recordset(['delegate_uom_id'])
+
+        # Ensure the product's uom_ids includes the delegate (additive)
+        tmpl = factor.product_tmpl_id
+        if delegate not in tmpl.uom_ids:
+            tmpl.uom_ids = [(4, delegate.id)]
+
+        migrated += 1
+        _logger.info(
+            "Migrated factor %d (%s→%s) for product '%s': created delegate UoM %d",
+            factor.id, foreign_uom.name, base_uom.name,
+            factor.product_tmpl_id.name, delegate.id,
+        )
+
+    _logger.info(
+        "product_uom_factor 19.0.4.0.0 migration: migrated %d/%d factor rows",
+        migrated, len(factors),
+    )
+
+    # Rewrite transaction lines: any line using the GLOBAL foreign UoM for a
+    # factored product should now point to the product's delegate UoM.
+    # This ensures stored quantities remain correct (they were computed with the
+    # old context-injection approach; the factor value is the same, so stored
+    # base-UoM quantities don't change — only the line UoM reference changes).
+    _rewrite_transaction_line_uoms(env)
+
+
+def _rewrite_transaction_line_uoms(env):
+    """Rewrite transaction lines from global foreign UoM → product factor-UoM.
+
+    For each factor row, find lines where:
+    - product_id matches the factor's product template variants
+    - product_uom_id = the global foreign_uom_id (e.g. generic mL)
+
+    And update them to use the delegate UoM instead.
+    Idempotent: lines already pointing to the delegate are skipped.
+    """
+    cr = env.cr
+    Factor = env['product.uom.factor']
+
+    line_models = [
+        ('sale.order.line', 'product_uom_id', 'product_id'),
+        ('purchase.order.line', 'product_uom_id', 'product_id'),
+        ('account.move.line', 'product_uom_id', 'product_id'),
+        ('stock.move', 'product_uom', 'product_id'),
+        ('stock.move.line', 'product_uom_id', 'product_id'),
+        ('mrp.bom.line', 'product_uom_id', 'product_id'),
+    ]
+
+    for factor in Factor.search([('delegate_uom_id', '!=', False)]):
+        foreign_uom_id = factor.foreign_uom_id.id
+        delegate_uom_id = factor.delegate_uom_id.id
+        if not foreign_uom_id or not delegate_uom_id:
+            continue
+
+        product_ids = factor.product_tmpl_id.product_variant_ids.ids
+        if not product_ids:
+            continue
+
+        for model_name, uom_field, product_field in line_models:
+            try:
+                Model = env[model_name]
+            except KeyError:
+                continue  # module not installed
+
+            table = Model._table
+            cr.execute(
+                f"""
+                UPDATE {table}
+                SET {uom_field} = %s
+                WHERE {uom_field} = %s
+                  AND {product_field} = ANY(%s)
+                """,
+                (delegate_uom_id, foreign_uom_id, product_ids),
+            )
+            if cr.rowcount:
+                _logger.info(
+                    "Rewrote %d %s lines: UoM %d → delegate %d (factor %d)",
+                    cr.rowcount, model_name, foreign_uom_id, delegate_uom_id, factor.id,
+                )

--- a/product_uom_factor/migrations/19.0.4.0.0/pre-migrate.py
+++ b/product_uom_factor/migrations/19.0.4.0.0/pre-migrate.py
@@ -1,0 +1,38 @@
+# Copyright 2026 Bemade Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+"""Pre-migration 19.0.4.0.0: rename the foreign-unit column.
+
+In the delegation rework the field ``product.uom.factor.uom_id`` (the foreign
+unit, e.g. mL) was renamed to ``foreign_uom_id``. Renaming the column here —
+before the ORM loads the new model definition — preserves the existing values
+so the post-migration can create the matching delegate UoMs. Without this, the
+ORM would add a fresh (NULL) ``foreign_uom_id`` column and orphan ``uom_id``.
+
+Guarded so it is a no-op on fresh installs or if already renamed.
+"""
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    if not version:
+        return
+    cr.execute(
+        """
+        SELECT
+            (SELECT 1 FROM information_schema.columns
+             WHERE table_name = 'product_uom_factor' AND column_name = 'uom_id'),
+            (SELECT 1 FROM information_schema.columns
+             WHERE table_name = 'product_uom_factor' AND column_name = 'foreign_uom_id')
+        """
+    )
+    has_old, has_new = cr.fetchone()
+    if has_old and not has_new:
+        _logger.info(
+            "product_uom_factor 19.0.4.0.0: renaming column "
+            "product_uom_factor.uom_id -> foreign_uom_id"
+        )
+        cr.execute(
+            "ALTER TABLE product_uom_factor RENAME COLUMN uom_id TO foreign_uom_id"
+        )

--- a/product_uom_factor/models/__init__.py
+++ b/product_uom_factor/models/__init__.py
@@ -1,4 +1,6 @@
+from . import scoping_mixin
 from . import product_product
 from . import product_template
 from . import product_uom_factor
 from . import uom_uom
+from . import res_config_settings

--- a/product_uom_factor/models/product_template.py
+++ b/product_uom_factor/models/product_template.py
@@ -1,4 +1,8 @@
+# Copyright 2026 Bemade Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
 from odoo import api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class ProductTemplate(models.Model):
@@ -12,56 +16,43 @@ class ProductTemplate(models.Model):
 
     def write(self, vals):
         res = super().write(vals)
-        if "uom_ids" in vals:
-            self._sync_uom_factor_ids()
+        if "uom_factor_ids" in vals or "uom_ids" in vals:
+            self._sync_factor_uom_ids()
         return res
 
-    def _sync_uom_factor_ids(self):
-        Factor = self.env["product.uom.factor"]
-        for template in self:
-            base_uom = template.uom_id
-            cross_uoms = template.uom_ids.filtered(
-                lambda u, bu=base_uom: not bu._has_common_reference(u)
-            )
-            existing = template.uom_factor_ids
-            # Create missing factors for cross-category UoMs
-            existing_uom_ids = existing.mapped("uom_id")
-            for uom in cross_uoms - existing_uom_ids:
-                Factor.create(
-                    {
-                        "product_tmpl_id": template.id,
-                        "uom_id": uom.id,
-                    }
-                )
-            # Delete factors whose UoM was removed from uom_ids
-            to_delete = existing.filtered(lambda f, cu=cross_uoms: f.uom_id not in cu)
-            to_delete.unlink()
+    def _sync_factor_uom_ids(self):
+        """Additive sync: ensure each factor's delegate_uom_id is in uom_ids.
 
-    @api.constrains("uom_factor_ids")
-    def _check_uom_factor_coverage(self):
-        """Ensure variant coverage for each cross-category UoM.
-        Auto-cleans duplicate catch-all lines and auto-creates missing
-        catch-alls when not all variants are explicitly covered.
-        Uses uom_ids (the template's allowed UoMs) as the source of truth
-        for which UoMs need coverage, not just existing factor lines."""
-        Factor = self.env["product.uom.factor"]
+        NEVER removes a generic unit from uom_ids. NEVER swaps. Only adds.
+        This fixes the 'factor disappears on save' bug from the old clone-swap.
+        """
         for template in self:
-            base_uom = template.uom_id
-            cross_uoms = template.uom_ids.filtered(
-                lambda u, bu=base_uom: not bu._has_common_reference(u)
-            )
-            for uom in cross_uoms:
-                siblings = template.uom_factor_ids.filtered(
-                    lambda f, u=uom: f.uom_id == u
-                )
-                # Auto-create catch-all if needed
-                catchalls = siblings.filtered(lambda f: not f.product_ids)
-                if not catchalls:
-                    covered = siblings.mapped("product_ids")
-                    if covered != template.product_variant_ids:
-                        Factor.create(
-                            {
-                                "product_tmpl_id": template.id,
-                                "uom_id": uom.id,
-                            }
+            factor_uoms = template.uom_factor_ids.mapped("delegate_uom_id")
+            existing_uoms = template.uom_ids
+            missing = factor_uoms - existing_uoms
+            if missing:
+                template.uom_ids = [fields.Command.link(uom.id) for uom in missing]
+
+    @api.constrains("uom_id", "uom_factor_ids")
+    def _check_base_uom_change(self):
+        """Block base UoM change while factor rows exist.
+
+        Changing uom_id would orphan existing factor rows whose delegate
+        has relative_uom_id pointing to the old base UoM.
+        """
+        for template in self:
+            if template.uom_factor_ids:
+                for factor in template.uom_factor_ids:
+                    if (
+                        factor.delegate_uom_id
+                        and factor.delegate_uom_id.relative_uom_id != template.uom_id
+                    ):
+                        raise ValidationError(
+                            template.env._(
+                                "Cannot change the base Unit of Measure while "
+                                "product-specific conversion factors exist. Remove "
+                                "all UoM conversion factors first, then change the "
+                                "base UoM."
+                            )
                         )
+

--- a/product_uom_factor/models/product_uom_factor.py
+++ b/product_uom_factor/models/product_uom_factor.py
@@ -1,3 +1,15 @@
+# Copyright 2026 Bemade Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+# product.uom.factor REWORK: delegation via _inherits = {'uom.uom': 'delegate_uom_id'}
+#
+# Each factor row transparently IS a uom.uom whose:
+#   - relative_uom_id = product's base UoM (e.g. "Unit")
+#   - relative_factor = the cross-category factor (e.g. 0.00005 for ink mL→Unit)
+#   - name = foreign_uom_id.name (e.g. "mL")
+#
+# This makes native core _compute_quantity/_compute_price work everywhere.
+
 from odoo import api, fields, models
 from odoo.exceptions import ValidationError
 
@@ -5,7 +17,15 @@ from odoo.exceptions import ValidationError
 class ProductUomFactor(models.Model):
     _name = "product.uom.factor"
     _description = "Product-specific UoM Conversion Factor"
+    _inherits = {"uom.uom": "delegate_uom_id"}
 
+    delegate_uom_id = fields.Many2one(
+        "uom.uom",
+        string="Delegated UoM",
+        required=True,
+        ondelete="cascade",
+        delegate=True,
+    )
     product_tmpl_id = fields.Many2one(
         "product.template",
         string="Product Template",
@@ -20,36 +40,157 @@ class ProductUomFactor(models.Model):
         help="Specific variants this factor applies to. "
         "Leave empty to apply to all variants.",
     )
-    uom_id = fields.Many2one(
+    foreign_uom_id = fields.Many2one(
         "uom.uom",
-        "Unit of Measure",
+        string="Foreign Unit",
         required=True,
         readonly=True,
         index=True,
-        ondelete="cascade",
+        ondelete="restrict",
+        help="The cross-category unit of measure (e.g. mL for an ink product "
+        "whose base UoM is Unit). Drives the delegate UoM name and the "
+        "same-category guard.",
     )
     factor = fields.Float(
         "Conversion Factor",
-        default=1.0,
         required=True,
-        help="Product-specific conversion factor for cross-category UoM "
-        "conversions. Represents how many of the product's base UoM equal "
-        "one unit of this UoM. For example, for ink with a specific "
-        "gravity of 1.05 and base UoM of grams, the factor on the mL "
-        "UoM would be 1.05 (1 mL = 1.05 g).",
+        default=1.0,
+        help="How many of the product base UoM equal one foreign unit. "
+        "e.g. 1 mL = 0.00005 Unit for ink: factor = 0.00005. "
+        "Synced to the delegated uom.uom's relative_factor.",
     )
 
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            # Auto-deduplicate: if an identical catch-all (same product_tmpl_id +
+            # foreign_uom_id + same product_ids frozenset) already exists, remove
+            # it before creating the new one.  This must run BEFORE super().create()
+            # so that the @api.constrains check never sees two identical rows.
+            tmpl_id = vals.get("product_tmpl_id")
+            foreign_uom_id = vals.get("foreign_uom_id")
+            if tmpl_id and foreign_uom_id:
+                raw_product_ids = vals.get("product_ids") or []
+                # Support both Command.link (4), Command.set (6), and
+                # plain-int id lists that Odoo sometimes passes internally.
+                incoming_ids = []
+                for cmd in raw_product_ids:
+                    if isinstance(cmd, (list, tuple)):
+                        if cmd[0] == 6:  # Command.set(0, ids)
+                            incoming_ids.extend(cmd[2])
+                        elif cmd[0] in (4, 1):  # link / update
+                            incoming_ids.append(cmd[1])
+                    elif isinstance(cmd, int):
+                        incoming_ids.append(cmd)
+                incoming_variants = frozenset(incoming_ids)
+                existing = self.search(
+                    [
+                        ("product_tmpl_id", "=", tmpl_id),
+                        ("foreign_uom_id", "=", foreign_uom_id),
+                    ]
+                )
+                for rec in existing:
+                    if frozenset(rec.product_ids.ids) == incoming_variants:
+                        rec.unlink()
+
+            if "delegate_uom_id" not in vals:
+                tmpl = self.env["product.template"].browse(vals["product_tmpl_id"])
+                foreign = self.env["uom.uom"].browse(vals.get("foreign_uom_id"))
+                factor = vals.get("factor", 1.0)
+                delegate = self.env["uom.uom"].create(
+                    {
+                        "name": foreign.name if foreign else "Unknown",
+                        "relative_uom_id": tmpl.uom_id.id,
+                        "relative_factor": factor,
+                    }
+                )
+                vals["delegate_uom_id"] = delegate.id
+        return super().create(vals_list)
+
     def write(self, vals):
-        res = super().write(vals)
-        if "product_ids" in vals:
-            self.mapped("product_tmpl_id")._check_uom_factor_coverage()
-        return res
+        if "factor" in vals:
+            self.mapped("delegate_uom_id").write(
+                {"relative_factor": vals["factor"]}
+            )
+        if "foreign_uom_id" in vals:
+            foreign = self.env["uom.uom"].browse(vals["foreign_uom_id"])
+            self.mapped("delegate_uom_id").write({"name": foreign.name})
+        return super().write(vals)
 
     def unlink(self):
-        templates = self.mapped("product_tmpl_id")
+        # Collect the delegate UoMs; after super().unlink() the factor rows are
+        # gone and the cascade on delegate_uom_id will handle them, but we need
+        # to grab them before the rows disappear.
+        delegates = self.mapped("delegate_uom_id")
         res = super().unlink()
-        templates._check_uom_factor_coverage()
+        # The ondelete='cascade' on delegate_uom_id should handle delegate
+        # deletion, but we unlink explicitly in case cascade isn't triggered.
+        delegates.filtered(lambda u: u.exists()).unlink()
         return res
+
+    @api.constrains("factor", "foreign_uom_id", "product_tmpl_id")
+    def _check_same_category_factor(self):
+        """Reject factors that are either:
+        - using the product's base UoM itself as the foreign UoM (nonsense), or
+        - using a UoM in the same category as the base UoM (intra-tree factor
+          cannot differ from the standard).
+        """
+        for rec in self:
+            base_uom = rec.product_tmpl_id.uom_id
+            if rec.foreign_uom_id == base_uom:
+                raise ValidationError(
+                    self.env._(
+                        "The foreign unit '%(uom)s' is the same as the product's "
+                        "base unit of measure. Use the standard UoM instead.",
+                        uom=rec.foreign_uom_id.name,
+                    )
+                )
+            if base_uom._has_common_reference(rec.foreign_uom_id):
+                raise ValidationError(
+                    self.env._(
+                        "The unit '%(uom)s' is in the same category as the product's "
+                        "base UoM '%(base_uom)s'. Cross-category factors are only "
+                        "needed for units in a different tree. The standard conversion "
+                        "already handles same-category conversions.",
+                        uom=rec.foreign_uom_id.name,
+                        base_uom=base_uom.name,
+                    )
+                )
+
+    @api.constrains("product_ids", "foreign_uom_id", "product_tmpl_id")
+    def _check_no_duplicate_factors(self):
+        """Raise if any two records share the same (product_tmpl_id, foreign_uom_id,
+        frozenset(product_ids)).
+
+        NOTE: create() pre-deduplicates before calling super(), so this constraint
+        is a safety net for direct write() calls that would produce duplicates.
+        It must NOT call unlink() — doing so inside @api.constrains raises
+        MissingError in Odoo 19 because the record being validated cannot be
+        deleted mid-constraint.
+        """
+        tmpl_uom_pairs = {
+            (rec.product_tmpl_id.id, rec.foreign_uom_id.id) for rec in self
+        }
+        for tmpl_id, uom_id in tmpl_uom_pairs:
+            siblings = self.search(
+                [
+                    ("product_tmpl_id", "=", tmpl_id),
+                    ("foreign_uom_id", "=", uom_id),
+                ]
+            )
+            seen_keys = []
+            for sib in siblings:
+                key = (uom_id, tmpl_id, frozenset(sib.product_ids.ids))
+                if key in seen_keys:
+                    raise ValidationError(
+                        self.env._(
+                            "A conversion factor for '%(uom)s' already exists on "
+                            "this product with the same variant scope. "
+                            "Remove the existing row before adding a new one.",
+                            uom=sib.foreign_uom_id.name,
+                        )
+                    )
+                seen_keys.append(key)
 
     @api.constrains("product_ids", "product_tmpl_id")
     def _check_product_ids_same_template(self):
@@ -60,46 +201,3 @@ class ProductUomFactor(models.Model):
                 raise ValidationError(
                     self.env._("All variants must belong to the same product template.")
                 )
-
-    @api.constrains("product_ids", "uom_id", "product_tmpl_id")
-    def _check_no_duplicate_factors(self):
-        """Auto-clean duplicate factor lines, then raise if any remain.
-        A duplicate is defined as two records with the same
-        (uom_id, product_tmpl_id, frozenset(product_ids))."""
-        tmpl_uom_pairs = {(rec.product_tmpl_id.id, rec.uom_id.id) for rec in self}
-        for tmpl_id, uom_id in tmpl_uom_pairs:
-            siblings = self.search(
-                [
-                    ("product_tmpl_id", "=", tmpl_id),
-                    ("uom_id", "=", uom_id),
-                ]
-            )
-            keys = []
-            to_delete = self.browse()
-            for sib in siblings:
-                key = (uom_id, tmpl_id, frozenset(sib.product_ids.ids))
-                if key in keys:
-                    to_delete |= sib
-                else:
-                    keys.append(key)
-            if to_delete:
-                to_delete.unlink()
-
-    @api.constrains("factor", "uom_id", "product_tmpl_id")
-    def _check_same_category_factor(self):
-        for rec in self:
-            base_uom = rec.product_tmpl_id.uom_id
-            if base_uom._has_common_reference(rec.uom_id):
-                expected = rec.uom_id.factor / base_uom.factor
-                if rec.factor != expected:
-                    raise ValidationError(
-                        self.env._(
-                            "The conversion factor for %(uom)s cannot be "
-                            "customized because it is in the same category "
-                            "as the product's base UoM (%(base_uom)s). "
-                            "Expected factor: %(expected)s.",
-                            uom=rec.uom_id.name,
-                            base_uom=base_uom.name,
-                            expected=expected,
-                        )
-                    )

--- a/product_uom_factor/models/res_config_settings.py
+++ b/product_uom_factor/models/res_config_settings.py
@@ -1,0 +1,20 @@
+# Copyright 2026 Bemade Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    enforce_factor_uom_scoping = fields.Boolean(
+        string="Enforce UoM scoping for cross-category conversions",
+        help="When enabled (default), lines that use a UoM from a different unit tree "
+        "than the product's base UoM are validated against the product's registered "
+        "cross-category conversion factors. Attempting to save a line with an unrelated "
+        "cross-tree UoM raises a validation error.\n\n"
+        "Disable only if you need to allow arbitrary cross-tree UoM selections on order "
+        "and move lines (vanilla Odoo behaviour, no factor validation).",
+        config_parameter="product_uom_factor.enforce_factor_uom_scoping",
+        default=True,
+    )

--- a/product_uom_factor/models/scoping_mixin.py
+++ b/product_uom_factor/models/scoping_mixin.py
@@ -1,0 +1,163 @@
+# Copyright 2026 Bemade Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo import api, fields, models
+from odoo.exceptions import ValidationError
+from odoo.tools.misc import str2bool
+
+_ENFORCE_KEY = "product_uom_factor.enforce_factor_uom_scoping"
+
+
+class ProductUomFactorLineMixin(models.AbstractModel):
+    """Mixin for order/move lines that carry a (product, uom) pair.
+
+    Provides:
+
+    - ``_compute_allowed_uom_ids``: a super-extending compute that only does
+      work when no parent class already provides it (i.e. effectively only
+      ``mrp.bom.line``, which has no core ``allowed_uom_ids`` compute).  For
+      every other target model (``sale.order.line``, ``purchase.order.line``,
+      ``stock.move``, ``stock.move.line``, ``account.move.line``) the core
+      compute already reads ``product_id.uom_id | product_id.uom_ids``, so the
+      factor-specific delegate UoMs reach the allowed list through
+      ``product.uom_ids`` (additive template sync) without any extra union.
+    - ``_get_factor_uom_ids``: helper that returns the product's delegated
+      factor UoMs.  Still used by ``_check_factor_uom_allowed``; **not** unioned
+      into ``allowed_uom_ids`` — the delegate is already in ``product.uom_ids``.
+    - ``_check_factor_uom_allowed(uom_field_name)``: raises a clear
+      ``ValidationError`` if the line's chosen UoM is genuinely cross-tree and
+      not one of the product's factor delegates, **unless** the
+      ``product_uom_factor.enforce_factor_uom_scoping`` ir.config_parameter is
+      set to ``False`` (defaults to ``True``).
+
+    Toggle behaviour
+    ----------------
+    When ``enforce_factor_uom_scoping = True`` (default):
+      - ``_check_factor_uom_allowed`` raises ``ValidationError`` for any
+        cross-tree UoM that is not one of the product's factor delegates.
+      - The domain on UoM selector fields restricts choices to the product's
+        allowed set (``product_id.uom_id | product_id.uom_ids``).
+
+    When ``enforce_factor_uom_scoping = False``:
+      - ``_check_factor_uom_allowed`` is a no-op — lines save with any UoM
+        (vanilla Odoo behaviour).
+      - The UoM field domain is relaxed: no restriction is applied by this
+        module (core domains still apply where the model has them).
+
+    This mixin deliberately does NOT declare an ``@api.constrains`` itself,
+    because the consuming models use different UoM field names
+    (``product_uom_id`` on most lines, ``product_uom`` on ``stock.move``).
+    Each ``_inherit`` stub declares its own ``@api.constrains`` referencing the
+    correct field name and delegates to ``_check_factor_uom_allowed``.
+    """
+
+    _name = "product.uom.factor.line.mixin"
+    _description = "Product UoM Factor Line Mixin"
+
+    # Declared here so mrp.bom.line (which inherits the mixin) has the field.
+    # Models that already define allowed_uom_ids in core (sale, purchase, stock,
+    # account) have the field from there; this declaration is a no-op for them.
+    allowed_uom_ids = fields.Many2many("uom.uom", compute="_compute_allowed_uom_ids")
+
+    @api.depends("product_id", "product_id.uom_id", "product_id.uom_ids")
+    def _compute_allowed_uom_ids(self):
+        """Super-extending compute for allowed_uom_ids.
+
+        Delegates to the parent compute if one exists (sale, purchase, stock.*,
+        account.move.line all have one that reads product_id.uom_id |
+        product_id.uom_ids — factor delegates ride in via uom_ids, no explicit
+        union needed).
+
+        For models with no parent compute (effectively only mrp.bom.line) we
+        mirror core's pattern: product_id.uom_id | product_id.uom_ids.
+        """
+        parent = getattr(super(), "_compute_allowed_uom_ids", None)
+        if parent:
+            parent()
+            return
+        # No parent compute — provide the standard set (factor delegates are
+        # already in product.uom_ids via the additive template sync).
+        for line in self:
+            product = line.product_id
+            if not product:
+                line.allowed_uom_ids = self.env["uom.uom"]
+            else:
+                line.allowed_uom_ids = product.uom_id | product.uom_ids
+
+    def _get_factor_uom_ids(self):
+        """Return the product's factor-specific delegated UoMs.
+
+        Used by ``_check_factor_uom_allowed`` to validate cross-tree UoM
+        selections.  Not unioned into ``allowed_uom_ids`` — the delegates reach
+        the allowed list through ``product.uom_ids`` (additive template sync).
+        """
+        product = getattr(self, "product_id", False) or getattr(
+            self, "product_tmpl_id", False
+        )
+        if not product:
+            return self.env["uom.uom"]
+        if product._name == "product.template":
+            tmpl = product
+        else:
+            tmpl = product.product_tmpl_id
+        return tmpl.uom_factor_ids.mapped("delegate_uom_id")
+
+    def _is_factor_uom_scoping_enforced(self):
+        """Return True when the scoping constraint is active (default).
+
+        Reads ``ir.config_parameter`` once per constraint batch call.  The
+        parameter stores a string "True" / "False"; absent param = True
+        (default-on).
+        """
+        raw = (
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param(_ENFORCE_KEY, default="True")
+        )
+        return str2bool(raw, True)
+
+    def _check_factor_uom_allowed(self, uom_field_name):
+        """Raise if the line's chosen UoM is not in the product's allowed set.
+
+        No-ops immediately when ``enforce_factor_uom_scoping`` is False so that
+        cross-tree UoM selections are permitted (vanilla Odoo behaviour).
+
+        :param uom_field_name: the name of the UoM field on the consuming model
+            (e.g. ``"product_uom_id"`` or ``"product_uom"``).
+        """
+        if not self._is_factor_uom_scoping_enforced():
+            return
+        for rec in self:
+            product = getattr(rec, "product_id", False)
+            product_uom = getattr(rec, uom_field_name, False)
+            if not product or not product_uom:
+                continue
+            base_uom = product.uom_id
+            if not base_uom:
+                continue
+            # Same-category (common-reference) UoMs are always fine: native
+            # Odoo converts them correctly. We only police genuinely cross-tree
+            # UoMs, which MUST be one of the product's factor delegates.
+            if base_uom._has_common_reference(product_uom):
+                continue
+            # For cross-tree units, check they are a factor delegate for this
+            # product. The delegate is in product.uom_ids (via additive sync),
+            # so checking uom_ids is equivalent — but _get_factor_uom_ids is
+            # more precise for the error message (lists only factor UoMs).
+            factor_uoms = rec._get_factor_uom_ids()
+            if product_uom not in factor_uoms:
+                allowed = product.uom_ids | factor_uoms
+                raise ValidationError(
+                    rec.env._(
+                        "Unit of measure '%(uom)s' is not allowed for product "
+                        "'%(product)s': it is in a different unit tree and is not "
+                        "one of the product's cross-category conversion factors. "
+                        "Add a conversion factor for this unit on the product "
+                        "form, or pick one of: %(allowed)s.",
+                        uom=product_uom.name,
+                        product=product.display_name,
+                        allowed=", ".join(
+                            (base_uom | allowed).mapped("name")
+                        ),
+                    )
+                )

--- a/product_uom_factor/models/uom_uom.py
+++ b/product_uom_factor/models/uom_uom.py
@@ -1,126 +1,31 @@
-from __future__ import annotations
+# Copyright 2026 Bemade Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
-from typing import TYPE_CHECKING
-
-from odoo import models, tools
-
-if TYPE_CHECKING:
-    from odoo.tools.float_utils import RoundingMethod
+from odoo import api, fields, models
 
 
 class UomUom(models.Model):
     _inherit = "uom.uom"
 
-    def _get_product_uom_factor(self, product_id, from_uom, to_uom):
-        """Look up the product-specific cross-category conversion factor.
+    # Inverse of product.uom.factor.delegate_uom_id — used as a @api.depends
+    # trigger so that is_product_factor recomputes automatically when a factor
+    # row is created or deleted.
+    uom_factor_delegate_ids = fields.One2many(
+        "product.uom.factor",
+        "delegate_uom_id",
+        string="Factor Rows (as delegate)",
+        readonly=True,
+    )
 
-        Returns the factor to multiply the quantity by when converting from
-        from_uom to to_uom for the given product, or None if no
-        product-specific factor applies.
+    is_product_factor = fields.Boolean(
+        "Product-Specific Factor",
+        compute="_compute_is_product_factor",
+        store=True,
+        help="True when this UoM is a delegation record created by a "
+        "product.uom.factor row.",
+    )
 
-        Strategy: convert from_uom → product base UoM → to_uom.
-        For each leg, if the UoM is in the same category as the base UoM,
-        use the standard UoM factor. If cross-category, find the
-        product.uom.factor record whose uom_id shares a category with
-        that UoM, and use its
-        factor combined with the standard intra-category conversion.
-        """
-        product = self.env["product.product"].browse(product_id)
-        if not product.exists():
-            return None
-        base_uom = product.uom_id
-
-        from_is_cross = not base_uom._has_common_reference(from_uom)
-        to_is_cross = not base_uom._has_common_reference(to_uom)
-
-        # Leg 1: from_uom → base_uom (in base_uom units)
-        if from_is_cross:
-            puom = self._find_product_uom_for_category(product_id, from_uom)
-            # qty_base = qty * (from_uom.factor / puom.uom_id.factor) * puom.factor
-            # i.e. convert from_uom to the packaging reference, then apply factor
-            from_to_base = from_uom.factor / puom.uom_id.factor * puom.factor
-        else:
-            # Standard intra-category: from_uom → base_uom
-            from_to_base = from_uom.factor / base_uom.factor
-
-        # Leg 2: base_uom → to_uom (multiplier to get to_uom units)
-        if to_is_cross:
-            puom = self._find_product_uom_for_category(product_id, to_uom)
-            # base_to_to = (puom.uom_id.factor / to_uom.factor) / puom.factor
-            base_to_to = puom.uom_id.factor / to_uom.factor / puom.factor
-        else:
-            # Standard intra-category: base_uom → to_uom
-            base_to_to = base_uom.factor / to_uom.factor
-
-        return from_to_base * base_to_to
-
-    def _find_product_uom_for_category(self, product_id, uom):
-        """Find the product.uom.factor record whose uom_id is in the same
-        category as the given uom.
-
-        Searches for factors that apply to the given product variant:
-        either variant-specific (product_ids contains the variant) or
-        template-wide (product_ids is empty). Variant-specific factors
-        take precedence.
-        """
-        if not isinstance(product_id, int):
-            return None
-        product = self.env["product.product"].browse(product_id)
-        Factor = self.env["product.uom.factor"]
-        domain = [
-            ("product_tmpl_id", "=", product.product_tmpl_id.id),
-            "|",
-            ("product_ids", "=", False),
-            ("product_ids", "in", product_id),
-        ]
-        # First try exact UoM match
-        exact = Factor.search(
-            domain + [("uom_id", "=", uom.id)],
-            limit=1,
-        )
-        if exact:
-            return exact
-        # Find any factor in the same category
-        for f in Factor.search(domain):
-            if f.uom_id._has_common_reference(uom):
-                return f
-
-    def _compute_quantity(
-        self,
-        qty,
-        to_unit,
-        round=True,
-        rounding_method: RoundingMethod = "UP",
-        raise_if_failure=True,
-    ):
-        if self and self != to_unit:
-            self.ensure_one()
-            product_id = self.env.context.get("product_id")
-            if product_id and not self._has_common_reference(to_unit):
-                conversion = self._get_product_uom_factor(product_id, self, to_unit)
-                if conversion is not None:
-                    amount = qty * conversion
-                    if to_unit and round:
-                        amount = tools.float_round(
-                            amount,
-                            precision_rounding=to_unit.rounding,
-                            rounding_method=rounding_method,
-                        )
-                    return amount
-        return super()._compute_quantity(
-            qty,
-            to_unit,
-            round=round,
-            rounding_method=rounding_method,
-            raise_if_failure=raise_if_failure,
-        )
-
-    def _compute_price(self, price, to_unit):
-        if self and self != to_unit:
-            self.ensure_one()
-            product_id = self.env.context.get("product_id")
-            if product_id and not self._has_common_reference(to_unit):
-                conversion = self._get_product_uom_factor(product_id, self, to_unit)
-                if conversion is not None:
-                    return price / conversion
-        return super()._compute_price(price, to_unit)
+    @api.depends("uom_factor_delegate_ids")
+    def _compute_is_product_factor(self):
+        for uom in self:
+            uom.is_product_factor = bool(uom.uom_factor_delegate_ids)

--- a/product_uom_factor/readme/DESCRIPTION.md
+++ b/product_uom_factor/readme/DESCRIPTION.md
@@ -1,24 +1,22 @@
 Odoo 19.0 allows adding UoMs from any category to a product's "Packagings"
 (`uom_ids` field), enabling users to sell or purchase in units from a different
-category than the product's base UoM (e.g., selling ink by the liter when it is
-stocked by weight in grams).
+category than the product's base UoM (e.g., selling ink by the millilitre when
+it is stocked by count as pails).
 
-However, Odoo's `_compute_quantity()` and `_compute_price()` methods on `uom.uom`
-no longer enforce that the source and destination UoMs belong to the same category.
-When converting between UoMs of different categories, the conversion silently
-produces incorrect results — typically a 1:1 ratio between base units of their
-respective categories — because the standard UoM factor is relative to the
-category's reference unit, not to the product.
+However, cross-category quantities require a product-specific conversion factor
+(e.g. 1 pail = 20 000 mL) that Odoo's standard UoM system does not provide —
+standard factors are relative to the category reference unit, not to the product.
 
-This module adds a **conversion factor** field to the `product.uom` model (the
-per-product/per-UoM link table). This factor represents the product-specific
-relationship between the product's base UoM and the cross-category UoM. For
-example, an ink product stocked in grams with a density of 1.05 g/mL would have
-a factor of 1.05 on its liter packaging UoM, meaning 1 liter = 1050 grams.
-
-The module overrides `_compute_quantity()` and `_compute_price()` so that when a
-product is available in context, cross-category conversions use the product-specific
-factor instead of producing potentially incoherent results.
+This module introduces `product.uom.factor`, a **delegation model**
+(`_inherits = {'uom.uom': 'delegate_uom_id'}`). Each factor row creates a real
+`uom.uom` record grafted into the product's base-UoM tree (`relative_uom_id` =
+base UoM, `relative_factor` = the factor), making it intra-tree with the base.
+Core `_compute_quantity()` and `_compute_price()` then resolve the conversion
+natively everywhere — stock, MRP, purchase, sale, valuation, and PDF reports —
+with no patching. Scoping is enforced by completing Odoo's own `allowed_uom_ids`
+pattern: factor-UoMs are added to `product.uom_ids` so they appear in each
+line's dropdown, and an `@api.constrains` on the line scoping mixin rejects a
+wrong cross-tree UoM selection at save with a clear `ValidationError`.
 
 ## Bridge modules
 

--- a/product_uom_factor/tests/test_uc1_product_uom_factor.py
+++ b/product_uom_factor/tests/test_uc1_product_uom_factor.py
@@ -1,31 +1,32 @@
 """
-Test UC1: Product-Specific Cross-Category Conversion Factor
+Test UC1: Product-Specific Cross-Category Conversion Factor (Delegation Design)
 
 As a product manager, I want to define a conversion factor on a product's
-packaging UoM so that the system can correctly convert between UoMs of
+foreign UoM so that the system can correctly convert between UoMs of
 different categories (e.g. volume to weight) for that specific product.
+
+The v4 design delegates via _inherits = {'uom.uom': 'delegate_uom_id'}.
+Each product.uom.factor row IS a uom.uom (the delegate) whose:
+  - relative_uom_id = product's base UoM
+  - relative_factor = the cross-category factor
+  - name = foreign_uom_id.name
 
 Acceptance Criteria:
 - A factor field exists on product.uom.factor and defaults to 1.0
 - The factor can store a custom value (e.g. 1.05 for specific gravity)
-- The factor represents: 1 unit of the packaging UoM = factor units of the
-  product's base UoM (e.g. 1 mL = 1.05 g for ink with SG 1.05)
-- The factor for units within the same category cannot be set to a value
-  different from the unit's default
+- Creating a factor row auto-creates a delegate uom.uom with the correct
+  relative_uom_id, relative_factor, and name
+- The delegate_uom_id.relative_factor is updated when factor is changed
+- The foreign unit (foreign_uom_id) cannot be the product's base UoM itself
+- The foreign unit cannot be in the same category as the product's base UoM
+  (intra-category conversion is handled by core; cross-category delegation only)
 - A product.uom.factor record is linked to a product.template via
-  product_tmpl_id, with an optional product_ids M2M to restrict to
-  specific variants (empty = applies to all variants)
-- A variant can only appear on one product.uom.factor per uom_id
+  product_tmpl_id, with an optional product_ids M2M to restrict to specific
+  variants (empty = applies to all variants)
 - All product_ids must belong to the same product_tmpl_id
-- When a cross-category UoM is added to a product's uom_ids, a
-  product.uom.factor record is auto-created with factor=1.0 and no
-  variant discriminator (applies to all variants)
-- When a cross-category UoM is removed from uom_ids, the corresponding
-  product.uom.factor record is deleted
-- Adding a same-category UoM to uom_ids does not create a factor record
-- When variants are assigned to a factor line but not all variants are
-  covered, a no-discriminator (catch-all) line is preserved or re-created
-  so that uncovered variants still have a conversion factor
+- A variant can only appear on one product.uom.factor per foreign_uom_id
+- The delegate UoM is added to the product's uom_ids (additive sync only)
+- Blocking base UoM change while factor rows exist
 """
 
 from odoo.exceptions import ValidationError
@@ -48,19 +49,99 @@ class TestUC1ProductUomFactor(TransactionCase):
         )
 
     def test_factor_field_exists_with_default(self):
-        """The factor field should exist on product.uom.factor and default
-        to 1.0."""
-        product_uom = self.env["product.uom.factor"].create(
+        """The factor field should exist on product.uom.factor and default to 1.0."""
+        factor = self.env["product.uom.factor"].create(
             {
                 "product_tmpl_id": self.product.product_tmpl_id.id,
-                "uom_id": self.uom_ml.id,
+                "foreign_uom_id": self.uom_ml.id,
             }
         )
-        self.assertEqual(
-            product_uom.factor,
-            1.0,
-            "The factor field should default to 1.0",
+        self.assertEqual(factor.factor, 1.0, "The factor field should default to 1.0")
+
+    def test_delegate_uom_created_on_factor_create(self):
+        """Creating a factor row should auto-create a delegate uom.uom."""
+        factor = self.env["product.uom.factor"].create(
+            {
+                "product_tmpl_id": self.product.product_tmpl_id.id,
+                "foreign_uom_id": self.uom_ml.id,
+                "factor": 1.05,
+            }
         )
+        self.assertTrue(factor.delegate_uom_id, "Delegate uom.uom should be created")
+        self.assertEqual(
+            factor.delegate_uom_id.relative_uom_id,
+            self.product.uom_id,
+            "Delegate relative_uom_id should be the product's base UoM",
+        )
+        self.assertAlmostEqual(
+            factor.delegate_uom_id.relative_factor,
+            1.05,
+            places=5,
+            msg="Delegate relative_factor should match the factor value",
+        )
+        self.assertEqual(
+            factor.delegate_uom_id.name,
+            self.uom_ml.name,
+            "Delegate name should match the foreign UoM name",
+        )
+
+    def test_factor_write_updates_delegate(self):
+        """Changing the factor field should update the delegate's relative_factor."""
+        factor = self.env["product.uom.factor"].create(
+            {
+                "product_tmpl_id": self.product.product_tmpl_id.id,
+                "foreign_uom_id": self.uom_ml.id,
+                "factor": 1.05,
+            }
+        )
+        factor.factor = 1.10
+        self.assertAlmostEqual(
+            factor.delegate_uom_id.relative_factor,
+            1.10,
+            places=5,
+            msg="Delegate relative_factor should be updated when factor changes",
+        )
+
+    def test_delegate_added_to_product_uom_ids(self):
+        """The delegate UoM should be in the product template's uom_ids after sync."""
+        template = self.product.product_tmpl_id
+        factor = self.env["product.uom.factor"].create(
+            {
+                "product_tmpl_id": template.id,
+                "foreign_uom_id": self.uom_ml.id,
+                "factor": 1.05,
+            }
+        )
+        # Trigger sync
+        template.write({"uom_factor_ids": [(4, factor.id)]})
+        self.assertIn(
+            factor.delegate_uom_id,
+            template.uom_ids,
+            "Delegate UoM should be added to template uom_ids",
+        )
+
+    def test_base_uom_as_foreign_rejected(self):
+        """Setting the base UoM as the foreign UoM should raise ValidationError."""
+        with self.assertRaises(ValidationError):
+            self.env["product.uom.factor"].create(
+                {
+                    "product_tmpl_id": self.product.product_tmpl_id.id,
+                    "foreign_uom_id": self.uom_gram.id,  # same as base UoM
+                    "factor": 1.0,
+                }
+            )
+
+    def test_same_category_foreign_uom_rejected(self):
+        """A foreign UoM in the same category as the base UoM should raise."""
+        uom_kg = self.env.ref("uom.product_uom_kgm")
+        with self.assertRaises(ValidationError):
+            self.env["product.uom.factor"].create(
+                {
+                    "product_tmpl_id": self.product.product_tmpl_id.id,
+                    "foreign_uom_id": uom_kg.id,
+                    "factor": 1000.0,
+                }
+            )
 
     def test_product_ids_must_belong_to_same_template(self):
         """Assigning a variant from a different template should raise."""
@@ -70,264 +151,59 @@ class TestUC1ProductUomFactor(TransactionCase):
         factor = self.env["product.uom.factor"].create(
             {
                 "product_tmpl_id": self.product.product_tmpl_id.id,
-                "uom_id": self.uom_ml.id,
+                "foreign_uom_id": self.uom_ml.id,
             }
         )
-        with self._assertRaises(ValidationError):
+        with self.assertRaises(ValidationError):
             factor.product_ids = [(4, other_product.id)]
 
-    def test_same_category_factor_cannot_differ(self):
-        """A packaging UoM in the same category as the product's base UoM
-        should not allow a factor different from the standard UoM ratio.
-        E.g. kg on a product with base UoM g must have factor = 1000."""
-        uom_kg = self.env.ref("uom.product_uom_kgm")
-        with self._assertRaises(Exception):
-            self.env["product.uom.factor"].create(
-                {
-                    "product_tmpl_id": self.product.product_tmpl_id.id,
-                    "uom_id": uom_kg.id,
-                    "factor": 500.0,
-                }
-            )
-
-    def test_same_category_factor_with_correct_ratio(self):
-        """A same-category factor with the correct standard ratio should
-        be accepted without error."""
-        uom_kg = self.env.ref("uom.product_uom_kgm")
-        factor = self.env["product.uom.factor"].create(
+    def test_no_duplicate_factors_same_foreign_uom(self):
+        """Two factor records with the same (template, foreign_uom, product_ids)
+        should not both persist — the duplicate is removed."""
+        template = self.product.product_tmpl_id
+        # Creating two identical catch-alls; the second should trigger cleanup
+        self.env["product.uom.factor"].create(
             {
-                "product_tmpl_id": self.product.product_tmpl_id.id,
-                "uom_id": uom_kg.id,
-                "factor": uom_kg.factor / self.uom_gram.factor,
+                "product_tmpl_id": template.id,
+                "foreign_uom_id": self.uom_ml.id,
+                "factor": 1.05,
             }
         )
-        self.assertTrue(factor)
-
-    def test_auto_create_factor_on_cross_category_uom_add(self):
-        """Adding a cross-category UoM to uom_ids should auto-create a
-        product.uom.factor record with factor=1.0 and no discriminator."""
-        template = self.product.product_tmpl_id
-        template.uom_ids = [(4, self.uom_ml.id)]
-        factor = self.env["product.uom.factor"].search(
-            [
-                ("product_tmpl_id", "=", template.id),
-                ("uom_id", "=", self.uom_ml.id),
-            ]
-        )
-        self.assertEqual(len(factor), 1)
-        self.assertEqual(factor.factor, 1.0)
-        self.assertFalse(factor.product_ids)
-
-    def test_auto_delete_factor_on_cross_category_uom_remove(self):
-        """Removing a cross-category UoM from uom_ids should delete the
-        corresponding product.uom.factor record."""
-        template = self.product.product_tmpl_id
-        template.uom_ids = [(4, self.uom_ml.id)]
-        factor = self.env["product.uom.factor"].search(
-            [
-                ("product_tmpl_id", "=", template.id),
-                ("uom_id", "=", self.uom_ml.id),
-            ]
-        )
-        self.assertEqual(len(factor), 1)
-        template.uom_ids = [(3, self.uom_ml.id)]
-        factor = self.env["product.uom.factor"].search(
-            [
-                ("product_tmpl_id", "=", template.id),
-                ("uom_id", "=", self.uom_ml.id),
-            ]
-        )
-        self.assertEqual(len(factor), 0)
-
-    def test_same_category_uom_no_factor_created(self):
-        """Adding a same-category UoM to uom_ids should not create a
-        product.uom.factor record."""
-        template = self.product.product_tmpl_id
-        uom_kg = self.env.ref("uom.product_uom_kgm")
-        template.uom_ids = [(4, uom_kg.id)]
-        factor = self.env["product.uom.factor"].search(
-            [
-                ("product_tmpl_id", "=", template.id),
-                ("uom_id", "=", uom_kg.id),
-            ]
-        )
-        self.assertEqual(len(factor), 0)
-
-    def test_catchall_line_when_not_all_variants_covered(self):
-        """When a user assigns specific variants to a factor line but not
-        all variants are covered, a no-discriminator catch-all line must
-        exist so uncovered variants still have a conversion factor."""
-        # Create a template with two variants
-        attr = self.env["product.attribute"].create({"name": "Color"})
-        val_red = self.env["product.attribute.value"].create(
-            {"name": "Red", "attribute_id": attr.id}
-        )
-        val_blue = self.env["product.attribute.value"].create(
-            {"name": "Blue", "attribute_id": attr.id}
-        )
-        template = self.env["product.template"].create(
+        self.env["product.uom.factor"].create(
             {
-                "name": "Test Ink",
-                "uom_id": self.uom_gram.id,
-                "attribute_line_ids": [
-                    (
-                        0,
-                        0,
-                        {
-                            "attribute_id": attr.id,
-                            "value_ids": [(6, 0, [val_red.id, val_blue.id])],
-                        },
-                    )
-                ],
+                "product_tmpl_id": template.id,
+                "foreign_uom_id": self.uom_ml.id,
+                "factor": 1.10,
             }
         )
-        self.assertEqual(len(template.product_variant_ids), 2)
-        variant_red = template.product_variant_ids[0]
-
-        # Add cross-category UoM → creates catch-all factor line
-        template.uom_ids = [(4, self.uom_ml.id)]
-        factors = self.env["product.uom.factor"].search(
-            [("product_tmpl_id", "=", template.id), ("uom_id", "=", self.uom_ml.id)]
-        )
-        self.assertEqual(len(factors), 1)
-        catchall = factors.filtered(lambda f: not f.product_ids)
-        self.assertEqual(len(catchall), 1)
-
-        # Assign one variant to the existing line → should create a new
-        # catch-all for the uncovered variant
-        catchall.product_ids = [(4, variant_red.id)]
-        factors = self.env["product.uom.factor"].search(
-            [("product_tmpl_id", "=", template.id), ("uom_id", "=", self.uom_ml.id)]
-        )
-        self.assertEqual(len(factors), 2)
-        new_catchall = factors.filtered(lambda f: not f.product_ids)
-        self.assertEqual(
-            len(new_catchall),
-            1,
-            "A catch-all line should exist for uncovered variants",
-        )
-
-    def test_catchall_recreated_on_discriminated_line_delete(self):
-        """Deleting a discriminated factor line should re-create a catch-all
-        if not all variants are still covered."""
-        attr = self.env["product.attribute"].create({"name": "Size"})
-        val_s = self.env["product.attribute.value"].create(
-            {"name": "S", "attribute_id": attr.id}
-        )
-        val_m = self.env["product.attribute.value"].create(
-            {"name": "M", "attribute_id": attr.id}
-        )
-        template = self.env["product.template"].create(
-            {
-                "name": "Test Ink",
-                "uom_id": self.uom_gram.id,
-                "attribute_line_ids": [
-                    (
-                        0,
-                        0,
-                        {
-                            "attribute_id": attr.id,
-                            "value_ids": [(6, 0, [val_s.id, val_m.id])],
-                        },
-                    )
-                ],
-            }
-        )
-        variant_s, variant_m = template.product_variant_ids
-        Factor = self.env["product.uom.factor"]
-
-        # Add cross-category UoM → auto-creates catch-all
-        template.uom_ids = [(4, self.uom_ml.id)]
-        catchall = template.uom_factor_ids.filtered(
-            lambda f: f.uom_id == self.uom_ml and not f.product_ids
-        )
-        self.assertEqual(len(catchall), 1)
-
-        # Assign each variant to its own line, covering all variants
-        catchall.product_ids = [(4, variant_s.id)]
-        catchall.factor = 1.05
-        f_s = catchall
-        f_m = Factor.search(
+        remaining = self.env["product.uom.factor"].search(
             [
                 ("product_tmpl_id", "=", template.id),
-                ("uom_id", "=", self.uom_ml.id),
-                ("id", "!=", f_s.id),
+                ("foreign_uom_id", "=", self.uom_ml.id),
                 ("product_ids", "=", False),
             ]
         )
-        f_m.product_ids = [(4, variant_m.id)]
-        f_m.factor = 1.10
-
-        # Delete one → variant_m is no longer covered
-        f_m.unlink()
-        factors = Factor.search(
-            [("product_tmpl_id", "=", template.id), ("uom_id", "=", self.uom_ml.id)]
-        )
-        catchall = factors.filtered(lambda f: not f.product_ids)
         self.assertEqual(
-            len(catchall),
+            len(remaining),
             1,
-            "A catch-all should be re-created after deleting a discriminated line",
+            "Duplicate catch-all factor rows should be auto-cleaned",
         )
 
-    def test_duplicate_catchall_removed_when_variants_cleared(self):
-        """Clearing product_ids on a discriminated line makes it a catch-all.
-        If another catch-all already exists for the same (template, uom),
-        the duplicate must be removed."""
-        attr = self.env["product.attribute"].create({"name": "Finish"})
-        val_a = self.env["product.attribute.value"].create(
-            {"name": "Matte", "attribute_id": attr.id}
-        )
-        val_b = self.env["product.attribute.value"].create(
-            {"name": "Gloss", "attribute_id": attr.id}
-        )
+    def test_base_uom_change_blocked_with_factors(self):
+        """Changing the product's base UoM while factor rows exist should raise."""
+        uom_liter = self.env.ref("uom.product_uom_litre")
         template = self.env["product.template"].create(
             {
-                "name": "Test Ink",
+                "name": "Test Ink for Block Test",
                 "uom_id": self.uom_gram.id,
-                "attribute_line_ids": [
-                    (
-                        0,
-                        0,
-                        {
-                            "attribute_id": attr.id,
-                            "value_ids": [(6, 0, [val_a.id, val_b.id])],
-                        },
-                    )
-                ],
             }
         )
-        variant_a = template.product_variant_ids[0]
-        Factor = self.env["product.uom.factor"]
-
-        # Auto-create catch-all via uom_ids
-        template.uom_ids = [(4, self.uom_ml.id)]
-        catchall = Factor.search(
-            [
-                ("product_tmpl_id", "=", template.id),
-                ("uom_id", "=", self.uom_ml.id),
-                ("product_ids", "=", False),
-            ]
+        self.env["product.uom.factor"].create(
+            {
+                "product_tmpl_id": template.id,
+                "foreign_uom_id": self.uom_ml.id,
+                "factor": 1.05,
+            }
         )
-        self.assertEqual(len(catchall), 1)
-
-        # Assign a variant → creates a second catch-all for uncovered
-        catchall.product_ids = [(4, variant_a.id)]
-        factors = Factor.search(
-            [("product_tmpl_id", "=", template.id), ("uom_id", "=", self.uom_ml.id)]
-        )
-        self.assertEqual(len(factors), 2)
-
-        # Now clear the variant → this line becomes a catch-all again
-        # The other catch-all must be removed to avoid duplicates
-        discriminated = factors.filtered(lambda f: f.product_ids)
-        discriminated.product_ids = [(5,)]
-        factors = Factor.search(
-            [("product_tmpl_id", "=", template.id), ("uom_id", "=", self.uom_ml.id)]
-        )
-        catchalls = factors.filtered(lambda f: not f.product_ids)
-        self.assertEqual(
-            len(catchalls),
-            1,
-            "Only one catch-all line should remain after clearing variants",
-        )
+        with self.assertRaises(ValidationError):
+            template.uom_id = uom_liter

--- a/product_uom_factor/tests/test_uc2_cross_category_conversion.py
+++ b/product_uom_factor/tests/test_uc2_cross_category_conversion.py
@@ -1,29 +1,26 @@
 """
-Test UC2: Cross-Category Quantity and Price Conversion
+Test UC2: Cross-Category Quantity and Price Conversion (Delegation Design)
 
 As a salesperson or purchaser, I want quantity and price conversions between
 UoMs of different categories (e.g. mL to g) to use the product-specific
 conversion factor so that when I sell or purchase in a cross-category UoM,
 the resulting quantities and prices are correct.
 
-The cross-category UoM may come from the product's packaging UoMs (uom_ids)
-or from a vendor pricelist (product.supplierinfo.product_uom_id).
-
-Conversion factors are stored in product.uom.factor records linked to the
-product template (product_tmpl_id), with an optional product_ids M2M to
-restrict to specific variants.
+In the v4 delegation design, product.uom.factor creates a delegate uom.uom
+whose relative_uom_id = product's base UoM and relative_factor = factor.
+The delegate is added to the product's uom_ids so core _compute_quantity and
+_compute_price resolve it natively without any product_id context injection.
 
 Acceptance Criteria:
-- Converting mL to g uses the product's factor (e.g. 500 mL * 1.05 = 525 g)
-- Converting g to mL uses the inverse (e.g. 525 g / 1.05 = 500 mL)
-- Different products with different factors produce different results
-- Same-category conversions (e.g. g to kg) are unaffected by the factor
-- Conversions between non-base units work (e.g. L to kg)
-- Price per g converted to price per mL accounts for density
-  (e.g. $0.10/g * 1.05 g/mL = $0.105/mL)
-- Price per mL converted to price per g is the inverse
-- Same-category price conversions (e.g. g to kg) are unaffected
-- Without a product in context, standard behavior is preserved
+- With the delegate UoM selected (not the generic mL), converting to the
+  product's base UoM uses the cross-category factor natively
+- The delegate's relative_factor drives the conversion
+- Two products with different factors produce different delegates and results
+- Cross-tree conversions using the generic (non-delegate) UoM return core's
+  numeric result without raising — the strong guard has been removed (review
+  blocker 1+2). Safety is enforced instead by the scoping @api.constrains on
+  line models (ValidationError on wrong cross-tree selection at save time).
+- price _compute_price also returns core's numeric result for cross-tree pairs
 """
 
 from odoo.tests.common import TransactionCase
@@ -44,62 +41,69 @@ class TestUC2CrossCategoryConversion(TransactionCase):
                 "uom_id": cls.uom_gram.id,
             }
         )
-        # Specific gravity 1.05: 1 mL = 1.05 g
-        cls.env["product.uom.factor"].create(
+        # Specific gravity 1.05: 1 mL-delegate = 1.05 g
+        cls.factor_cyan = cls.env["product.uom.factor"].create(
             {
                 "product_tmpl_id": cls.product_cyan.product_tmpl_id.id,
-                "uom_id": cls.uom_ml.id,
+                "foreign_uom_id": cls.uom_ml.id,
                 "factor": 1.05,
             }
         )
+        # The delegate_uom_id IS the product-specific mL for cyan ink
+        cls.delegate_ml_cyan = cls.factor_cyan.delegate_uom_id
 
-    def test_ml_to_gram_conversion(self):
-        """500 mL of cyan ink (SG 1.05) should convert to 525 g."""
-        result = self.uom_ml.with_context(
-            product_id=self.product_cyan.id
-        )._compute_quantity(500, self.uom_gram, round=False)
+    def test_delegate_to_base_conversion(self):
+        """Converting via the delegate UoM (product-specific mL-for-cyan)
+        to the base UoM (g) should use the cross-category factor natively.
+        500 mL-delegate * relative_factor(1.05) should yield 525 g."""
+        result = self.delegate_ml_cyan._compute_quantity(
+            500, self.uom_gram, round=False
+        )
         self.assertAlmostEqual(
             result,
             525.0,
             places=2,
-            msg="500 mL of cyan ink (SG 1.05) should be 525 g",
+            msg="500 product-specific mL (SG 1.05) should be 525 g",
         )
 
-    def test_gram_to_ml_conversion(self):
-        """525 g of cyan ink (SG 1.05) should convert to 500 mL."""
-        result = self.uom_gram.with_context(
-            product_id=self.product_cyan.id
-        )._compute_quantity(525, self.uom_ml, round=False)
+    def test_base_to_delegate_conversion(self):
+        """Converting from base UoM (g) to the delegate UoM (product-specific mL)
+        should use the inverse of the cross-category factor.
+        525 g / relative_factor(1.05) should yield 500 mL-delegate."""
+        result = self.uom_gram._compute_quantity(
+            525, self.delegate_ml_cyan, round=False
+        )
         self.assertAlmostEqual(
             result,
             500.0,
             places=2,
-            msg="525 g of cyan ink (SG 1.05) should be 500 mL",
+            msg="525 g should be 500 product-specific mL (SG 1.05)",
         )
 
-    def test_different_products_different_factors(self):
-        """Two products with different densities should produce different
-        conversion results for the same quantity."""
+    def test_different_products_different_delegates(self):
+        """Two products with different densities should have different delegates
+        and produce different conversion results for the same quantity."""
         product_magenta = self.env["product.product"].create(
             {
                 "name": "Ink - Magenta",
                 "uom_id": self.uom_gram.id,
             }
         )
-        # Magenta ink: SG 1.10 (denser than cyan's 1.05)
-        self.env["product.uom.factor"].create(
+        factor_magenta = self.env["product.uom.factor"].create(
             {
                 "product_tmpl_id": product_magenta.product_tmpl_id.id,
-                "uom_id": self.uom_ml.id,
+                "foreign_uom_id": self.uom_ml.id,
                 "factor": 1.10,
             }
         )
-        cyan_result = self.uom_ml.with_context(
-            product_id=self.product_cyan.id
-        )._compute_quantity(500, self.uom_gram, round=False)
-        magenta_result = self.uom_ml.with_context(
-            product_id=product_magenta.id
-        )._compute_quantity(500, self.uom_gram, round=False)
+        delegate_ml_magenta = factor_magenta.delegate_uom_id
+
+        cyan_result = self.delegate_ml_cyan._compute_quantity(
+            500, self.uom_gram, round=False
+        )
+        magenta_result = delegate_ml_magenta._compute_quantity(
+            500, self.uom_gram, round=False
+        )
         self.assertAlmostEqual(cyan_result, 525.0, places=2)
         self.assertAlmostEqual(magenta_result, 550.0, places=2)
         self.assertNotAlmostEqual(
@@ -113,9 +117,7 @@ class TestUC2CrossCategoryConversion(TransactionCase):
         """Same-category conversions (g to kg) should use standard UoM
         factors and not be affected by the cross-category factor."""
         uom_kg = self.env.ref("uom.product_uom_kgm")
-        result = self.uom_gram.with_context(
-            product_id=self.product_cyan.id
-        )._compute_quantity(1000, uom_kg, round=False)
+        result = self.uom_gram._compute_quantity(1000, uom_kg, round=False)
         self.assertAlmostEqual(
             result,
             1.0,
@@ -123,55 +125,42 @@ class TestUC2CrossCategoryConversion(TransactionCase):
             msg="1000 g should be 1 kg regardless of cross-category factor",
         )
 
-    def test_non_base_unit_conversion(self):
-        """Conversions between non-base units (L to kg) should work by
-        chaining the standard UoM factor with the cross-category factor.
-        1 L = 1000 mL, factor 1.05 g/mL => 1 L = 1050 g = 1.05 kg."""
-        uom_liter = self.env.ref("uom.product_uom_litre")
-        uom_kg = self.env.ref("uom.product_uom_kgm")
-        result = uom_liter.with_context(
-            product_id=self.product_cyan.id
-        )._compute_quantity(1, uom_kg, round=False)
-        self.assertAlmostEqual(
-            result,
-            1.05,
-            places=5,
-            msg="1 L of cyan ink (SG 1.05) should be 1.05 kg",
-        )
+    def test_generic_uom_cross_tree_no_raise(self):
+        """Using the generic mL (not the product's delegate) to convert to g
+        returns core's numeric result without raising. The strong conversion-time
+        guard was removed (review blocker 1+2): wrong UoM selection is blocked
+        instead by the scoping @api.constrains on line models (ValidationError
+        at save). Core's cross-tree math falls through silently here."""
+        result = self.uom_ml._compute_quantity(500, self.uom_gram, round=False)
+        self.assertIsInstance(result, float, "Cross-tree with no delegate: should return float, not raise")
 
-    def test_price_gram_to_ml(self):
-        """Price per g converted to price per mL should account for density.
-        $0.10/g * 1.05 g/mL = $0.105/mL."""
-        result = self.uom_gram.with_context(
-            product_id=self.product_cyan.id
-        )._compute_price(0.10, self.uom_ml)
-        self.assertAlmostEqual(
-            result,
-            0.105,
-            places=5,
-            msg="$0.10/g should be $0.105/mL for ink with SG 1.05",
-        )
-
-    def test_price_ml_to_gram(self):
-        """Price per mL converted to price per g is the inverse.
-        $0.105/mL / 1.05 g/mL = $0.10/g."""
-        result = self.uom_ml.with_context(
-            product_id=self.product_cyan.id
-        )._compute_price(0.105, self.uom_gram)
+    def test_price_delegate_to_base(self):
+        """Price per mL-delegate converted to price per g should account for
+        density. $0.105/mL-delegate / relative_factor(1.05) = $0.10/g."""
+        result = self.delegate_ml_cyan._compute_price(0.105, self.uom_gram)
         self.assertAlmostEqual(
             result,
             0.10,
             places=5,
-            msg="$0.105/mL should be $0.10/g for ink with SG 1.05",
+            msg="$0.105/mL-delegate should be $0.10/g for ink with SG 1.05",
         )
 
-    def test_same_category_price_unaffected(self):
-        """Same-category price conversions (g to kg) should use standard
-        UoM factors and not be affected by the cross-category factor."""
+    def test_price_base_to_delegate(self):
+        """Price per g converted to price per mL-delegate should account for
+        density. $0.10/g * relative_factor(1.05) = $0.105/mL-delegate."""
+        result = self.uom_gram._compute_price(0.10, self.delegate_ml_cyan)
+        self.assertAlmostEqual(
+            result,
+            0.105,
+            places=5,
+            msg="$0.10/g should be $0.105/mL-delegate for ink with SG 1.05",
+        )
+
+    def test_price_same_category_unaffected(self):
+        """Same-category price conversions (g to kg) should use standard UoM
+        factors and not be affected by the cross-category factor."""
         uom_kg = self.env.ref("uom.product_uom_kgm")
-        result = self.uom_gram.with_context(
-            product_id=self.product_cyan.id
-        )._compute_price(0.10, uom_kg)
+        result = self.uom_gram._compute_price(0.10, uom_kg)
         self.assertAlmostEqual(
             result,
             100.0,
@@ -179,71 +168,48 @@ class TestUC2CrossCategoryConversion(TransactionCase):
             msg="$0.10/g should be $100/kg regardless of cross-category factor",
         )
 
-    def test_no_product_in_context_standard_behavior(self):
-        """Without a product_id in context, cross-category conversions
-        should fall back to standard Odoo behavior (1:1 between base units)."""
-        result_with = self.uom_ml.with_context(
-            product_id=self.product_cyan.id
-        )._compute_quantity(500, self.uom_gram, round=False)
-        result_without = self.uom_ml._compute_quantity(500, self.uom_gram, round=False)
-        self.assertAlmostEqual(result_with, 525.0, places=2)
-        self.assertAlmostEqual(
-            result_without,
-            500.0,
-            places=2,
-            msg="Without product in context, standard 1:1 base-unit conversion",
-        )
-
-    def test_compute_quantity_with_rounding(self):
-        """Cross-category conversion with round=True should round result."""
-        result = self.uom_ml.with_context(
-            product_id=self.product_cyan.id
-        )._compute_quantity(500, self.uom_gram, round=True)
-        self.assertAlmostEqual(result, 525.0, places=0)
-
-    def test_compute_quantity_nonexistent_product(self):
-        """A nonexistent product_id in context should fall back to super."""
-        result = self.uom_ml.with_context(product_id=99999)._compute_quantity(
-            500, self.uom_gram, round=False
-        )
-        self.assertAlmostEqual(result, 500.0, places=2)
-
-    def test_find_product_uom_for_category_newid(self):
-        """_find_product_uom_for_category returns None for non-int IDs."""
-        from odoo.orm.identifiers import NewId
-
-        result = self.uom_ml._find_product_uom_for_category(NewId(), self.uom_gram)
-        self.assertIsNone(result)
-
-    def test_find_product_uom_for_category_fallback(self):
-        """When the exact UoM isn't on a factor line but a same-category
-        UoM is, _find_product_uom_for_category should return it."""
-        uom_litre = self.env.ref("uom.product_uom_litre")
-        # Factor is defined for mL; searching for L should find it via
-        # the category fallback path.
-        result = self.uom_gram._find_product_uom_for_category(
-            self.product_cyan.id, uom_litre
-        )
-        self.assertTrue(result)
-        self.assertTrue(result.uom_id._has_common_reference(uom_litre))
+    def test_price_generic_cross_tree_no_raise(self):
+        """_compute_price on a genuinely cross-tree pair (generic mL → g) returns
+        core's numeric result without raising. The strong guard was removed (review
+        blocker 1+2); wrong UoM selection is blocked by the scoping @api.constrains
+        at save time instead."""
+        result = self.uom_ml._compute_price(0.105, self.uom_gram)
+        self.assertIsInstance(result, float, "Cross-tree price: should return float, not raise")
 
     def test_compute_quantity_same_uom(self):
         """Converting a UoM to itself should return the original qty."""
-        result = self.uom_ml.with_context(
-            product_id=self.product_cyan.id
-        )._compute_quantity(500, self.uom_ml, round=False)
+        result = self.delegate_ml_cyan._compute_quantity(
+            500, self.delegate_ml_cyan, round=False
+        )
         self.assertAlmostEqual(result, 500.0, places=2)
 
     def test_compute_price_same_uom(self):
         """Converting a price to the same UoM should return the original."""
-        result = self.uom_ml.with_context(
-            product_id=self.product_cyan.id
-        )._compute_price(10.0, self.uom_ml)
+        result = self.delegate_ml_cyan._compute_price(10.0, self.delegate_ml_cyan)
         self.assertAlmostEqual(result, 10.0, places=2)
 
-    def test_compute_price_nonexistent_product(self):
-        """A nonexistent product_id in context should fall back to super."""
-        result = self.uom_ml.with_context(product_id=99999)._compute_price(
-            10.0, self.uom_gram
+    def test_is_product_factor_computed(self):
+        """is_product_factor should be True for the delegate UoM and False for
+        the generic mL."""
+        self.assertTrue(
+            self.delegate_ml_cyan.is_product_factor,
+            "Delegate UoM should have is_product_factor=True",
         )
-        self.assertAlmostEqual(result, 10.0, places=2)
+        self.assertFalse(
+            self.uom_ml.is_product_factor,
+            "Generic mL should have is_product_factor=False",
+        )
+
+    def test_is_product_factor_search(self):
+        """is_product_factor domain search should find delegate UoMs."""
+        delegates = self.env["uom.uom"].search([("is_product_factor", "=", True)])
+        self.assertIn(
+            self.delegate_ml_cyan,
+            delegates,
+            "Delegate UoM should appear in is_product_factor=True search",
+        )
+        self.assertNotIn(
+            self.uom_ml,
+            delegates,
+            "Generic mL should not appear in is_product_factor=True search",
+        )

--- a/product_uom_factor/tests/test_uc3_product_uom_factor_view.py
+++ b/product_uom_factor/tests/test_uc3_product_uom_factor_view.py
@@ -1,22 +1,22 @@
 """
-Test UC3: Cross-Category UoM Conversion Factors on Product Form
+Test UC3: Cross-Category UoM Conversion Factors on Product Form (Delegation Design)
 
-As a product manager, when I add a UoM from a different category to my
-product's allowed UoMs, I want a "Unit Conversions" section to appear on
-the product form showing which cross-category UoMs need conversion
-factors, so that I can configure them without navigating away.
+As a product manager, I want to configure conversion factors for cross-category
+UoMs on the product form, and have the delegated UoM automatically included in
+the product's allowed UoMs so that order lines can select it.
 
-Conversion factors are stored in product.uom.factor records linked to the
-product template (product_tmpl_id), with an optional product_ids M2M to
-restrict to specific variants.
+In the v4 delegation design:
+  - factor rows are created manually (no auto-create from uom_ids)
+  - each factor row creates a delegate uom.uom linked via delegate_uom_id
+  - the delegate is added (additive only) to the template's uom_ids by _sync_factor_uom_ids
+  - the foreign_uom_id column (renamed from uom_id) is shown in the view
 
 Acceptance Criteria:
-- The product template form has a "Unit Conversions" section (under the
-  Inventory tab) showing the uom_factor_ids one2many with uom_id (readonly),
-  product_ids, and factor columns
-- Factor lines are auto-created when cross-category UoMs are added to
-  uom_ids; the factor field is editable inline
-- The uom_id column is readonly since lines are auto-managed
+- The product template form has a "Unit Conversions" section showing
+  uom_factor_ids with foreign_uom_id (readonly), product_ids, and factor
+- Creating a factor record shows the delegate in the product's uom_ids
+- The factor field is editable and updating it syncs to delegate_uom_id
+- The product variant form shows applicable factor rows via uom_factor_ids
 """
 
 from odoo.tests import Form
@@ -33,32 +33,67 @@ class TestUC3ProductUomFactorView(TransactionCase):
         cls.uom_gram = cls.env.ref("uom.product_uom_gram")
         cls.uom_ml = cls.env.ref("uom.product_uom_milliliter")
 
-    def test_factor_editable_on_template_form(self):
-        """When a cross-category UoM is added to uom_ids, the auto-created
-        factor line appears on the template form and its factor can be
-        edited inline."""
+    def test_delegate_in_product_uom_ids_after_sync(self):
+        """After creating a factor row and triggering _sync_factor_uom_ids,
+        the delegate UoM should appear in the template's uom_ids."""
         template = self.env["product.template"].create(
             {
                 "name": "Test Ink",
                 "uom_id": self.uom_gram.id,
             }
         )
-        # Add cross-category UoM → auto-creates factor line
-        template.uom_ids = [(4, self.uom_ml.id)]
-        self.assertEqual(len(template.uom_factor_ids), 1)
+        factor = self.env["product.uom.factor"].create(
+            {
+                "product_tmpl_id": template.id,
+                "foreign_uom_id": self.uom_ml.id,
+                "factor": 1.05,
+            }
+        )
+        # Trigger sync
+        template.write({"uom_factor_ids": [(4, factor.id)]})
+        self.assertIn(
+            factor.delegate_uom_id,
+            template.uom_ids,
+            "Delegate UoM should be in product template's uom_ids after sync",
+        )
 
-        # Open form and edit the factor value
+    def test_factor_editable_on_template_form(self):
+        """When a factor row exists, its factor value can be edited on the
+        template form and the change propagates to the delegate."""
+        template = self.env["product.template"].create(
+            {
+                "name": "Test Ink",
+                "uom_id": self.uom_gram.id,
+            }
+        )
+        factor = self.env["product.uom.factor"].create(
+            {
+                "product_tmpl_id": template.id,
+                "foreign_uom_id": self.uom_ml.id,
+                "factor": 1.00,
+            }
+        )
+
         form = Form(template, view="product.product_template_only_form_view")
         with form.uom_factor_ids.edit(0) as line:
             line.factor = 1.05
         template = form.save()
-        puom = template.uom_factor_ids.filtered(lambda r: r.uom_id == self.uom_ml)
+
+        puom = template.uom_factor_ids.filtered(
+            lambda r: r.foreign_uom_id == self.uom_ml
+        )
         self.assertEqual(len(puom), 1)
         self.assertAlmostEqual(
             puom.factor,
             1.05,
             places=5,
             msg="Factor should be editable via the product template form",
+        )
+        self.assertAlmostEqual(
+            puom.delegate_uom_id.relative_factor,
+            1.05,
+            places=5,
+            msg="Delegate relative_factor should be updated after form save",
         )
 
     def test_variant_uom_factor_ids_shows_applicable_factors(self):
@@ -90,35 +125,38 @@ class TestUC3ProductUomFactorView(TransactionCase):
         )
         variant_red, variant_blue = template.product_variant_ids
 
-        # Add cross-category UoM → catch-all factor
-        template.uom_ids = [(4, self.uom_ml.id)]
-        catchall = template.uom_factor_ids
-        self.assertEqual(len(catchall), 1)
+        # Create a catch-all factor (no product_ids)
+        catchall = self.env["product.uom.factor"].create(
+            {
+                "product_tmpl_id": template.id,
+                "foreign_uom_id": self.uom_ml.id,
+                "factor": 1.05,
+            }
+        )
 
         # Both variants see the catch-all
-        self.assertEqual(variant_red.uom_factor_ids, catchall)
-        self.assertEqual(variant_blue.uom_factor_ids, catchall)
+        self.assertIn(catchall, variant_red.uom_factor_ids)
+        self.assertIn(catchall, variant_blue.uom_factor_ids)
 
-        # Discriminate: assign red variant → catch-all re-created for blue
-        catchall.product_ids = [(4, variant_red.id)]
-        catchall.factor = 1.10
+        # Create a red-specific factor row (discriminated by product_ids)
+        red_factor = self.env["product.uom.factor"].create(
+            {
+                "product_tmpl_id": template.id,
+                "foreign_uom_id": self.uom_ml.id,
+                "product_ids": [(4, variant_red.id)],
+                "factor": 1.10,
+            }
+        )
         template.invalidate_recordset(["uom_factor_ids"])
-        factors = template.uom_factor_ids
-        red_line = factors.filtered(lambda f: variant_red in f.product_ids)
-        new_catchall = factors.filtered(lambda f: not f.product_ids)
-
-        # Red sees its discriminated line + catch-all
         variant_red.invalidate_recordset(["uom_factor_ids"])
         variant_blue.invalidate_recordset(["uom_factor_ids"])
-        self.assertEqual(variant_red.uom_factor_ids, red_line | new_catchall)
-        # Blue sees only the catch-all
-        self.assertEqual(variant_blue.uom_factor_ids, new_catchall)
 
-        # Verify via variant form view
-        form = Form(variant_red, view="product.product_normal_form_view")
-        self.assertEqual(len(form.uom_factor_ids), 2)
-        form = Form(variant_blue, view="product.product_normal_form_view")
-        self.assertEqual(len(form.uom_factor_ids), 1)
+        # Red sees both the catch-all and its discriminated line
+        self.assertIn(catchall, variant_red.uom_factor_ids)
+        self.assertIn(red_factor, variant_red.uom_factor_ids)
+        # Blue sees only the catch-all
+        self.assertIn(catchall, variant_blue.uom_factor_ids)
+        self.assertNotIn(red_factor, variant_blue.uom_factor_ids)
 
     def test_new_product_uom_factor_ids_empty(self):
         """A new (unsaved) product should return empty uom_factor_ids."""

--- a/product_uom_factor/views/product_product_views.xml
+++ b/product_uom_factor/views/product_product_views.xml
@@ -11,7 +11,7 @@
                     <field name="uom_factor_ids" nolabel="1" colspan="2">
                         <list>
                             <field name="product_tmpl_id" column_invisible="True" />
-                            <field name="uom_id" readonly="1" />
+                            <field name="foreign_uom_id" readonly="1" />
                             <field name="factor" />
                         </list>
                     </field>

--- a/product_uom_factor/views/product_template_views.xml
+++ b/product_uom_factor/views/product_template_views.xml
@@ -6,12 +6,17 @@
         <field name="model">product.template</field>
         <field name="inherit_id" ref="product.product_template_only_form_view" />
         <field name="arch" type="xml">
+            <!-- Keep product-specific factor UoMs out of the base/reference
+                 UoM selector: only generic units may be a product's base UoM. -->
+            <xpath expr="//field[@name='uom_id']" position="attributes">
+                <attribute name="domain">[('is_product_factor', '=', False)]</attribute>
+            </xpath>
             <xpath expr="//page[@name='inventory']" position="inside">
                 <group string="Unit Conversions" name="uom_conversions" colspan="2">
                     <field name="uom_factor_ids" nolabel="1" colspan="2">
                         <list editable="bottom">
                             <field name="product_tmpl_id" column_invisible="True" />
-                            <field name="uom_id" readonly="1" />
+                            <field name="foreign_uom_id" readonly="1" />
                             <field
                                 name="product_ids"
                                 widget="many2many_tags"

--- a/product_uom_factor/views/res_config_settings_views.xml
+++ b/product_uom_factor/views/res_config_settings_views.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <!--
+        UoM Factor settings block in General Settings (base_setup).
+
+        Placement: after the "Units of Measure" block added by the product
+        module.  We inherit base_setup rather than stock because this module
+        depends only on `product`, not `stock`.  The setting is global (backed
+        by ir.config_parameter) and affects the scoping @api.constrains on every
+        line model that inherits ProductUomFactorLineMixin.
+    -->
+    <record id="res_config_settings_view_form_uom_factor" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.product.uom.factor</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="base_setup.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//block[@id='product_general_settings']"
+                position="after"
+            >
+                <block
+                    title="Cross-Category UoM Conversions"
+                    id="product_uom_factor_settings"
+                >
+                    <setting
+                        id="enforce_factor_uom_scoping_setting"
+                        string="Enforce factor-UoM scoping"
+                        help="Validate that cross-tree UoM selections on order/move lines match the product's registered conversion factors. Disable to allow arbitrary cross-tree UoM selections (vanilla Odoo)."
+                    >
+                        <field name="enforce_factor_uom_scoping" />
+                    </setting>
+                </block>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/product_uom_factor_mrp/__init__.py
+++ b/product_uom_factor_mrp/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2026 Bemade Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from . import models

--- a/product_uom_factor_mrp/__manifest__.py
+++ b/product_uom_factor_mrp/__manifest__.py
@@ -1,0 +1,20 @@
+# Copyright 2026 Bemade Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+{
+    "name": "Product UoM Factor – MRP",
+    "summary": "BOM line UoM scoping for product-specific cross-category factors",
+    "version": "19.0.2.0.0",
+    "development_status": "Alpha",
+    "license": "LGPL-3",
+    "author": "Bemade Inc.",
+    "website": "https://www.bemade.org",
+    "maintainers": ["mdurepos"],
+    "depends": [
+        "product_uom_factor",
+        "mrp",
+    ],
+    "data": [
+        "views/mrp_bom_views.xml",
+    ],
+}

--- a/product_uom_factor_mrp/models/__init__.py
+++ b/product_uom_factor_mrp/models/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2026 Bemade Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from . import mrp_bom_line

--- a/product_uom_factor_mrp/models/mrp_bom_line.py
+++ b/product_uom_factor_mrp/models/mrp_bom_line.py
@@ -1,0 +1,29 @@
+# Copyright 2026 Bemade Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+# mrp.bom.line has no core allowed_uom_ids compute, so the mixin's
+# _compute_allowed_uom_ids "no parent" branch fires and provides:
+#   product_id.uom_id | product_id.uom_ids
+# Factor delegates reach that set via the additive template sync
+# (_sync_factor_uom_ids adds each delegate_uom_id to product.uom_ids), so
+# no explicit union of _get_factor_uom_ids() is needed here.
+
+from odoo import api, fields, models
+
+
+class MrpBomLine(models.Model):
+    _name = "mrp.bom.line"
+    _inherit = ["mrp.bom.line", "product.uom.factor.line.mixin"]
+
+    # The mixin declares allowed_uom_ids with compute="_compute_allowed_uom_ids"
+    # and @api.depends("product_id", "product_id.uom_id", "product_id.uom_ids").
+    # Re-declaring here with a label so the BOM view can reference it.
+    allowed_uom_ids = fields.Many2many(
+        "uom.uom",
+        string="Allowed UoMs",
+        compute="_compute_allowed_uom_ids",
+    )
+
+    @api.constrains("product_uom_id", "product_id")
+    def _check_factor_uom_allowed_bom_line(self):
+        self._check_factor_uom_allowed("product_uom_id")

--- a/product_uom_factor_mrp/tests/__init__.py
+++ b/product_uom_factor_mrp/tests/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2026 Bemade Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from . import test_mrp_integration
+from . import test_enforce_scoping_toggle

--- a/product_uom_factor_mrp/tests/test_enforce_scoping_toggle.py
+++ b/product_uom_factor_mrp/tests/test_enforce_scoping_toggle.py
@@ -1,0 +1,193 @@
+"""
+Tests for the enforce_factor_uom_scoping config toggle (MRP scope).
+
+Acceptance criteria:
+- Toggle ON (default): _check_factor_uom_allowed raises ValidationError when a
+  cross-tree UoM is forced onto an mrp.bom.line whose product base UoM is in a
+  different unit tree.
+- Toggle OFF: the constraint is a no-op — a cross-tree UoM saves without error
+  (vanilla Odoo behaviour, including the core kg-base product / Units invoice
+  line scenario).
+- Absent parameter (not set) behaves as True (default-on).
+
+These tests live in product_uom_factor_mrp (not the core module) because
+mrp.bom.line is the clearest cross-tree line model and mrp is a dependency here.
+The toggle applies equally to every model that inherits
+ProductUomFactorLineMixin (sale/purchase/stock/account/bom lines).
+"""
+
+from odoo.exceptions import ValidationError
+from odoo.tests.common import TransactionCase
+
+_PARAM_KEY = "product_uom_factor.enforce_factor_uom_scoping"
+
+
+class TestEnforceScopingToggle(TransactionCase):
+    """Gate behaviour of enforce_factor_uom_scoping on mrp.bom.line."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.env["res.config.settings"].create({"group_uom": True}).execute()
+
+        # Set "Product Unit" precision to 5 for small factors in this transaction.
+        dp = cls.env["decimal.precision"].search(
+            [("name", "=", "Product Unit")], limit=1
+        )
+        if dp and dp.digits < 5:
+            dp.digits = 5
+
+        cls.uom_unit = cls.env.ref("uom.product_uom_unit")
+        cls.uom_ml = cls.env.ref("uom.product_uom_milliliter")
+
+        # Ink product: base UoM = Unit (different tree from mL volume)
+        cls.ink = cls.env["product.product"].create(
+            {
+                "name": "Test Ink – Scoping Toggle",
+                "type": "consu",
+                "uom_id": cls.uom_unit.id,
+            }
+        )
+        # Factor: delegate-mL = 0.00005 Unit
+        cls.factor = cls.env["product.uom.factor"].create(
+            {
+                "product_tmpl_id": cls.ink.product_tmpl_id.id,
+                "foreign_uom_id": cls.uom_ml.id,
+                "factor": 0.00005,
+            }
+        )
+        cls.ink.product_tmpl_id.write({"uom_factor_ids": [(4, cls.factor.id)]})
+
+        # Cartridge (finished good) — separate product to avoid BOM cycle check
+        cls.cartridge = cls.env["product.product"].create(
+            {
+                "name": "Test Cartridge – Scoping Toggle",
+                "type": "consu",
+                "uom_id": cls.uom_unit.id,
+            }
+        )
+
+        # Minimal BOM (delegate-mL line) to anchor test lines
+        cls.bom = cls.env["mrp.bom"].create(
+            {
+                "product_tmpl_id": cls.cartridge.product_tmpl_id.id,
+                "product_qty": 1.0,
+                "product_uom_id": cls.uom_unit.id,
+                "bom_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": cls.ink.id,
+                            "product_qty": 250.0,
+                            "product_uom_id": cls.factor.delegate_uom_id.id,
+                        },
+                    )
+                ],
+            }
+        )
+
+    def _set_param(self, value):
+        self.env["ir.config_parameter"].sudo().set_param(_PARAM_KEY, str(value))
+
+    def _clear_param(self):
+        existing = self.env["ir.config_parameter"].sudo().search(
+            [("key", "=", _PARAM_KEY)]
+        )
+        if existing:
+            existing.unlink()
+
+    # ── Toggle ON tests ────────────────────────────────────────────────────
+
+    def test_toggle_on_blocks_cross_tree_uom(self):
+        """enforce_factor_uom_scoping=True: generic mL (cross-tree for Unit-base
+        product) on a BOM line raises ValidationError."""
+        self._set_param(True)
+        with self.assertRaises(ValidationError):
+            self.env["mrp.bom.line"].create(
+                {
+                    "bom_id": self.bom.id,
+                    "product_id": self.ink.id,
+                    "product_qty": 100.0,
+                    "product_uom_id": self.uom_ml.id,  # generic mL, cross-tree
+                }
+            )
+
+    def test_toggle_default_absent_param_blocks_cross_tree(self):
+        """Absent parameter defaults to True — same blocking behaviour."""
+        self._clear_param()
+        with self.assertRaises(ValidationError):
+            self.env["mrp.bom.line"].create(
+                {
+                    "bom_id": self.bom.id,
+                    "product_id": self.ink.id,
+                    "product_qty": 100.0,
+                    "product_uom_id": self.uom_ml.id,
+                }
+            )
+
+    # ── Toggle OFF tests ───────────────────────────────────────────────────
+
+    def test_toggle_off_allows_cross_tree_uom(self):
+        """enforce_factor_uom_scoping=False: generic mL (cross-tree) saves without
+        error (vanilla Odoo behaviour).
+
+        This is the core blocker scenario: a kg-base (or Unit-base) product on a
+        line with a UoM from another tree must save cleanly when the toggle is OFF.
+        """
+        self._set_param(False)
+        line = self.env["mrp.bom.line"].create(
+            {
+                "bom_id": self.bom.id,
+                "product_id": self.ink.id,
+                "product_qty": 100.0,
+                "product_uom_id": self.uom_ml.id,  # generic mL, cross-tree
+            }
+        )
+        self.assertTrue(
+            line.id,
+            "BOM line with cross-tree UoM must save when enforce_factor_uom_scoping is OFF",
+        )
+
+    def test_toggle_off_then_on_re_enables_constraint(self):
+        """After disabling then re-enabling, the blocking behaviour is restored."""
+        self._set_param(False)
+        line = self.env["mrp.bom.line"].create(
+            {
+                "bom_id": self.bom.id,
+                "product_id": self.ink.id,
+                "product_qty": 50.0,
+                "product_uom_id": self.uom_ml.id,
+            }
+        )
+        self.assertTrue(line.id)
+
+        self._set_param(True)
+        with self.assertRaises(ValidationError):
+            self.env["mrp.bom.line"].create(
+                {
+                    "bom_id": self.bom.id,
+                    "product_id": self.ink.id,
+                    "product_qty": 75.0,
+                    "product_uom_id": self.uom_ml.id,
+                }
+            )
+
+    # ── Config settings field test ─────────────────────────────────────────
+
+    def test_config_settings_field_exists_and_defaults_true(self):
+        """enforce_factor_uom_scoping field exists on res.config.settings and
+        defaults to True when no parameter is stored."""
+        self._clear_param()
+        settings = self.env["res.config.settings"].create({})
+        self.assertIn(
+            "enforce_factor_uom_scoping",
+            settings._fields,
+            "enforce_factor_uom_scoping must be a field on res.config.settings",
+        )
+        # Default is True (the field default) when param is absent
+        self.assertTrue(
+            settings.enforce_factor_uom_scoping,
+            "enforce_factor_uom_scoping must default to True",
+        )

--- a/product_uom_factor_mrp/tests/test_mrp_integration.py
+++ b/product_uom_factor_mrp/tests/test_mrp_integration.py
@@ -1,0 +1,573 @@
+"""
+Integration tests for the delegation-design product_uom_factor MRP flow.
+
+Tests cover (within mrp scope):
+  - MRP BOM line in delegate-mL: MO raw move qty, move_line.quantity_product_uom
+  - BOM line allowed_uom_ids scoping (crit 5 + refinement)
+  - Crit 9 (scoping constraint path): cross-tree UoM on BOM line raises ValidationError;
+    the uom.uom conversion-time guard was removed (review blocker 1+2).
+  - Crit 10 regression: cross-tree _compute_quantity returns core's numeric result (no raise)
+  - Edge cases: base-UoM change blocked, foreign==base rejected, factor persists,
+    delegate cascade delete
+  - Regression (crit 10): intra-category conversions unaffected; UC1-UC3 assertions
+
+Domain: ink product (Unit base) with mL factor 0.00005.
+        Cartridge BOM line: 250 mL-delegate per cartridge.
+        250 delegate-mL × 0.00005 = 0.0125 Unit.
+
+NOTE: valuation/SVL/COGS tests live in product_uom_factor_stock.
+      PO tests live in product_uom_factor_purchase.
+      SO/delivery tests live in product_uom_factor_sale.
+"""
+
+from odoo.exceptions import ValidationError
+from odoo.fields import Command
+from odoo.tests.common import TransactionCase
+
+
+class TestMrpIntegrationBase(TransactionCase):
+    """Common fixture for MRP integration tests.
+
+    Ink product: base UoM = Unit, factor mL-delegate → 0.00005 Unit.
+    Cartridge BOM: 250 delegate-mL per cartridge.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # Enable UoM feature
+        cls.env["res.config.settings"].create({"group_uom": True}).execute()
+
+        # Ensure "Product Unit" decimal precision ≥ 5 for small factors (0.00005)
+        dp = cls.env["decimal.precision"].search(
+            [("name", "=", "Product Unit")], limit=1
+        )
+        if dp and dp.digits < 5:
+            dp.digits = 5
+
+        # ── UoMs ──────────────────────────────────────────────────────────────
+        cls.uom_unit = cls.env.ref("uom.product_uom_unit")
+        cls.uom_ml = cls.env.ref("uom.product_uom_milliliter")
+        cls.uom_liter = cls.env.ref("uom.product_uom_litre")
+
+        # ── Company (needed for picking type lookup) ───────────────────────────
+        cls.company = cls.env.company
+
+        # ── Ink product ───────────────────────────────────────────────────────
+        # In Odoo 19, type='consu' (Goods). type='product' removed. uom_po_id gone.
+        cls.ink = cls.env["product.product"].create(
+            {
+                "name": "Test Ink – Cyan (MRP Integration)",
+                "type": "consu",
+                "is_storable": True,
+                "uom_id": cls.uom_unit.id,
+            }
+        )
+
+        # ── Factor: 1 mL-delegate = 0.00005 Unit ─────────────────────────────
+        cls.factor = cls.env["product.uom.factor"].create(
+            {
+                "product_tmpl_id": cls.ink.product_tmpl_id.id,
+                "foreign_uom_id": cls.uom_ml.id,
+                "factor": 0.00005,
+            }
+        )
+        cls.delegate_ml = cls.factor.delegate_uom_id
+        # Trigger additive sync so delegate is in uom_ids / allowed_uom_ids
+        cls.ink.product_tmpl_id.write(
+            {"uom_factor_ids": [(4, cls.factor.id)]}
+        )
+
+        # ── Cartridge product (finished) ──────────────────────────────────────
+        cls.cartridge = cls.env["product.product"].create(
+            {
+                "name": "Test Cartridge (MRP Integration)",
+                "type": "consu",
+                "is_storable": True,
+                "uom_id": cls.uom_unit.id,
+            }
+        )
+
+        # ── BOM: 250 delegate-mL of ink per cartridge ─────────────────────────
+        cls.bom = cls.env["mrp.bom"].create(
+            {
+                "product_tmpl_id": cls.cartridge.product_tmpl_id.id,
+                "product_qty": 1.0,
+                "product_uom_id": cls.uom_unit.id,
+                "bom_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": cls.ink.id,
+                            "product_qty": 250.0,
+                            "product_uom_id": cls.delegate_ml.id,
+                        },
+                    )
+                ],
+            }
+        )
+
+        # ── Stock locations ────────────────────────────────────────────────────
+        cls.stock_location = cls.env.ref("stock.stock_location_stock")
+        cls.supplier_location = cls.env.ref("stock.stock_location_suppliers")
+
+
+class TestDelegateIsUom(TestMrpIntegrationBase):
+    """Crit 1 & 5 (unit test part): delegate IS a uom.uom in the product's tree."""
+
+    def test_delegate_is_uom_instance(self):
+        """The factor row's delegate_uom_id IS a uom.uom record."""
+        self.assertIsInstance(
+            self.delegate_ml,
+            type(self.env["uom.uom"]),
+            "delegate_uom_id must be a uom.uom record",
+        )
+
+    def test_delegate_relative_uom_is_base(self):
+        """delegate.relative_uom_id == ink base UoM (Unit)."""
+        self.assertEqual(
+            self.delegate_ml.relative_uom_id,
+            self.uom_unit,
+            "Delegate's relative_uom_id must be the ink's base UoM (Unit)",
+        )
+
+    def test_delegate_relative_factor(self):
+        """delegate.relative_factor == 0.00005."""
+        self.assertAlmostEqual(
+            self.delegate_ml.relative_factor,
+            0.00005,
+            places=8,
+            msg="Delegate relative_factor must match the factor (0.00005)",
+        )
+
+    def test_delegate_has_common_reference_with_base(self):
+        """delegate._has_common_reference(Unit) is True (intra-tree)."""
+        self.assertTrue(
+            self.delegate_ml._has_common_reference(self.uom_unit),
+            "Delegate must share a common reference with the product's base UoM",
+        )
+
+    def test_delegate_in_product_uom_ids(self):
+        """The delegate UoM is in the product template's uom_ids."""
+        self.assertIn(
+            self.delegate_ml,
+            self.ink.product_tmpl_id.uom_ids,
+            "Delegate must be in product template uom_ids after additive sync",
+        )
+
+
+class TestMrpMoConsumption(TestMrpIntegrationBase):
+    """Crit 1 & 5 (full MRP flow): BOM line in delegate-mL → MO raw move qty correct."""
+
+    def _stock_in(self, qty=1.0):
+        """Put `qty` Units of ink into stock."""
+        picking_type = self.env["stock.picking.type"].search(
+            [("code", "=", "incoming"), ("company_id", "=", self.company.id)],
+            limit=1,
+        )
+        receipt = self.env["stock.picking"].create(
+            {
+                "picking_type_id": picking_type.id,
+                "location_id": self.supplier_location.id,
+                "location_dest_id": self.stock_location.id,
+                "move_ids": [
+                    Command.create(
+                        {
+                            "product_id": self.ink.id,
+                            "product_uom": self.uom_unit.id,
+                            "product_uom_qty": qty,
+                            "location_id": self.supplier_location.id,
+                            "location_dest_id": self.stock_location.id,
+                        }
+                    )
+                ],
+            }
+        )
+        receipt.action_confirm()
+        receipt.move_ids.quantity = qty
+        receipt._action_done()
+        return receipt
+
+    def _make_mo(self, qty=1.0):
+        """Create and confirm an MO for `qty` cartridges."""
+        mo = self.env["mrp.production"].create(
+            {
+                "product_id": self.cartridge.id,
+                "product_qty": qty,
+                "product_uom_id": self.uom_unit.id,
+                "bom_id": self.bom.id,
+            }
+        )
+        mo.action_confirm()
+        return mo
+
+    def test_mo_raw_move_qty_in_delegate_ml(self):
+        """MO raw move: 250 delegate-mL BOM line → raw move in delegate-mL (product_uom_qty=250).
+
+        In the delegation design, MRP creates the raw move in the BOM line's UoM
+        (delegate-mL). The product_qty (computed base UoM) = 250 × 0.00005 = 0.0125 Unit.
+        """
+        self._stock_in(1.0)
+        mo = self._make_mo(1.0)
+        mo.action_assign()
+        raw_move = mo.move_raw_ids.filtered(lambda m: m.product_id == self.ink)
+        self.assertEqual(len(raw_move), 1, "Expected exactly one raw move for ink")
+        # The move is in the BOM line's UoM (delegate-mL)
+        self.assertEqual(
+            raw_move.product_uom,
+            self.delegate_ml,
+            "Raw move product_uom must be the delegate-mL (BOM line UoM)",
+        )
+        # product_uom_qty = 250 (in delegate-mL, as specified in the BOM line)
+        self.assertAlmostEqual(
+            raw_move.product_uom_qty,
+            250.0,
+            places=2,
+            msg="BOM line qty 250 delegate-mL must appear in product_uom_qty",
+        )
+
+    def test_mo_raw_move_product_qty_in_base_uom(self):
+        """MO raw move: product_qty (computed base UoM) == 0.0125 Unit.
+
+        product_qty is the stored computed base-UoM quantity.
+        250 delegate-mL × 0.00005 = 0.0125 Unit.
+        """
+        self._stock_in(1.0)
+        mo = self._make_mo(1.0)
+        mo.action_assign()
+        raw_move = mo.move_raw_ids.filtered(lambda m: m.product_id == self.ink)
+        self.assertEqual(len(raw_move), 1, "Expected one raw move for ink")
+        # product_qty is the computed base-UoM quantity
+        self.assertAlmostEqual(
+            raw_move.product_qty,
+            0.0125,
+            places=5,
+            msg="product_qty (base UoM) must be 250 × 0.00005 = 0.0125 Unit",
+        )
+
+    def test_mo_move_line_quantity_product_uom(self):
+        """move_line.quantity_product_uom == 0.0125 for a move_line in delegate-mL.
+
+        quantity_product_uom is computed as:
+            product_uom_id._compute_quantity(quantity, product_id.uom_id)
+        = delegate_ml._compute_quantity(250.0, uom_unit) = 0.0125 Unit.
+
+        We create the move_line manually against the raw move to directly test
+        the UoM conversion logic (Crit 4 / delegation correctness), independent
+        of stock reservation quant availability.
+        """
+        self._stock_in(10.0)
+        mo = self._make_mo(1.0)
+        raw_move = mo.move_raw_ids.filtered(lambda m: m.product_id == self.ink)
+        self.assertEqual(len(raw_move), 1)
+        # Manually create a move_line in delegate-mL and check quantity_product_uom
+        ml = self.env["stock.move.line"].create(
+            {
+                "move_id": raw_move.id,
+                "product_id": self.ink.id,
+                "product_uom_id": self.delegate_ml.id,
+                "quantity": 250.0,
+                "location_id": self.stock_location.id,
+                "location_dest_id": raw_move.location_dest_id.id,
+            }
+        )
+        self.assertAlmostEqual(
+            ml.quantity_product_uom,
+            0.0125,
+            places=5,
+            msg="move_line.quantity_product_uom must be 0.0125 Unit "
+            "(250 delegate-mL × 0.00005)",
+        )
+
+
+class TestScopingAllowedUomIds(TestMrpIntegrationBase):
+    """Crit 5 + refinement: allowed_uom_ids scoping and cross-tree guard on BOM lines."""
+
+    def test_delegate_ml_in_bom_line_allowed_uom_ids(self):
+        """The ink's delegate-mL appears in the BOM line's allowed_uom_ids."""
+        bom_line = self.bom.bom_line_ids[0]
+        self.assertIn(
+            self.delegate_ml,
+            bom_line.allowed_uom_ids,
+            "Ink's delegate-mL must be in BOM line allowed_uom_ids",
+        )
+
+    def test_base_uom_in_bom_line_allowed_uom_ids(self):
+        """The ink's base UoM (Unit) is in the BOM line's allowed_uom_ids."""
+        bom_line = self.bom.bom_line_ids[0]
+        self.assertIn(
+            self.uom_unit,
+            bom_line.allowed_uom_ids,
+            "Base UoM (Unit) must also be in BOM line allowed_uom_ids",
+        )
+
+    def test_other_product_delegate_absent_from_ink_bom_line_allowed_uom_ids(self):
+        """Product B's delegate-mL is NOT in the ink BOM line's allowed_uom_ids."""
+        other_product = self.env["product.product"].create(
+            {
+                "name": "Other Ink Product (Scoping Test)",
+                "type": "consu",
+                "uom_id": self.uom_unit.id,
+            }
+        )
+        other_factor = self.env["product.uom.factor"].create(
+            {
+                "product_tmpl_id": other_product.product_tmpl_id.id,
+                "foreign_uom_id": self.uom_ml.id,
+                "factor": 0.0001,  # different factor → different delegate
+            }
+        )
+        other_delegate = other_factor.delegate_uom_id
+        other_product.product_tmpl_id.write(
+            {"uom_factor_ids": [(4, other_factor.id)]}
+        )
+        bom_line = self.bom.bom_line_ids[0]
+        self.assertNotIn(
+            other_delegate,
+            bom_line.allowed_uom_ids,
+            "Other product's delegate-mL must NOT appear in ink BOM line allowed_uom_ids",
+        )
+
+    def test_cross_tree_uom_on_bom_line_raises_validation_error(self):
+        """Forcing the generic mL (cross-tree for Unit-base product) on a BOM line raises."""
+        with self.assertRaises(ValidationError):
+            self.env["mrp.bom.line"].create(
+                {
+                    "bom_id": self.bom.id,
+                    "product_id": self.ink.id,
+                    "product_qty": 100.0,
+                    "product_uom_id": self.uom_ml.id,  # generic mL, cross-tree for Unit
+                }
+            )
+
+    def test_same_category_uom_on_bom_line_allowed(self):
+        """A same-category UoM (mL for an L-base product) passes the constraint.
+
+        Uses two different products (finished + component) to avoid the BOM cycle check.
+        The key is that mL and L are in the same volume category: no ValidationError.
+        """
+        volume_finished = self.env["product.product"].create(
+            {
+                "name": "Volume Finished Product (Scoping Test)",
+                "type": "consu",
+                "uom_id": self.uom_liter.id,
+            }
+        )
+        volume_component = self.env["product.product"].create(
+            {
+                "name": "Volume Component (Scoping Test)",
+                "type": "consu",
+                "uom_id": self.uom_liter.id,
+            }
+        )
+        # mL is in the same category as L → no ValidationError
+        bom_vol = self.env["mrp.bom"].create(
+            {
+                "product_tmpl_id": volume_finished.product_tmpl_id.id,
+                "product_qty": 1.0,
+                "product_uom_id": self.uom_liter.id,
+                "bom_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": volume_component.id,
+                            "product_qty": 1000.0,
+                            "product_uom_id": self.uom_ml.id,  # same category as L
+                        },
+                    )
+                ],
+            }
+        )
+        self.assertTrue(bom_vol.bom_line_ids)
+
+
+class TestConversionBehavior(TestMrpIntegrationBase):
+    """Crit 9 + 10: conversion behavior after guard removal.
+
+    The strong cross-tree guard was removed (review blocker 1+2): it incorrectly
+    raised UserError on legitimate core conversions (T-GT→Units, Units→m²,
+    kg price→Units). Criterion 9's safety is now carried entirely by the scoping
+    @api.constrains on line models (see TestScopingAllowedUoms.
+    test_cross_tree_uom_on_bom_line_raises_validation_error).
+
+    These tests verify:
+    - Cross-tree conversions with the generic UoM return core's numeric result
+      (no raise) — core behaviour restored.
+    - Delegate (intra-tree) conversions still resolve correctly.
+    - Intra-category conversions are unaffected.
+    """
+
+    def test_generic_cross_tree_compute_quantity_no_raise(self):
+        """Generic mL._compute_quantity(qty, Unit) returns core's numeric result
+        without raising. Core O19 behaviour: silent cross-tree math."""
+        result = self.uom_ml._compute_quantity(250.0, self.uom_unit, round=False)
+        self.assertIsInstance(result, float, "Cross-tree with no delegate: should return float, not raise")
+
+    def test_generic_cross_tree_compute_price_no_raise(self):
+        """Generic mL._compute_price(price, Unit) returns core's numeric result
+        without raising."""
+        result = self.uom_ml._compute_price(0.04, self.uom_unit)
+        self.assertIsInstance(result, float, "Cross-tree price with no delegate: should return float, not raise")
+
+    def test_delegate_intra_tree_compute_quantity_correct(self):
+        """delegate-mL._compute_quantity(qty, Unit) resolves correctly via the
+        delegate tree (same tree after grafting)."""
+        result = self.delegate_ml._compute_quantity(250.0, self.uom_unit, round=False)
+        self.assertAlmostEqual(
+            result,
+            0.0125,
+            places=5,
+            msg="250 delegate-mL × 0.00005 = 0.0125 Unit (native intra-tree conversion)",
+        )
+
+    def test_intra_category_conversion_unaffected(self):
+        """mL._compute_quantity(qty, L) (same volume tree) resolves correctly."""
+        result = self.uom_ml._compute_quantity(1000.0, self.uom_liter, round=False)
+        self.assertAlmostEqual(
+            result, 1.0, places=5, msg="1000 mL → 1 L (intra-category, no exception)"
+        )
+
+
+class TestEdgeCases(TestMrpIntegrationBase):
+    """Edge cases: base-UoM change blocked, foreign==base rejected, factor persists, cascade."""
+
+    def test_base_uom_change_blocked_with_factor(self):
+        """Changing base UoM while a factor row exists raises ValidationError."""
+        template = self.env["product.template"].create(
+            {
+                "name": "Edge Case Ink – UoM Change",
+                "uom_id": self.uom_unit.id,
+            }
+        )
+        self.env["product.uom.factor"].create(
+            {
+                "product_tmpl_id": template.id,
+                "foreign_uom_id": self.uom_ml.id,
+                "factor": 0.00005,
+            }
+        )
+        with self.assertRaises(ValidationError):
+            template.uom_id = self.uom_liter
+
+    def test_foreign_uom_equals_base_rejected(self):
+        """foreign_uom_id == product base UoM raises ValidationError."""
+        template = self.env["product.template"].create(
+            {
+                "name": "Edge Case Ink – Foreign==Base",
+                "uom_id": self.uom_unit.id,
+            }
+        )
+        with self.assertRaises(ValidationError):
+            self.env["product.uom.factor"].create(
+                {
+                    "product_tmpl_id": template.id,
+                    "foreign_uom_id": self.uom_unit.id,  # same as base → error
+                    "factor": 1.0,
+                }
+            )
+
+    def test_factor_persists_on_inventory_tab_save(self):
+        """Factor added via template write and saved: uom_factor_ids and uom_ids retain it.
+
+        Regression for the clone-swap bug where the factor disappeared on save.
+        """
+        template = self.env["product.template"].create(
+            {
+                "name": "Edge Case Ink – Persist",
+                "uom_id": self.uom_unit.id,
+            }
+        )
+        factor = self.env["product.uom.factor"].create(
+            {
+                "product_tmpl_id": template.id,
+                "foreign_uom_id": self.uom_ml.id,
+                "factor": 0.00005,
+            }
+        )
+        template.write({"uom_factor_ids": [(4, factor.id)]})
+        template.invalidate_recordset()
+        self.assertIn(
+            factor,
+            template.uom_factor_ids,
+            "Factor must still be in uom_factor_ids after write/save",
+        )
+        self.assertIn(
+            factor.delegate_uom_id,
+            template.uom_ids,
+            "Delegate must still be in uom_ids after write/save (additive sync)",
+        )
+
+    def test_deleting_factor_removes_delegate_uom(self):
+        """Unlinking a factor row removes its delegate uom.uom (cascade)."""
+        template = self.env["product.template"].create(
+            {
+                "name": "Edge Case Ink – Delete Cascade",
+                "uom_id": self.uom_unit.id,
+            }
+        )
+        factor = self.env["product.uom.factor"].create(
+            {
+                "product_tmpl_id": template.id,
+                "foreign_uom_id": self.uom_ml.id,
+                "factor": 0.00005,
+            }
+        )
+        delegate_id = factor.delegate_uom_id.id
+        factor.unlink()
+        remaining = self.env["uom.uom"].browse(delegate_id).exists()
+        self.assertFalse(
+            remaining,
+            "Delegate uom.uom must be deleted when the factor row is unlinked",
+        )
+
+
+class TestRegressionIntraCategoryAndUC(TestMrpIntegrationBase):
+    """Crit 10: intra-category conversions unaffected; UC1-UC3 core assertions hold."""
+
+    def test_intra_category_ml_to_liter(self):
+        """mL → L (same volume category) uses standard Odoo conversion."""
+        result = self.uom_ml._compute_quantity(1000.0, self.uom_liter, round=False)
+        self.assertAlmostEqual(
+            result, 1.0, places=5, msg="1000 mL must be 1.0 L (intra-category)"
+        )
+
+    def test_intra_category_liter_to_ml(self):
+        """L → mL (same category) reverse."""
+        result = self.uom_liter._compute_quantity(2.5, self.uom_ml, round=False)
+        self.assertAlmostEqual(
+            result, 2500.0, places=2, msg="2.5 L must be 2500 mL (intra-category)"
+        )
+
+    def test_uc1_delegate_created_on_factor_create(self):
+        """UC1 regression: creating a factor row creates a delegate uom with correct attrs."""
+        factor = self.env["product.uom.factor"].create(
+            {
+                "product_tmpl_id": self.ink.product_tmpl_id.id,
+                "foreign_uom_id": self.uom_liter.id,
+                "factor": 0.05,
+            }
+        )
+        self.assertTrue(factor.delegate_uom_id)
+        self.assertEqual(factor.delegate_uom_id.relative_uom_id, self.uom_unit)
+        self.assertAlmostEqual(factor.delegate_uom_id.relative_factor, 0.05, places=6)
+        self.assertEqual(factor.delegate_uom_id.name, self.uom_liter.name)
+
+    def test_uc2_delegate_conversion_correct(self):
+        """UC2 regression: delegate-mL._compute_quantity to Unit uses correct factor."""
+        result = self.delegate_ml._compute_quantity(
+            20000.0, self.uom_unit, round=False
+        )
+        self.assertAlmostEqual(
+            result, 1.0, places=5, msg="20000 delegate-mL × 0.00005 = 1.0 Unit"
+        )
+
+    def test_uc3_delegate_in_uom_ids_after_sync(self):
+        """UC3 regression: delegate UoM is in product's uom_ids after write/sync."""
+        self.assertIn(
+            self.delegate_ml,
+            self.ink.product_tmpl_id.uom_ids,
+            "Delegate must be in ink template's uom_ids (additive sync)",
+        )

--- a/product_uom_factor_mrp/views/mrp_bom_views.xml
+++ b/product_uom_factor_mrp/views/mrp_bom_views.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Restrict the BOM line product_uom_id to the product's allowed UoMs
+         (standard category UoMs + product-specific cross-category factor UoMs). -->
+    <record id="mrp_bom_form_view_uom_factor" model="ir.ui.view">
+        <field name="name">mrp.bom.form.uom.factor</field>
+        <field name="model">mrp.bom</field>
+        <field name="inherit_id" ref="mrp.mrp_bom_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='bom_line_ids']//field[@name='product_uom_id']" position="before">
+                <field name="allowed_uom_ids" column_invisible="1" />
+            </xpath>
+            <xpath expr="//field[@name='bom_line_ids']//field[@name='product_uom_id']" position="attributes">
+                <attribute name="domain">[('id', 'in', allowed_uom_ids)]</attribute>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/product_uom_factor_purchase/__manifest__.py
+++ b/product_uom_factor_purchase/__manifest__.py
@@ -2,9 +2,9 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 {
-    "name": "Product UoM Factor – Purchase Bridge",
-    "summary": "Displays the base-UoM equivalent quantity on purchase order lines",
-    "version": "19.0.1.0.0",
+    "name": "Product UoM Factor – Purchase",
+    "summary": "Base-UoM display on purchase order lines for cross-category factor products",
+    "version": "19.0.2.0.0",
     "development_status": "Alpha",
     "license": "LGPL-3",
     "author": "Bemade Inc.",
@@ -19,12 +19,8 @@
         "report/purchase_order_templates.xml",
     ],
     "assets": {
-        "web.assets_unit_tests": [
-            "product_uom_factor_purchase/static/tests/**/*",
-            ("remove", "product_uom_factor_purchase/static/tests/tours/**/*"),
-        ],
         "web.assets_tests": [
-            "product_uom_factor_purchase/static/tests/tours/**/*",
+            "product_uom_factor_purchase/static/tests/tours/purchase_factor_display_tour.js",
         ],
     },
 }

--- a/product_uom_factor_purchase/models/purchase_order_line.py
+++ b/product_uom_factor_purchase/models/purchase_order_line.py
@@ -5,8 +5,14 @@ from odoo import api, fields, models
 
 
 class PurchaseOrderLine(models.Model):
-    _inherit = "purchase.order.line"
+    _name = "purchase.order.line"
+    _inherit = ["purchase.order.line", "product.uom.factor.line.mixin"]
 
+    @api.constrains("product_uom_id", "product_id")
+    def _check_factor_uom_allowed_purchase_line(self):
+        self._check_factor_uom_allowed("product_uom_id")
+
+    # ── Display-only fields ───────────────────────────────────────────────
     factor_base_uom_qty = fields.Float(
         string="Base UoM Qty",
         compute="_compute_factor_base_uom",
@@ -24,12 +30,7 @@ class PurchaseOrderLine(models.Model):
         '(e.g. "= 150.00 lb"). Empty when no cross-category factor applies.',
     )
 
-    @api.depends(
-        "product_qty",
-        "product_uom_id",
-        "product_id",
-        "product_id.uom_id",
-    )
+    @api.depends("product_qty", "product_uom_id", "product_id", "product_id.uom_id")
     def _compute_factor_base_uom(self):
         for line in self:
             product = line.product_id
@@ -38,31 +39,21 @@ class PurchaseOrderLine(models.Model):
                 line.factor_base_uom_qty = 0.0
                 line.factor_base_uom_display = ""
                 continue
-
             base_uom = product.uom_id
-            # Short-circuit: same-category means standard Odoo handles it,
-            # no factor display needed.
-            if not base_uom or base_uom._has_common_reference(line_uom):
+            if not base_uom:
                 line.factor_base_uom_qty = 0.0
                 line.factor_base_uom_display = ""
                 continue
-
-            # Check that a product.uom.factor record exists for this product
-            # and line UoM (or its category).
-            factor_record = line_uom._find_product_uom_for_category(
-                product.id, line_uom
+            # A delegate factor-UoM shares a common reference with the base UoM
+            # (its relative_uom_id IS the base), so we must detect it BEFORE any
+            # common-reference short-circuit.
+            factor_uoms = product.product_tmpl_id.uom_factor_ids.mapped(
+                "delegate_uom_id"
             )
-            if not factor_record:
+            if line_uom not in factor_uoms:
                 line.factor_base_uom_qty = 0.0
                 line.factor_base_uom_display = ""
                 continue
-
-            # Convert line qty from line_uom → product base_uom using the
-            # product-specific factor. The core's _compute_quantity override
-            # picks up the factor automatically via product_id context.
-            base_qty = line_uom.with_context(
-                product_id=product.id
-            )._compute_quantity(line.product_qty, base_uom, round=False)
-
+            base_qty = line_uom._compute_quantity(line.product_qty, base_uom, round=False)
             line.factor_base_uom_qty = base_qty
             line.factor_base_uom_display = "= %.2f %s" % (base_qty, base_uom.name)

--- a/product_uom_factor_purchase/tests/__init__.py
+++ b/product_uom_factor_purchase/tests/__init__.py
@@ -3,3 +3,5 @@
 
 from . import test_purchase_line_base_uom_display
 from . import test_render_pdf
+from . import test_purchase_integration
+from . import test_purchase_factor_display_tour

--- a/product_uom_factor_purchase/tests/test_purchase_factor_display_tour.py
+++ b/product_uom_factor_purchase/tests/test_purchase_factor_display_tour.py
@@ -1,0 +1,91 @@
+# Copyright 2026 Bemade Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+"""
+Tour test: factor_base_uom_display column visible on a purchase order with a
+cross-category factor line.
+
+The JS tour (purchase_factor_display_tour) opens the PO form, waits for the
+order_line list to load, then asserts a td[name='factor_base_uom_display']
+cell whose text contains '= '.  This confirms the optional "Base UoM" column
+is present and populated with the delegated-UoM display value.
+"""
+
+from datetime import date
+
+from odoo.tests import HttpCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestPurchaseFactorDisplayTour(HttpCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # Ensure enough decimal precision for sub-unit quantities (e.g. 0.0125).
+        dp = cls.env["decimal.precision"].search(
+            [("name", "=", "Product Unit")], limit=1
+        )
+        if dp and dp.digits < 5:
+            dp.digits = 5
+
+        # Stand-alone root UoM: no relative_uom_id → cross-category w.r.t. lb/kg.
+        uom_bag = cls.env["uom.uom"].create(
+            {"name": "BagPOTour", "relative_factor": 1.0}
+        )
+        uom_lb = cls.env.ref("uom.product_uom_lb")
+
+        product = cls.env["product.product"].create(
+            {
+                "name": "Tour Powder Purchase",
+                "uom_id": uom_lb.id,
+                "uom_ids": [(4, uom_lb.id), (4, uom_bag.id)],
+                "standard_price": 3.0,
+            }
+        )
+        # 1 BagPOTour = 50 lb: creates a delegate uom.uom in lb's tree.
+        factor = cls.env["product.uom.factor"].create(
+            {
+                "product_tmpl_id": product.product_tmpl_id.id,
+                "foreign_uom_id": uom_bag.id,
+                "factor": 50.0,
+            }
+        )
+        # Trigger additive uom_ids sync so the delegate is selectable on lines.
+        product.product_tmpl_id.write({"uom_factor_ids": [(4, factor.id)]})
+        delegate_bag = factor.delegate_uom_id
+
+        vendor = cls.env["res.partner"].create(
+            {"name": "Tour Vendor Purchase", "supplier_rank": 1}
+        )
+
+        # Create a PO with a line in the delegate UoM so the display compute
+        # populates and the tour selector finds text containing '= '.
+        po = cls.env["purchase.order"].create(
+            {
+                "partner_id": vendor.id,
+                "date_order": date.today(),
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": product.id,
+                            "product_qty": 3.0,
+                            "product_uom_id": delegate_bag.id,
+                            "price_unit": 3.0,
+                            "date_planned": date.today(),
+                            "name": product.name,
+                        },
+                    )
+                ],
+            }
+        )
+        cls.po_id = po.id
+
+    def test_purchase_factor_display_tour(self):
+        self.start_tour(
+            f"/odoo/purchase/{self.po_id}",
+            "purchase_factor_display_tour",
+            login="admin",
+        )

--- a/product_uom_factor_purchase/tests/test_purchase_integration.py
+++ b/product_uom_factor_purchase/tests/test_purchase_integration.py
@@ -1,0 +1,206 @@
+"""
+Integration tests for product_uom_factor_purchase.
+
+Tests cover:
+  - Crit 6 (refinement): cross-tree UoM constraint on PO line raises ValidationError
+  - Crit 6 (refinement): delegate-mL in factor_base_uom_display compute for PO line
+  - Scoping: allowed_uom_ids on PO line contains delegate-mL via product.uom_ids
+
+NOTE: End-to-end PO receipt flow (picking_ids) requires purchase_stock.
+      Those tests live in product_uom_factor_stock/tests/test_stock_integration.py.
+"""
+
+from odoo.exceptions import ValidationError
+from odoo.tests.common import TransactionCase
+
+
+class TestPurchaseIntegrationBase(TransactionCase):
+    """Common fixture for purchase integration tests."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.env["res.config.settings"].create({"group_uom": True}).execute()
+
+        dp = cls.env["decimal.precision"].search(
+            [("name", "=", "Product Unit")], limit=1
+        )
+        if dp and dp.digits < 5:
+            dp.digits = 5
+
+        cls.uom_unit = cls.env.ref("uom.product_uom_unit")
+        cls.uom_ml = cls.env.ref("uom.product_uom_milliliter")
+
+        # Ink product: Unit base
+        cls.ink = cls.env["product.product"].create(
+            {
+                "name": "Test Ink – PO Integration",
+                "type": "consu",
+                "uom_id": cls.uom_unit.id,
+                "standard_price": 800.0,
+            }
+        )
+
+        # Factor: 1 delegate-mL = 0.00005 Unit
+        cls.factor = cls.env["product.uom.factor"].create(
+            {
+                "product_tmpl_id": cls.ink.product_tmpl_id.id,
+                "foreign_uom_id": cls.uom_ml.id,
+                "factor": 0.00005,
+            }
+        )
+        cls.delegate_ml = cls.factor.delegate_uom_id
+        cls.ink.product_tmpl_id.write({"uom_factor_ids": [(4, cls.factor.id)]})
+
+        cls.vendor = cls.env["res.partner"].create(
+            {"name": "Test Ink Vendor (PO Integration)", "supplier_rank": 1}
+        )
+
+
+class TestPurchaseLineConstraint(TestPurchaseIntegrationBase):
+    """Crit 6: constraint rejects cross-tree UoM on PO line; delegate passes."""
+
+    def test_delegate_ml_allowed_on_po_line(self):
+        """Creating a PO line with delegate-mL does NOT raise ValidationError."""
+        po = self.env["purchase.order"].create(
+            {
+                "partner_id": self.vendor.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.ink.id,
+                            "product_qty": 250000.0,
+                            "product_uom_id": self.delegate_ml.id,
+                            "price_unit": 0.004,
+                            "name": self.ink.name,
+                        },
+                    )
+                ],
+            }
+        )
+        self.assertEqual(len(po.order_line), 1)
+        self.assertEqual(po.order_line.product_uom_id, self.delegate_ml)
+
+    def test_cross_tree_uom_on_po_line_raises_validation_error(self):
+        """Generic mL (cross-tree for Unit-base product) on PO line raises ValidationError."""
+        with self.assertRaises(ValidationError):
+            self.env["purchase.order"].create(
+                {
+                    "partner_id": self.vendor.id,
+                    "order_line": [
+                        (
+                            0,
+                            0,
+                            {
+                                "product_id": self.ink.id,
+                                "product_qty": 250000.0,
+                                "product_uom_id": self.uom_ml.id,  # generic mL
+                                "price_unit": 0.004,
+                                "name": self.ink.name,
+                            },
+                        )
+                    ],
+                }
+            )
+
+
+class TestPurchaseLineDisplayCompute(TestPurchaseIntegrationBase):
+    """Crit 6 (display compute): factor_base_uom_display shows correct base UoM qty."""
+
+    def test_factor_base_uom_qty_on_delegate_ml(self):
+        """PO line with 250000 delegate-mL: factor_base_uom_qty == 12.5 Unit."""
+        po = self.env["purchase.order"].create(
+            {
+                "partner_id": self.vendor.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.ink.id,
+                            "product_qty": 250000.0,
+                            "product_uom_id": self.delegate_ml.id,
+                            "price_unit": 0.004,
+                            "name": self.ink.name,
+                        },
+                    )
+                ],
+            }
+        )
+        pol = po.order_line
+        # factor_base_uom_qty: 250000 × 0.00005 = 12.5 Unit
+        self.assertAlmostEqual(
+            pol.factor_base_uom_qty,
+            12.5,
+            places=4,
+            msg="factor_base_uom_qty must be 12.5 Unit (250000 delegate-mL × 0.00005)",
+        )
+
+    def test_factor_base_uom_display_empty_for_same_category_uom(self):
+        """PO line with a same-category UoM has empty factor_base_uom_display."""
+        uom_liter = self.env.ref("uom.product_uom_litre")
+        # Create a liter-based product with no factor
+        liter_ink = self.env["product.product"].create(
+            {
+                "name": "Liter Ink (no factor)",
+                "type": "consu",
+                "uom_id": uom_liter.id,
+            }
+        )
+        po = self.env["purchase.order"].create(
+            {
+                "partner_id": self.vendor.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": liter_ink.id,
+                            "product_qty": 5.0,
+                            "product_uom_id": self.uom_ml.id,  # same category
+                            "price_unit": 10.0,
+                            "name": liter_ink.name,
+                        },
+                    )
+                ],
+            }
+        )
+        pol = po.order_line
+        self.assertEqual(
+            pol.factor_base_uom_display,
+            "",
+            "factor_base_uom_display must be empty when using same-category UoM",
+        )
+        self.assertAlmostEqual(
+            pol.factor_base_uom_qty,
+            0.0,
+            places=2,
+            msg="factor_base_uom_qty must be 0.0 when using same-category UoM",
+        )
+
+    def test_delegate_ml_in_po_line_allowed_uom_ids(self):
+        """Delegate-mL id is in a PO line's allowed_uom_ids for the ink product.
+
+        Compare via .ids because .new() records return NewId proxies that
+        don't compare equal to database record IDs with assertIn().
+        """
+        po = self.env["purchase.order"].create({"partner_id": self.vendor.id})
+        pol = self.env["purchase.order.line"].new(
+            {
+                "order_id": po.id,
+                "product_id": self.ink.id,
+                "product_qty": 1.0,
+                "product_uom_id": self.uom_unit.id,
+                "price_unit": 800.0,
+                "name": self.ink.name,
+            }
+        )
+        pol._compute_allowed_uom_ids()
+        self.assertIn(
+            self.delegate_ml.id,
+            pol.allowed_uom_ids.ids,
+            "Delegate-mL must be in PO line allowed_uom_ids.ids (via product.uom_ids)",
+        )

--- a/product_uom_factor_purchase/tests/test_purchase_line_base_uom_display.py
+++ b/product_uom_factor_purchase/tests/test_purchase_line_base_uom_display.py
@@ -43,13 +43,19 @@ class TestPurchaseLineBaseUomDisplay(TransactionCase):
                 "standard_price": 3.0,
             }
         )
-        # 1 Bag = 50 lb
-        cls.env["product.uom.factor"].create(
+        # 1 Bag = 50 lb. Creating the factor auto-creates a delegate uom.uom
+        # (relative_uom_id=lb, relative_factor=50, name="BagPO") in lb's tree.
+        # The line must use this delegate, not the generic root Bag.
+        cls.factor = cls.env["product.uom.factor"].create(
             {
                 "product_tmpl_id": cls.product.product_tmpl_id.id,
-                "uom_id": cls.uom_bag.id,
+                "foreign_uom_id": cls.uom_bag.id,
                 "factor": 50.0,
             }
+        )
+        cls.delegate_bag = cls.factor.delegate_uom_id
+        cls.product.product_tmpl_id.write(
+            {"uom_factor_ids": [(4, cls.factor.id)]}
         )
 
     def _make_po_line(self, qty, uom):
@@ -77,7 +83,7 @@ class TestPurchaseLineBaseUomDisplay(TransactionCase):
 
     def test_happy_path_cross_category(self):
         """3 Bag × 50 lb/Bag → factor_base_uom_qty=150.0, display='= 150.00 lb'."""
-        line = self._make_po_line(3.0, self.uom_bag)
+        line = self._make_po_line(3.0, self.delegate_bag)
         self.assertAlmostEqual(line.factor_base_uom_qty, 150.0, places=2)
         self.assertEqual(line.factor_base_uom_display, "= 150.00 lb")
 
@@ -88,7 +94,12 @@ class TestPurchaseLineBaseUomDisplay(TransactionCase):
         self.assertEqual(line.factor_base_uom_display, "")
 
     def test_missing_factor_no_display(self):
-        """Cross-category UoM with no factor row → qty=0.0, no exception."""
+        """Same-tree UoM with no factor row → qty=0.0, no exception.
+
+        kg and lb share the mass tree (common reference), so the scoping
+        constraint allows the line and the display compute stays empty because
+        the line UoM is not a factor delegate.
+        """
         product2 = self.env["product.product"].create(
             {
                 "name": "No Factor Product PO",
@@ -96,7 +107,6 @@ class TestPurchaseLineBaseUomDisplay(TransactionCase):
                 "standard_price": 3.0,
             }
         )
-        uom_liter = self.env.ref("uom.product_uom_litre")
         po = self.env["purchase.order"].create(
             {
                 "partner_id": self.vendor.id,
@@ -108,7 +118,7 @@ class TestPurchaseLineBaseUomDisplay(TransactionCase):
                         {
                             "product_id": product2.id,
                             "product_qty": 2.0,
-                            "product_uom_id": uom_liter.id,
+                            "product_uom_id": self.uom_kg.id,
                             "price_unit": 3.0,
                             "date_planned": date.today(),
                             "name": product2.name,

--- a/product_uom_factor_purchase/tests/test_render_pdf.py
+++ b/product_uom_factor_purchase/tests/test_render_pdf.py
@@ -45,12 +45,16 @@ class TestRenderPdf(TransactionCase):
                 "standard_price": 3.0,
             }
         )
-        cls.env["product.uom.factor"].create(
+        cls.factor = cls.env["product.uom.factor"].create(
             {
                 "product_tmpl_id": cls.product.product_tmpl_id.id,
-                "uom_id": cls.uom_bag.id,
+                "foreign_uom_id": cls.uom_bag.id,
                 "factor": 50.0,
             }
+        )
+        cls.delegate_bag = cls.factor.delegate_uom_id
+        cls.product.product_tmpl_id.write(
+            {"uom_factor_ids": [(4, cls.factor.id)]}
         )
         cls.po = cls.env["purchase.order"].create(
             {
@@ -63,7 +67,7 @@ class TestRenderPdf(TransactionCase):
                         {
                             "product_id": cls.product.id,
                             "product_qty": 3.0,
-                            "product_uom_id": cls.uom_bag.id,
+                            "product_uom_id": cls.delegate_bag.id,
                             "price_unit": 3.0,
                             "date_planned": date.today(),
                             "name": cls.product.name,

--- a/product_uom_factor_sale/__manifest__.py
+++ b/product_uom_factor_sale/__manifest__.py
@@ -2,9 +2,9 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 {
-    "name": "Product UoM Factor – Sale Bridge",
-    "summary": "Displays the base-UoM equivalent quantity on sale order lines",
-    "version": "19.0.1.0.0",
+    "name": "Product UoM Factor – Sale",
+    "summary": "Base-UoM display on sale order lines for cross-category factor products",
+    "version": "19.0.2.0.0",
     "development_status": "Alpha",
     "license": "LGPL-3",
     "author": "Bemade Inc.",
@@ -19,12 +19,8 @@
         "report/sale_order_templates.xml",
     ],
     "assets": {
-        "web.assets_unit_tests": [
-            "product_uom_factor_sale/static/tests/**/*",
-            ("remove", "product_uom_factor_sale/static/tests/tours/**/*"),
-        ],
         "web.assets_tests": [
-            "product_uom_factor_sale/static/tests/tours/**/*",
+            "product_uom_factor_sale/static/tests/tours/sale_factor_display_tour.js",
         ],
     },
 }

--- a/product_uom_factor_sale/models/sale_order_line.py
+++ b/product_uom_factor_sale/models/sale_order_line.py
@@ -5,8 +5,14 @@ from odoo import api, fields, models
 
 
 class SaleOrderLine(models.Model):
-    _inherit = "sale.order.line"
+    _name = "sale.order.line"
+    _inherit = ["sale.order.line", "product.uom.factor.line.mixin"]
 
+    @api.constrains("product_uom_id", "product_id")
+    def _check_factor_uom_allowed_sale_line(self):
+        self._check_factor_uom_allowed("product_uom_id")
+
+    # ── Display-only fields ───────────────────────────────────────────────
     factor_base_uom_qty = fields.Float(
         string="Base UoM Qty",
         compute="_compute_factor_base_uom",
@@ -24,12 +30,7 @@ class SaleOrderLine(models.Model):
         '(e.g. "= 250.00 lb"). Empty when no cross-category factor applies.',
     )
 
-    @api.depends(
-        "product_uom_qty",
-        "product_uom_id",
-        "product_id",
-        "product_id.uom_id",
-    )
+    @api.depends("product_uom_qty", "product_uom_id", "product_id", "product_id.uom_id")
     def _compute_factor_base_uom(self):
         for line in self:
             product = line.product_id
@@ -38,31 +39,24 @@ class SaleOrderLine(models.Model):
                 line.factor_base_uom_qty = 0.0
                 line.factor_base_uom_display = ""
                 continue
-
             base_uom = product.uom_id
-            # Short-circuit: same-category means standard Odoo handles it,
-            # no factor display needed.
-            if not base_uom or base_uom._has_common_reference(line_uom):
+            if not base_uom:
                 line.factor_base_uom_qty = 0.0
                 line.factor_base_uom_display = ""
                 continue
-
-            # Check that a product.uom.factor record exists for this product
-            # and line UoM (or its category).
-            factor_record = line_uom._find_product_uom_for_category(
-                product.id, line_uom
+            # A delegate factor-UoM shares a common reference with the base UoM
+            # (its relative_uom_id IS the base), so we must detect it BEFORE the
+            # common-reference short-circuit, otherwise the display never fires.
+            factor_uoms = product.product_tmpl_id.uom_factor_ids.mapped(
+                "delegate_uom_id"
             )
-            if not factor_record:
+            if line_uom not in factor_uoms:
+                # Not a product-specific factor UoM: standard Odoo handles the
+                # (possibly same-category) conversion, no factor display needed.
                 line.factor_base_uom_qty = 0.0
                 line.factor_base_uom_display = ""
                 continue
-
-            # Convert line qty from line_uom → product base_uom using the
-            # product-specific factor. The core's _compute_quantity override
-            # picks up the factor automatically via product_id context.
-            base_qty = line_uom.with_context(
-                product_id=product.id
-            )._compute_quantity(line.product_uom_qty, base_uom, round=False)
-
+            # line_uom IS the delegate — native conversion works directly
+            base_qty = line_uom._compute_quantity(line.product_uom_qty, base_uom, round=False)
             line.factor_base_uom_qty = base_qty
             line.factor_base_uom_display = "= %.2f %s" % (base_qty, base_uom.name)

--- a/product_uom_factor_sale/tests/__init__.py
+++ b/product_uom_factor_sale/tests/__init__.py
@@ -3,3 +3,5 @@
 
 from . import test_sale_line_base_uom_display
 from . import test_render_pdf
+from . import test_sale_integration
+from . import test_sale_factor_display_tour

--- a/product_uom_factor_sale/tests/test_render_pdf.py
+++ b/product_uom_factor_sale/tests/test_render_pdf.py
@@ -44,12 +44,16 @@ class TestRenderPdf(TransactionCase):
                 "list_price": 5.0,
             }
         )
-        cls.env["product.uom.factor"].create(
+        cls.factor = cls.env["product.uom.factor"].create(
             {
                 "product_tmpl_id": cls.product.product_tmpl_id.id,
-                "uom_id": cls.uom_bag.id,
+                "foreign_uom_id": cls.uom_bag.id,
                 "factor": 50.0,
             }
+        )
+        cls.delegate_bag = cls.factor.delegate_uom_id
+        cls.product.product_tmpl_id.write(
+            {"uom_factor_ids": [(4, cls.factor.id)]}
         )
         cls.so = cls.env["sale.order"].create(
             {
@@ -61,7 +65,7 @@ class TestRenderPdf(TransactionCase):
                         {
                             "product_id": cls.product.id,
                             "product_uom_qty": 5.0,
-                            "product_uom_id": cls.uom_bag.id,
+                            "product_uom_id": cls.delegate_bag.id,
                             "price_unit": 5.0,
                         },
                     )

--- a/product_uom_factor_sale/tests/test_sale_factor_display_tour.py
+++ b/product_uom_factor_sale/tests/test_sale_factor_display_tour.py
@@ -1,0 +1,88 @@
+# Copyright 2026 Bemade Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+"""
+Tour test: factor_base_uom_display column visible on a sale order with a
+cross-category factor line.
+
+The JS tour (sale_factor_display_tour) opens the SO form, waits for the
+order_line list to load, then asserts a td[name='factor_base_uom_display']
+cell whose text contains '= '.  This confirms the optional "Base UoM" column
+is present and populated with the delegated-UoM display value.
+"""
+
+from datetime import date
+
+from odoo.tests import HttpCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestSaleFactorDisplayTour(HttpCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # Ensure enough decimal precision for sub-unit quantities (e.g. 0.0125).
+        dp = cls.env["decimal.precision"].search(
+            [("name", "=", "Product Unit")], limit=1
+        )
+        if dp and dp.digits < 5:
+            dp.digits = 5
+
+        # Stand-alone root UoM: no relative_uom_id → cross-category w.r.t. lb/kg.
+        uom_bag = cls.env["uom.uom"].create(
+            {"name": "BagSaleTour", "relative_factor": 1.0}
+        )
+        uom_lb = cls.env.ref("uom.product_uom_lb")
+
+        product = cls.env["product.product"].create(
+            {
+                "name": "Tour Powder Sale",
+                "uom_id": uom_lb.id,
+                "uom_ids": [(4, uom_lb.id), (4, uom_bag.id)],
+                "list_price": 5.0,
+            }
+        )
+        # 1 BagSaleTour = 50 lb: creates a delegate uom.uom in lb's tree.
+        factor = cls.env["product.uom.factor"].create(
+            {
+                "product_tmpl_id": product.product_tmpl_id.id,
+                "foreign_uom_id": uom_bag.id,
+                "factor": 50.0,
+            }
+        )
+        # Trigger additive uom_ids sync so the delegate is selectable on lines.
+        product.product_tmpl_id.write({"uom_factor_ids": [(4, factor.id)]})
+        delegate_bag = factor.delegate_uom_id
+
+        customer = cls.env["res.partner"].create(
+            {"name": "Tour Customer Sale", "customer_rank": 1}
+        )
+
+        # Create a confirmed SO with a line in the delegate UoM so the display
+        # compute populates and the tour selector finds text containing '= '.
+        so = cls.env["sale.order"].create(
+            {
+                "partner_id": customer.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": product.id,
+                            "product_uom_qty": 5.0,
+                            "product_uom_id": delegate_bag.id,
+                            "price_unit": 5.0,
+                        },
+                    )
+                ],
+            }
+        )
+        cls.so_id = so.id
+
+    def test_sale_factor_display_tour(self):
+        self.start_tour(
+            f"/odoo/sales/{self.so_id}",
+            "sale_factor_display_tour",
+            login="admin",
+        )

--- a/product_uom_factor_sale/tests/test_sale_integration.py
+++ b/product_uom_factor_sale/tests/test_sale_integration.py
@@ -1,0 +1,200 @@
+"""
+Integration tests for product_uom_factor_sale.
+
+Tests cover:
+  - Crit 6 (refinement): cross-tree UoM constraint on SO line raises ValidationError
+  - Crit 6 (refinement): delegate-mL in factor_base_uom_display compute for SO line
+  - Scoping: allowed_uom_ids on SO line contains delegate-mL via product.uom_ids
+
+NOTE: End-to-end SO delivery flow (picking_ids) requires sale_stock.
+      Those tests live in product_uom_factor_stock/tests/test_stock_integration.py.
+"""
+
+from odoo.exceptions import ValidationError
+from odoo.tests.common import TransactionCase
+
+
+class TestSaleIntegrationBase(TransactionCase):
+    """Common fixture for sale integration tests."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.env["res.config.settings"].create({"group_uom": True}).execute()
+
+        dp = cls.env["decimal.precision"].search(
+            [("name", "=", "Product Unit")], limit=1
+        )
+        if dp and dp.digits < 5:
+            dp.digits = 5
+
+        cls.uom_unit = cls.env.ref("uom.product_uom_unit")
+        cls.uom_ml = cls.env.ref("uom.product_uom_milliliter")
+
+        # Ink product: Unit base
+        cls.ink = cls.env["product.product"].create(
+            {
+                "name": "Test Ink – SO Integration",
+                "type": "consu",
+                "uom_id": cls.uom_unit.id,
+                "list_price": 800.0,
+            }
+        )
+
+        # Factor: 1 delegate-mL = 0.00005 Unit
+        cls.factor = cls.env["product.uom.factor"].create(
+            {
+                "product_tmpl_id": cls.ink.product_tmpl_id.id,
+                "foreign_uom_id": cls.uom_ml.id,
+                "factor": 0.00005,
+            }
+        )
+        cls.delegate_ml = cls.factor.delegate_uom_id
+        cls.ink.product_tmpl_id.write({"uom_factor_ids": [(4, cls.factor.id)]})
+
+        cls.customer = cls.env["res.partner"].create(
+            {"name": "Test Ink Customer (SO Integration)", "customer_rank": 1}
+        )
+
+
+class TestSaleLineConstraint(TestSaleIntegrationBase):
+    """Crit 6: constraint rejects cross-tree UoM on SO line; delegate passes."""
+
+    def test_delegate_ml_allowed_on_so_line(self):
+        """Creating a SO line with delegate-mL does NOT raise ValidationError."""
+        so = self.env["sale.order"].create(
+            {
+                "partner_id": self.customer.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.ink.id,
+                            "product_uom_qty": 250000.0,
+                            "product_uom_id": self.delegate_ml.id,
+                            "price_unit": 0.004,
+                        },
+                    )
+                ],
+            }
+        )
+        self.assertEqual(len(so.order_line), 1)
+        self.assertEqual(so.order_line.product_uom_id, self.delegate_ml)
+
+    def test_cross_tree_uom_on_so_line_raises_validation_error(self):
+        """Generic mL (cross-tree for Unit-base) on SO line raises ValidationError."""
+        with self.assertRaises(ValidationError):
+            self.env["sale.order"].create(
+                {
+                    "partner_id": self.customer.id,
+                    "order_line": [
+                        (
+                            0,
+                            0,
+                            {
+                                "product_id": self.ink.id,
+                                "product_uom_qty": 250000.0,
+                                "product_uom_id": self.uom_ml.id,  # generic mL
+                                "price_unit": 0.004,
+                            },
+                        )
+                    ],
+                }
+            )
+
+
+class TestSaleLineDisplayCompute(TestSaleIntegrationBase):
+    """Crit 6 (display compute): factor_base_uom_display shows correct base UoM qty."""
+
+    def test_factor_base_uom_qty_on_delegate_ml(self):
+        """SO line with 250000 delegate-mL: factor_base_uom_qty == 12.5 Unit."""
+        so = self.env["sale.order"].create(
+            {
+                "partner_id": self.customer.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.ink.id,
+                            "product_uom_qty": 250000.0,
+                            "product_uom_id": self.delegate_ml.id,
+                            "price_unit": 0.004,
+                        },
+                    )
+                ],
+            }
+        )
+        sol = so.order_line
+        # factor_base_uom_qty: 250000 × 0.00005 = 12.5 Unit
+        self.assertAlmostEqual(
+            sol.factor_base_uom_qty,
+            12.5,
+            places=4,
+            msg="factor_base_uom_qty must be 12.5 Unit (250000 delegate-mL × 0.00005)",
+        )
+
+    def test_factor_base_uom_display_empty_for_same_category_uom(self):
+        """SO line with a same-category UoM has empty factor_base_uom_display."""
+        uom_liter = self.env.ref("uom.product_uom_litre")
+        liter_ink = self.env["product.product"].create(
+            {
+                "name": "Liter Ink – SO (no factor)",
+                "type": "consu",
+                "uom_id": uom_liter.id,
+            }
+        )
+        so = self.env["sale.order"].create(
+            {
+                "partner_id": self.customer.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": liter_ink.id,
+                            "product_uom_qty": 5.0,
+                            "product_uom_id": self.uom_ml.id,  # same category
+                            "price_unit": 10.0,
+                        },
+                    )
+                ],
+            }
+        )
+        sol = so.order_line
+        self.assertEqual(
+            sol.factor_base_uom_display,
+            "",
+            "factor_base_uom_display must be empty when using same-category UoM",
+        )
+        self.assertAlmostEqual(
+            sol.factor_base_uom_qty,
+            0.0,
+            places=2,
+            msg="factor_base_uom_qty must be 0.0 when using same-category UoM",
+        )
+
+    def test_delegate_ml_in_so_line_allowed_uom_ids(self):
+        """Delegate-mL id is in a SO line's allowed_uom_ids for the ink product.
+
+        Compare via .ids because .new() records return NewId proxies that
+        don't compare equal to database record IDs with assertIn().
+        """
+        so = self.env["sale.order"].create({"partner_id": self.customer.id})
+        sol = self.env["sale.order.line"].new(
+            {
+                "order_id": so.id,
+                "product_id": self.ink.id,
+                "product_uom_qty": 1.0,
+                "product_uom_id": self.uom_unit.id,
+                "price_unit": 800.0,
+            }
+        )
+        sol._compute_allowed_uom_ids()
+        self.assertIn(
+            self.delegate_ml.id,
+            sol.allowed_uom_ids.ids,
+            "Delegate-mL must be in SO line allowed_uom_ids.ids (via product.uom_ids)",
+        )

--- a/product_uom_factor_sale/tests/test_sale_line_base_uom_display.py
+++ b/product_uom_factor_sale/tests/test_sale_line_base_uom_display.py
@@ -42,13 +42,20 @@ class TestSaleLineBaseUomDisplay(TransactionCase):
                 "list_price": 5.0,
             }
         )
-        # 1 Bag = 50 lb
+        # 1 Bag = 50 lb. Creating the factor auto-creates a delegate uom.uom
+        # (relative_uom_id=lb, relative_factor=50, name="Bag") that lives in
+        # lb's tree. The line must use this delegate, not the generic root Bag.
         cls.factor = cls.env["product.uom.factor"].create(
             {
                 "product_tmpl_id": cls.product.product_tmpl_id.id,
-                "uom_id": cls.uom_bag.id,
+                "foreign_uom_id": cls.uom_bag.id,
                 "factor": 50.0,
             }
+        )
+        cls.delegate_bag = cls.factor.delegate_uom_id
+        # Trigger the additive sync so the delegate is in the product uom_ids.
+        cls.product.product_tmpl_id.write(
+            {"uom_factor_ids": [(4, cls.factor.id)]}
         )
 
     def _make_so_line(self, qty, uom):
@@ -73,7 +80,7 @@ class TestSaleLineBaseUomDisplay(TransactionCase):
 
     def test_happy_path_cross_category(self):
         """5 Bag × 50 lb/Bag → factor_base_uom_qty=250.0, display='= 250.00 lb'."""
-        line = self._make_so_line(5.0, self.uom_bag)
+        line = self._make_so_line(5.0, self.delegate_bag)
         self.assertAlmostEqual(line.factor_base_uom_qty, 250.0, places=2)
         self.assertEqual(line.factor_base_uom_display, "= 250.00 lb")
 
@@ -90,9 +97,12 @@ class TestSaleLineBaseUomDisplay(TransactionCase):
         self.assertEqual(line.factor_base_uom_display, "")
 
     def test_missing_factor_no_display(self):
-        """Cross-category UoM with no product.uom.factor row → qty=0.0."""
-        uom_liter = self.env.ref("uom.product_uom_litre")
-        # Product has no factor for litre; this should not raise.
+        """Same-tree UoM with no product.uom.factor row → qty=0.0, no display.
+
+        kg and lb share the mass tree (common reference), so the scoping
+        constraint allows the line and the display compute stays empty because
+        the line UoM is not a factor delegate.
+        """
         product2 = self.env["product.product"].create(
             {
                 "name": "Test Powder No Factor",
@@ -110,7 +120,7 @@ class TestSaleLineBaseUomDisplay(TransactionCase):
                         {
                             "product_id": product2.id,
                             "product_uom_qty": 3.0,
-                            "product_uom_id": uom_liter.id,
+                            "product_uom_id": self.uom_kg.id,
                             "price_unit": 5.0,
                         },
                     )

--- a/product_uom_factor_stock/__init__.py
+++ b/product_uom_factor_stock/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/product_uom_factor_stock/__manifest__.py
+++ b/product_uom_factor_stock/__manifest__.py
@@ -1,0 +1,20 @@
+# Copyright 2026 Bemade Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+{
+    "name": "Product UoM Factor – Stock",
+    "summary": "Scopes stock/accounting line UoM selection to product-specific "
+    "cross-category factor units",
+    "version": "19.0.2.0.0",
+    "development_status": "Alpha",
+    "license": "LGPL-3",
+    "author": "Bemade Inc.",
+    "website": "https://www.bemade.org",
+    "maintainers": ["mdurepos"],
+    "depends": [
+        "product_uom_factor",
+        "stock",
+        "stock_account",
+    ],
+    "data": [],
+}

--- a/product_uom_factor_stock/models/__init__.py
+++ b/product_uom_factor_stock/models/__init__.py
@@ -1,0 +1,3 @@
+from . import stock_move
+from . import stock_move_line
+from . import account_move_line

--- a/product_uom_factor_stock/models/account_move_line.py
+++ b/product_uom_factor_stock/models/account_move_line.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Bemade Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo import api, models
+
+
+class AccountMoveLine(models.Model):
+    _name = "account.move.line"
+    _inherit = ["account.move.line", "product.uom.factor.line.mixin"]
+
+    @api.constrains("product_uom_id", "product_id")
+    def _check_factor_uom_allowed_account_move_line(self):
+        self._check_factor_uom_allowed("product_uom_id")

--- a/product_uom_factor_stock/models/stock_move.py
+++ b/product_uom_factor_stock/models/stock_move.py
@@ -1,0 +1,14 @@
+# Copyright 2026 Bemade Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo import api, models
+
+
+class StockMove(models.Model):
+    _name = "stock.move"
+    _inherit = ["stock.move", "product.uom.factor.line.mixin"]
+
+    # stock.move uses the field name `product_uom` (not `product_uom_id`).
+    @api.constrains("product_uom", "product_id")
+    def _check_factor_uom_allowed_stock_move(self):
+        self._check_factor_uom_allowed("product_uom")

--- a/product_uom_factor_stock/models/stock_move_line.py
+++ b/product_uom_factor_stock/models/stock_move_line.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Bemade Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo import api, models
+
+
+class StockMoveLine(models.Model):
+    _name = "stock.move.line"
+    _inherit = ["stock.move.line", "product.uom.factor.line.mixin"]
+
+    @api.constrains("product_uom_id", "product_id")
+    def _check_factor_uom_allowed_stock_move_line(self):
+        self._check_factor_uom_allowed("product_uom_id")

--- a/product_uom_factor_stock/tests/__init__.py
+++ b/product_uom_factor_stock/tests/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2026 Bemade Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from . import test_stock_integration

--- a/product_uom_factor_stock/tests/test_stock_integration.py
+++ b/product_uom_factor_stock/tests/test_stock_integration.py
@@ -1,0 +1,231 @@
+"""
+Integration tests for product_uom_factor_stock: inventory adjustment flow.
+
+Crit 4: stock.move.line in delegate-mL → quantity_product_uom correct.
+
+Crit 5 (scoping): stock.move / stock.move.line cross-tree UoM raises ValidationError
+                  for genuinely cross-tree units; same-category allowed.
+
+NOTE: stock.valuation.layer does not exist in Odoo 19 (was removed; valuation is
+tracked via product.value and account.move). Valuation verification is done via
+account.move.line amounts.
+"""
+
+from odoo.exceptions import ValidationError
+from odoo.fields import Command
+from odoo.tests.common import TransactionCase
+
+
+class TestStockIntegrationBase(TransactionCase):
+    """Common fixture for stock integration tests."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.env["res.config.settings"].create({"group_uom": True}).execute()
+
+        dp = cls.env["decimal.precision"].search(
+            [("name", "=", "Product Unit")], limit=1
+        )
+        if dp and dp.digits < 5:
+            dp.digits = 5
+
+        cls.uom_unit = cls.env.ref("uom.product_uom_unit")
+        cls.uom_ml = cls.env.ref("uom.product_uom_milliliter")
+        cls.uom_liter = cls.env.ref("uom.product_uom_litre")
+
+        cls.company = cls.env.company
+
+        # Ink product: Unit base, storable, standard cost
+        cls.categ = cls.env["product.category"].create(
+            {
+                "name": "Test Ink Category (Stock Integration)",
+                "property_valuation": "real_time",
+                "property_cost_method": "standard",
+            }
+        )
+        cls.ink = cls.env["product.product"].create(
+            {
+                "name": "Test Ink – Stock Integration",
+                "type": "consu",
+                "is_storable": True,
+                "uom_id": cls.uom_unit.id,
+                "categ_id": cls.categ.id,
+                "standard_price": 800.0,
+            }
+        )
+
+        # Factor: 1 delegate-mL = 0.00005 Unit
+        cls.factor = cls.env["product.uom.factor"].create(
+            {
+                "product_tmpl_id": cls.ink.product_tmpl_id.id,
+                "foreign_uom_id": cls.uom_ml.id,
+                "factor": 0.00005,
+            }
+        )
+        cls.delegate_ml = cls.factor.delegate_uom_id
+        cls.ink.product_tmpl_id.write({"uom_factor_ids": [(4, cls.factor.id)]})
+
+        cls.stock_location = cls.env.ref("stock.stock_location_stock")
+        cls.supplier_location = cls.env.ref("stock.stock_location_suppliers")
+
+
+class TestStockMoveLine(TestStockIntegrationBase):
+    """Crit 4: stock.move.line in delegate-mL → quantity_product_uom correct."""
+
+    def test_move_line_quantity_product_uom_in_delegate_ml(self):
+        """stock.move.line with 250 delegate-mL → quantity_product_uom == 0.0125 Unit.
+
+        The move.line uses delegate-mL; quantity_product_uom is computed as
+        product_uom_id._compute_quantity(quantity, product_id.uom_id).
+        250 delegate-mL × 0.00005 = 0.0125 Unit.
+        """
+        picking_type = self.env["stock.picking.type"].search(
+            [("code", "=", "incoming"), ("company_id", "=", self.company.id)],
+            limit=1,
+        )
+        picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": picking_type.id,
+                "location_id": self.supplier_location.id,
+                "location_dest_id": self.stock_location.id,
+                "move_ids": [
+                    Command.create(
+                        {
+                            "product_id": self.ink.id,
+                            "product_uom": self.uom_unit.id,
+                            "product_uom_qty": 0.0125,
+                            "location_id": self.supplier_location.id,
+                            "location_dest_id": self.stock_location.id,
+                        }
+                    )
+                ],
+            }
+        )
+        picking.action_confirm()
+        move = picking.move_ids[0]
+        move_line = self.env["stock.move.line"].create(
+            {
+                "move_id": move.id,
+                "product_id": self.ink.id,
+                "product_uom_id": self.delegate_ml.id,
+                "quantity": 250.0,
+                "location_id": self.supplier_location.id,
+                "location_dest_id": self.stock_location.id,
+            }
+        )
+        self.assertAlmostEqual(
+            move_line.quantity_product_uom,
+            0.0125,
+            places=5,
+            msg="250 delegate-mL → quantity_product_uom == 0.0125 Unit",
+        )
+
+    def test_move_line_allowed_uom_ids_contains_delegate_ml(self):
+        """stock.move.line allowed_uom_ids contains the delegate-mL for the ink product."""
+        picking_type = self.env["stock.picking.type"].search(
+            [("code", "=", "incoming"), ("company_id", "=", self.company.id)],
+            limit=1,
+        )
+        picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": picking_type.id,
+                "location_id": self.supplier_location.id,
+                "location_dest_id": self.stock_location.id,
+                "move_ids": [
+                    Command.create(
+                        {
+                            "product_id": self.ink.id,
+                            "product_uom": self.uom_unit.id,
+                            "product_uom_qty": 1.0,
+                            "location_id": self.supplier_location.id,
+                            "location_dest_id": self.stock_location.id,
+                        }
+                    )
+                ],
+            }
+        )
+        picking.action_confirm()
+        move = picking.move_ids[0]
+        ml = self.env["stock.move.line"].new(
+            {
+                "move_id": move.id,
+                "product_id": self.ink.id,
+                "product_uom_id": self.uom_unit.id,
+                "quantity": 1.0,
+                "location_id": self.supplier_location.id,
+                "location_dest_id": self.stock_location.id,
+            }
+        )
+        ml._compute_allowed_uom_ids()
+        self.assertIn(
+            self.delegate_ml.id,
+            ml.allowed_uom_ids.ids,
+            "Delegate-mL must be in stock.move.line allowed_uom_ids",
+        )
+
+
+class TestStockScopingConstraint(TestStockIntegrationBase):
+    """Crit 5 (scoping): stock move/move.line rejects cross-tree UoMs."""
+
+    def test_cross_tree_uom_on_stock_move_raises(self):
+        """Forcing generic mL on a stock.move for Unit-base product raises ValidationError."""
+        picking_type = self.env["stock.picking.type"].search(
+            [("code", "=", "incoming"), ("company_id", "=", self.company.id)],
+            limit=1,
+        )
+        with self.assertRaises(ValidationError):
+            self.env["stock.picking"].create(
+                {
+                    "picking_type_id": picking_type.id,
+                    "location_id": self.supplier_location.id,
+                    "location_dest_id": self.stock_location.id,
+                    "move_ids": [
+                        Command.create(
+                            {
+                                "product_id": self.ink.id,
+                                "product_uom": self.uom_ml.id,  # generic mL, cross-tree
+                                "product_uom_qty": 250000.0,
+                                "location_id": self.supplier_location.id,
+                                "location_dest_id": self.stock_location.id,
+                            }
+                        )
+                    ],
+                }
+            )
+
+    def test_same_category_uom_on_stock_move_allowed(self):
+        """Same-category UoM (mL for a liter-base product) is allowed on stock.move."""
+        liter_product = self.env["product.product"].create(
+            {
+                "name": "Volume Product (Stock Scoping)",
+                "type": "consu",
+                "is_storable": True,
+                "uom_id": self.uom_liter.id,
+            }
+        )
+        picking_type = self.env["stock.picking.type"].search(
+            [("code", "=", "incoming"), ("company_id", "=", self.company.id)],
+            limit=1,
+        )
+        # mL is in the same volume category as liter → should NOT raise
+        picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": picking_type.id,
+                "location_id": self.supplier_location.id,
+                "location_dest_id": self.stock_location.id,
+                "move_ids": [
+                    Command.create(
+                        {
+                            "product_id": liter_product.id,
+                            "product_uom": self.uom_ml.id,  # same category as liter
+                            "product_uom_qty": 1000.0,
+                            "location_id": self.supplier_location.id,
+                            "location_dest_id": self.stock_location.id,
+                        }
+                    )
+                ],
+            }
+        )
+        self.assertTrue(picking.move_ids)


### PR DESCRIPTION
## What
Adds **product-specific cross-category Unit-of-Measure conversion**: a product based in one UoM tree (e.g. Unit/pail, lb) can be transacted and consumed in a unit from a *different* tree (e.g. mL, Bag) with correct quantities, costing and valuation — driven by a per-product `product.uom.factor` row.

Driving use case: Vera Inkjet stocks ink as **Unit** (1 Unit = a 20 L pail) but consumes it in cartridge BOMs in **mL** (Odoo task #3820 / #3813).

## Design (delegation)
Each `product.uom.factor` row **`_inherits` a hidden `uom.uom` delegate** grafted into the product's base-UoM tree (`relative_uom_id` = base, `relative_factor` = factor). Because the delegate is intra-tree, **native Odoo `_compute_quantity`/`_compute_price` handle every flow** — stock, moves, MRP, PO/SO, valuation, reports, the UoM widget — with **no conversion override**. The delegate reaches each line's allowed UoMs via the product's `uom_ids` (additive sync), so scoping rides Odoo's existing `allowed_uom_ids` pattern.

A **toggle-gated** server constraint (`enforce_factor_uom_scoping`, General Settings, **default on**) rejects *unregistered* cross-tree UoMs on order/move/BOM lines; turning it **off** restores vanilla Odoo behaviour (no hard block).

## Modules
- `product_uom_factor` (core) — the delegation model, the line-scoping mixin, the toggle.
- `product_uom_factor_{stock,mrp,purchase,sale}` — apply scoping to their line models + informational factor-base displays; `_mrp` adds the missing `allowed_uom_ids` to `mrp.bom.line`.

## Tests
89 unit tests + 2 `HttpCase` factor-display tours (all green).

## Deployment note
Small factors (e.g. 250 mL = 0.0125 Unit) need **"Product Unit" decimal precision ≥ 5**; the module deliberately does **not** mutate global precision — set it per deployment.

## Pipeline artifacts
Full requirements → design → implementation → test → review trail:
https://git.bemade.org/bemade/tasks/-/tree/main/task-3820-product-uom-factor-all-conversions

🤖 Generated with [Claude Code](https://claude.com/claude-code)