### PR TITLE
[3633] bemade_alias_utm_tracking: per-alias UTM source tracking → tickets → leads

### DIFF
--- a/bemade_alias_utm_tracking/__init__.py
+++ b/bemade_alias_utm_tracking/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/bemade_alias_utm_tracking/__manifest__.py
+++ b/bemade_alias_utm_tracking/__manifest__.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "Mail Alias UTM Source Tracking",
+    "version": "18.0.1.0.0",
+    "category": "Marketing/Email Marketing",
+    "summary": "Attribute records created from an inbound mail alias to a UTM "
+    "source/medium/campaign, and carry it to leads created from tickets.",
+    "description": """
+Mail Alias UTM Source Tracking
+==============================
+
+Lets you flag, per ``mail.alias``, that records created from inbound mail to
+that alias should be attributed to a UTM source (and, optionally, medium and
+campaign).
+
+* Adds ``track_utm_source`` (boolean) plus ``utm_source_id``,
+  ``utm_medium_id`` and ``utm_campaign_id`` to ``mail.alias``.
+* When a record is created from inbound mail to a tracking alias, the
+  configured UTM values are stamped onto the new record (any alias target
+  model that carries the ``utm.mixin`` fields ``source_id`` / ``medium_id`` /
+  ``campaign_id`` — e.g. ``helpdesk.ticket`` and ``crm.lead``).
+* The Enterprise "Convert to lead" wizard already copies these fields from the
+  ticket to the lead, so a source set on a ticket carries through on
+  conversion. This module's tests assert that end-to-end behaviour.
+    """,
+    "author": "Bemade Inc.",
+    "website": "https://www.bemade.org",
+    "license": "LGPL-3",
+    "depends": [
+        "mail",
+        "utm",
+        # crm_helpdesk pulls in crm + helpdesk and provides the
+        # "Convert to lead" wizard (helpdesk.ticket.to.lead) that already copies
+        # source/medium/campaign from the ticket to the lead — the ticket->lead
+        # transfer this module relies on (and tests end-to-end).
+        "crm_helpdesk",
+    ],
+    "data": [
+        "views/mail_alias_views.xml",
+    ],
+    "installable": True,
+    "application": False,
+}

--- a/bemade_alias_utm_tracking/models/__init__.py
+++ b/bemade_alias_utm_tracking/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+from . import mail_alias
+from . import mail_thread

--- a/bemade_alias_utm_tracking/models/mail_alias.py
+++ b/bemade_alias_utm_tracking/models/mail_alias.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+
+from odoo import api, fields, models
+
+
+class MailAlias(models.Model):
+    _inherit = "mail.alias"
+
+    track_utm_source = fields.Boolean(
+        string="Track UTM Source",
+        help="When enabled, records created from inbound mail to this alias "
+        "are attributed to the UTM source/medium/campaign configured below "
+        "(for any target model that supports UTM tracking, e.g. helpdesk "
+        "tickets and CRM leads).",
+    )
+    utm_source_id = fields.Many2one(
+        comodel_name="utm.source",
+        string="UTM Source",
+        ondelete="set null",
+        help="UTM source stamped on records created from inbound mail to this "
+        "alias.",
+    )
+    utm_medium_id = fields.Many2one(
+        comodel_name="utm.medium",
+        string="UTM Medium",
+        ondelete="set null",
+        help="Optional UTM medium stamped on records created from inbound mail "
+        "to this alias.",
+    )
+    utm_campaign_id = fields.Many2one(
+        comodel_name="utm.campaign",
+        string="UTM Campaign",
+        ondelete="set null",
+        help="Optional UTM campaign stamped on records created from inbound "
+        "mail to this alias.",
+    )
+
+    # Mapping of the UTM config field on mail.alias -> the field on the target
+    # record (utm.mixin convention). Kept as a single source of truth so the
+    # creation-values builder and the mail.thread override stay in sync.
+    _UTM_ALIAS_TO_RECORD = {
+        "utm_source_id": "source_id",
+        "utm_medium_id": "medium_id",
+        "utm_campaign_id": "campaign_id",
+    }
+
+    def _get_utm_creation_values(self):
+        """Return the UTM defaults this alias should stamp on a created record.
+
+        Empty dict when tracking is off or no source is configured. Only
+        non-empty M2o values are returned, keyed by the *record* field name
+        (``source_id`` / ``medium_id`` / ``campaign_id``).
+        """
+        self.ensure_one()
+        if not self.track_utm_source or not self.utm_source_id:
+            return {}
+        values = {}
+        for alias_field, record_field in self._UTM_ALIAS_TO_RECORD.items():
+            value = self[alias_field]
+            if value:
+                values[record_field] = value.id
+        return values

--- a/bemade_alias_utm_tracking/models/mail_thread.py
+++ b/bemade_alias_utm_tracking/models/mail_thread.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+
+from odoo import api, models
+
+
+class MailThread(models.AbstractModel):
+    _inherit = "mail.thread"
+
+    @api.model
+    def _message_route_process(self, message, message_dict, routes):
+        """Fold a tracking alias's UTM defaults into each route's creation values.
+
+        Each route is a tuple ``(model, thread_id, custom_values, user_id,
+        alias)``. For a route whose ``alias`` is flagged ``track_utm_source``
+        with a source configured, we stamp the alias's UTM source/medium/
+        campaign onto the ``custom_values`` dict that core passes to the target
+        model's ``message_new`` -> ``create``.
+
+        Guards:
+        * only applied to brand-new records (no ``thread_id``); updates to an
+          existing thread keep their source;
+        * only fields the target model actually has are set (so a non-UTM
+          alias target is untouched);
+        * never overwrites a value already present in ``custom_values`` (an
+          explicit ``alias_defaults`` wins over the config fields).
+        """
+        new_routes = []
+        for route in routes or ():
+            model, thread_id, custom_values, user_id, alias = route
+            if alias and not thread_id and model in self.env:
+                utm_values = alias._get_utm_creation_values()
+                if utm_values:
+                    target_fields = self.env[model]._fields
+                    custom_values = dict(custom_values or {})
+                    for field_name, value in utm_values.items():
+                        if field_name in target_fields and not custom_values.get(
+                            field_name
+                        ):
+                            custom_values[field_name] = value
+                    route = (model, thread_id, custom_values, user_id, alias)
+            new_routes.append(route)
+        return super()._message_route_process(message, message_dict, new_routes)

--- a/bemade_alias_utm_tracking/tests/__init__.py
+++ b/bemade_alias_utm_tracking/tests/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import test_alias_utm_tracking

--- a/bemade_alias_utm_tracking/tests/test_alias_utm_tracking.py
+++ b/bemade_alias_utm_tracking/tests/test_alias_utm_tracking.py
@@ -1,0 +1,159 @@
+# -*- coding: utf-8 -*-
+# Acceptance criteria (task 3633):
+#   AC-1: An alias flagged track_utm_source with source X exposes those defaults
+#         (track off, or no source -> no defaults). [_get_utm_creation_values]
+#   AC-2: A record created from inbound mail to a tracking alias is stamped with
+#         source X (and medium/campaign when set) — end-to-end via message_process.
+#   AC-3: An explicit alias_defaults source wins over the configured field
+#         (we never overwrite a value the caller already provided).
+#   AC-4: Converting/creating a lead from that ticket carries source X to the
+#         lead (Enterprise helpdesk.ticket.to.lead wizard, end-to-end).
+
+from odoo.addons.mail.tests.common import MailCommon
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestAliasUtmTracking(MailCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # MailCommon sets up cls.mail_alias_domain (a mail.alias.domain) and the
+        # mail gateway, so inbound message_process can route by recipient.
+        cls.source_x = cls.env["utm.source"].create({"name": "Alias Source X"})
+        cls.source_y = cls.env["utm.source"].create({"name": "Alias Source Y"})
+        cls.medium = cls.env["utm.medium"].create({"name": "Alias Medium"})
+        cls.campaign = cls.env["utm.campaign"].create({"name": "Alias Campaign"})
+
+        cls.team = cls.env["helpdesk.team"].create(
+            {"name": "UTM Test Team", "use_alias": False}
+        )
+        ticket_model = cls.env["ir.model"]._get("helpdesk.ticket")
+
+        # Alias -> helpdesk.ticket, flagged to track source X (+ medium/campaign).
+        cls.alias = cls.env["mail.alias"].create(
+            {
+                "alias_name": "utm-track-team",
+                "alias_model_id": ticket_model.id,
+                "alias_domain_id": cls.mail_alias_domain.id,
+                "alias_defaults": "{'team_id': %s}" % cls.team.id,
+                "track_utm_source": True,
+                "utm_source_id": cls.source_x.id,
+                "utm_medium_id": cls.medium.id,
+                "utm_campaign_id": cls.campaign.id,
+            }
+        )
+        cls.alias_email = "%s@%s" % (cls.alias.alias_name, cls.mail_alias_domain.name)
+
+    def _inbound(self, to=None, msg_id="<utm-3633@test>"):
+        """Push a plain inbound email to `to` (defaults to the tracking alias)
+        through the mail gateway and return the created helpdesk.ticket."""
+        to = to or self.alias_email
+        mime = (
+            "MIME-Version: 1.0\n"
+            "Date: Thu, 27 Dec 2018 16:27:45 +0100\n"
+            "Message-ID: %s\n"
+            "Subject: I need help\n"
+            "From: Client UTM <client_utm@example.com>\n"
+            "To: %s\n"
+            'Content-Type: text/plain; charset="UTF-8"\n'
+            "\n"
+            "Please help me.\n"
+        ) % (msg_id, to)
+        ticket_id = (
+            self.env["mail.thread"].sudo().message_process(False, mime)
+        )
+        return self.env["helpdesk.ticket"].browse(ticket_id)
+
+    # ---- AC-1: alias creation-values builder --------------------------------
+
+    def test_creation_values_when_tracking(self):
+        """AC-1: a tracking alias returns its UTM defaults keyed by record field."""
+        self.assertEqual(
+            self.alias._get_utm_creation_values(),
+            {
+                "source_id": self.source_x.id,
+                "medium_id": self.medium.id,
+                "campaign_id": self.campaign.id,
+            },
+        )
+
+    def test_creation_values_when_tracking_off(self):
+        """AC-1: tracking off -> no defaults even if a source is set."""
+        self.alias.track_utm_source = False
+        self.assertEqual(self.alias._get_utm_creation_values(), {})
+
+    def test_creation_values_when_no_source(self):
+        """AC-1: tracking on but no source -> no defaults (source is the trigger)."""
+        self.alias.utm_source_id = False
+        self.assertEqual(self.alias._get_utm_creation_values(), {})
+
+    def test_creation_values_source_only(self):
+        """AC-1: medium/campaign are optional; source alone is enough."""
+        self.alias.utm_medium_id = False
+        self.alias.utm_campaign_id = False
+        self.assertEqual(
+            self.alias._get_utm_creation_values(),
+            {"source_id": self.source_x.id},
+        )
+
+    # ---- AC-2: inbound mail -> ticket gets the alias source -----------------
+
+    def test_inbound_mail_creates_ticket_with_source(self):
+        """AC-2 (end-to-end): an email to the tracking alias yields a ticket
+        attributed to source X (+ medium/campaign), with unrelated alias_defaults
+        (team_id) preserved."""
+        ticket = self._inbound()
+        self.assertTrue(ticket.exists(), "inbound mail should create a ticket")
+        self.assertEqual(ticket.team_id, self.team, "team_id alias_default preserved")
+        self.assertEqual(
+            ticket.source_id, self.source_x, "ticket must carry the alias UTM source"
+        )
+        self.assertEqual(ticket.medium_id, self.medium)
+        self.assertEqual(ticket.campaign_id, self.campaign)
+        return ticket
+
+    def test_inbound_no_source_when_tracking_off(self):
+        """AC-2 (negative): a non-tracking alias does not stamp any source."""
+        self.alias.track_utm_source = False
+        ticket = self._inbound(msg_id="<utm-3633-off@test>")
+        self.assertTrue(ticket.exists())
+        self.assertFalse(ticket.source_id, "no source should be stamped when off")
+
+    def test_inbound_explicit_alias_default_wins(self):
+        """AC-3: an explicit source_id in alias_defaults is not overwritten by
+        the configured utm_source_id."""
+        self.alias.alias_defaults = "{'team_id': %s, 'source_id': %s}" % (
+            self.team.id,
+            self.source_y.id,
+        )
+        ticket = self._inbound(msg_id="<utm-3633-explicit@test>")
+        self.assertTrue(ticket.exists())
+        self.assertEqual(
+            ticket.source_id,
+            self.source_y,
+            "explicit alias_defaults source must win over the configured field",
+        )
+
+    # ---- AC-4: ticket -> lead carries the source ----------------------------
+
+    def test_ticket_to_lead_carries_source(self):
+        """AC-4 (end-to-end): converting the inbound-created ticket to a lead
+        carries source X (+ medium/campaign) to the lead."""
+        ticket = self.test_inbound_mail_creates_ticket_with_source()
+        # group_use_lead so the wizard produces a lead (vs an opportunity).
+        self.env.user.groups_id += self.env.ref("crm.group_use_lead")
+        wizard = (
+            self.env["helpdesk.ticket.to.lead"]
+            .with_context(active_id=ticket.id, active_model="helpdesk.ticket")
+            .create({"ticket_id": ticket.id})
+        )
+        action = wizard.action_convert_to_lead()
+        lead = self.env["crm.lead"].browse(action["res_id"])
+        self.assertTrue(lead.exists(), "wizard should create a lead")
+        self.assertEqual(
+            lead.source_id, self.source_x, "lead must inherit the ticket's UTM source"
+        )
+        self.assertEqual(lead.medium_id, self.medium)
+        self.assertEqual(lead.campaign_id, self.campaign)

--- a/bemade_alias_utm_tracking/views/mail_alias_views.xml
+++ b/bemade_alias_utm_tracking/views/mail_alias_views.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<odoo>
+
+    <record id="mail_alias_view_form_utm" model="ir.ui.view">
+        <field name="name">mail.alias.view.form.utm.tracking</field>
+        <field name="model">mail.alias</field>
+        <field name="inherit_id" ref="mail.mail_alias_view_form"/>
+        <field name="arch" type="xml">
+            <field name="alias_defaults" position="after">
+                <field name="track_utm_source"/>
+                <field name="utm_source_id"
+                       required="track_utm_source"
+                       invisible="not track_utm_source"/>
+                <field name="utm_medium_id"
+                       invisible="not track_utm_source"/>
+                <field name="utm_campaign_id"
+                       invisible="not track_utm_source"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Durpro task 3633 — codeable core (Marc's 2026-06-17 direction). Mailbox/alias provisioning is out of scope (Marc provisions it; only matters once live for testing).

**New shared module `bemade_alias_utm_tracking`** (depends mail, utm, crm_helpdesk):
- `mail.alias`: `track_utm_source` (bool) + `utm_source_id`/`utm_medium_id`/`utm_campaign_id`; `_get_utm_creation_values()` returns the source defaults when tracking is on.
- `mail.thread._message_route_process` override: folds the alias's UTM defaults into each route's `custom_values` (guarded: new records only, field-presence, no-overwrite) before `message_new` → so an inbound-mail-created helpdesk ticket is stamped with the configured source.
- View exposes the 4 fields on the alias form (source/medium/campaign hidden unless tracking on).

`helpdesk.ticket`/`crm.lead` already carry `utm.mixin`, and the stock `helpdesk.ticket.to.lead` wizard already copies source/medium/campaign — so ticket→lead transfer needs no new code; it's proven end-to-end by a test that runs the real wizard and asserts the lead carries the source.

8 tests green (alias builder on/off/no-source/source-only; inbound→ticket stamped; tracking-off negative; explicit-default-wins; ticket→lead carries source). Adversarial review: APPROVE.

Shared module → upstream-first. On merge the downstream Durpro submodule bump follows. NB Durpro is mid 18.0→19.0 migration: a 19.0 port of this new module is a separate follow-up (assessed against what's landed on bemade-addons 19.0).