### PR TITLE
[MIG] bemade_helpdesk_one_ticket_per_email: migrate to 19.0

### DIFF
--- a/bemade_helpdesk_one_ticket_per_email/__init__.py
+++ b/bemade_helpdesk_one_ticket_per_email/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/bemade_helpdesk_one_ticket_per_email/__manifest__.py
+++ b/bemade_helpdesk_one_ticket_per_email/__manifest__.py
@@ -1,0 +1,31 @@
+#
+#    Bemade Inc.
+#
+#    Copyright (C) 2023-June Bemade Inc. (<https://www.bemade.org>).
+#    Author: Marc Durepos (Contact : mdurepos@durpro.com)
+#
+#    This program is under the terms of the Odoo Proprietary License v1.0 (OPL-1)
+#    It is forbidden to publish, distribute, sublicense, or sell copies of the Software
+#    or modified copies of the Software.
+#
+#    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+#    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+#    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+#    ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#    DEALINGS IN THE SOFTWARE.
+#
+{
+    "name": "Helpdesk One Ticket Per Email",
+    "version": "19.0.1.0.0",
+    "summary": "Restrict ticket creation to a single ticket per email received.",
+    "category": "Helpdesk",
+    "author": "Bemade Inc.",
+    "website": "http://www.bemade.org",
+    "license": "OPL-1",
+    "depends": ["mail"],
+    "data": [],
+    "installable": True,
+    "auto_install": False,
+}

--- a/bemade_helpdesk_one_ticket_per_email/models/__init__.py
+++ b/bemade_helpdesk_one_ticket_per_email/models/__init__.py
@@ -1,0 +1,1 @@
+from . import mail_thread

--- a/bemade_helpdesk_one_ticket_per_email/models/mail_thread.py
+++ b/bemade_helpdesk_one_ticket_per_email/models/mail_thread.py
@@ -1,0 +1,50 @@
+from odoo import models, api
+from odoo.exceptions import UserError
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+class MailThread(models.AbstractModel):
+    _inherit = "mail.thread"
+
+    @api.model
+    def _message_route_process(self, message, message_dict, routes):
+        """
+        Process the routes for an incoming message, ensuring only one helpdesk route is used if multiple
+        helpdesk routes are detected.
+
+        This override filters the routes to avoid processing a message multiple times for helpdesk models
+        (`helpdesk.ticket` and `helpdesk.team`). If multiple helpdesk routes are found, only the first one
+        is retained, and a log entry is created to indicate the adjustment.
+
+        Parameters:
+            message (object): The incoming message object.
+            message_dict (dict): Dictionary of parsed message values.
+            routes (list): List of route tuples, each containing the target model and relevant information.
+
+        Returns:
+            bool: Result of the `_message_route_process` from the superclass.
+        """
+        try:
+            # Filter routes to keep only those related to helpdesk models if they are present
+            helpdesk_routes = [
+                r for r in routes if r[0] in ("helpdesk.ticket", "helpdesk.team")
+            ]
+
+            if helpdesk_routes:
+                _logger.info(
+                    "Messages contained helpdesk routes. Only the first one will be used."
+                )
+                # Retain only the first helpdesk route
+                routes = [helpdesk_routes[0]]
+
+            # Call the parent method with potentially modified routes
+            return super()._message_route_process(message, message_dict, routes)
+
+        except Exception as e:
+            # Log the exception and raise it to ensure errors are traceable
+            _logger.error(f"An error occurred in _message_route_process: {str(e)}")
+            raise UserError(
+                "An unexpected error occurred while processing message routes. Please contact support."
+            )

--- a/bemade_helpdesk_one_ticket_per_email/tests/__init__.py
+++ b/bemade_helpdesk_one_ticket_per_email/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_module

--- a/bemade_helpdesk_one_ticket_per_email/tests/test_module.py
+++ b/bemade_helpdesk_one_ticket_per_email/tests/test_module.py
@@ -1,0 +1,28 @@
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestHelpdeskOneTicketPerEmail(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.MailThread = cls.env["mail.thread"]
+        cls.HelpdeskTicket = cls.env.get("helpdesk.ticket")
+
+    def test_mail_thread_model_exists(self):
+        """Test that mail.thread model exists"""
+        self.assertIsNotNone(self.MailThread)
+
+    def test_helpdesk_ticket_model(self):
+        """Test that helpdesk.ticket model exists if installed"""
+        if self.HelpdeskTicket:
+            self.assertIsNotNone(self.HelpdeskTicket)
+
+    def test_mail_thread_fields(self):
+        """Test mail.thread has expected fields"""
+        self.assertTrue(hasattr(self.MailThread, "message_ids"))
+
+    def test_thread_message_tracking(self):
+        """Test message tracking in mail.thread"""
+        # Basic test that thread model works
+        self.assertTrue(True)


### PR DESCRIPTION
Ports **bemade_helpdesk_one_ticket_per_email** (v19.0.1.0.0) into bemade-addons on 19.0, from the vendored 19.0-validated copy in DurPro (running in production on odoo19.durpro.com). Restores the single-source structure (symlinks DurPro addons/ -> bemade-addons/) as in 18.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)