### PR TITLE
[MIG] bemade_picking_upstream: migrate to 19.0

### DIFF
--- a/bemade_picking_upstream/__init__.py
+++ b/bemade_picking_upstream/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/bemade_picking_upstream/__manifest__.py
+++ b/bemade_picking_upstream/__manifest__.py
@@ -1,0 +1,32 @@
+#
+#    Bemade Inc.
+#
+#    Copyright (C) 2023-June Bemade Inc. (<https://www.bemade.org>).
+#    Author: Marc Durepos (Contact : marc@bemade.org)
+#
+#    This program is under the terms of the Odoo Proprietary License v1.0 (OPL-1)
+#    It is forbidden to publish, distribute, sublicense, or sell copies of the Software
+#    or modified copies of the Software.
+#
+#    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+#    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+#    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+#    ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#    DEALINGS IN THE SOFTWARE.
+#
+{
+    "name": "Show Upstream Pickings",
+    "version": "19.0.1.0.0",
+    "summary": "Show upstream pickings when a picking is waiting on other moves.",
+    "category": "Stock",
+    "author": "Bemade Inc.",
+    "website": "http://www.bemade.org",
+    "license": "LGPL-3",
+    "depends": ["stock"],
+    "data": ["views/stock_picking_views.xml"],
+    "assets": {},
+    "installable": True,
+    "auto_install": False,
+}

--- a/bemade_picking_upstream/models/__init__.py
+++ b/bemade_picking_upstream/models/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_picking

--- a/bemade_picking_upstream/models/stock_picking.py
+++ b/bemade_picking_upstream/models/stock_picking.py
@@ -1,0 +1,37 @@
+from odoo import models, fields, api
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    upstream_picking_ids = fields.One2many(
+        compute="_compute_upstream_picking_ids",
+        comodel_name="stock.picking",
+        string="Upstream Transfers",
+        help="Transfers that this transfer depends on for stock availability.",
+        compute_sudo=True,
+    )
+
+    upstream_picking_count = fields.Integer(
+        compute="_compute_upstream_picking_ids",
+        compute_sudo=True,
+    )
+
+    @api.depends(
+        "move_ids", "move_ids.move_orig_ids", "move_ids.move_orig_ids.picking_id"
+    )
+    def _compute_upstream_picking_ids(self):
+        for rec in self:
+            rec.upstream_picking_ids = (
+                rec.move_ids.mapped("move_orig_ids").mapped("picking_id") - rec
+            )
+            rec.upstream_picking_count = len(rec.upstream_picking_ids)
+
+    def action_view_upstream_transfers(self):
+        return {
+            "name": "Upstream Transfers",
+            "type": "ir.actions.act_window",
+            "res_model": "stock.picking",
+            "domain": [("id", "in", self.upstream_picking_ids.ids)],
+            "view_mode": "list,kanban,form,calendar,map",
+        }

--- a/bemade_picking_upstream/tests/__init__.py
+++ b/bemade_picking_upstream/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_module

--- a/bemade_picking_upstream/tests/test_module.py
+++ b/bemade_picking_upstream/tests/test_module.py
@@ -1,0 +1,55 @@
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestPickingUpstream(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.StockPicking = cls.env["stock.picking"]
+        cls.Product = cls.env["product.product"]
+        cls.Location = cls.env["stock.location"]
+        cls.Warehouse = cls.env["stock.warehouse"]
+
+    def test_picking_model_extended(self):
+        """Test that stock.picking is extended"""
+        self.assertIsNotNone(self.StockPicking)
+
+    def test_picking_creation(self):
+        """Test basic picking creation"""
+        warehouse = self.Warehouse.search([], limit=1)
+        if warehouse:
+            picking = self.StockPicking.create({
+                "location_id": warehouse.lot_stock_id.id,
+                "location_dest_id": self.Location.search([], limit=1).id,
+                "picking_type_id": warehouse.out_type_id.id,
+            })
+            self.assertIsNotNone(picking.id)
+
+    def test_picking_with_move(self):
+        """Test picking with stock move"""
+        warehouse = self.Warehouse.search([], limit=1)
+        product = self.Product.create({
+            "name": "Picking Product",
+            "type": "consu",
+        })
+
+        if warehouse:
+            picking = self.StockPicking.create({
+                "location_id": warehouse.lot_stock_id.id,
+                "location_dest_id": self.Location.search([], limit=1).id,
+                "picking_type_id": warehouse.out_type_id.id,
+                "move_ids": [
+                    (0, 0, {
+                        "product_id": product.id,
+                        "product_uom_qty": 1.0,
+                        "product_uom": product.uom_id.id,
+                    })
+                ]
+            })
+            self.assertEqual(len(picking.move_ids), 1)
+
+    def test_upstream_picking_flow(self):
+        """Test upstream picking flow"""
+        warehouse = self.Warehouse.search([], limit=1)
+        self.assertIsNotNone(warehouse)

--- a/bemade_picking_upstream/views/stock_picking_views.xml
+++ b/bemade_picking_upstream/views/stock_picking_views.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="stock_picking_view_form" model="ir.ui.view">
+        <field name="inherit_id" ref="stock.view_picking_form"/>
+        <field name="model">stock.picking</field>
+        <field name="arch" type="xml">
+            <button name="action_see_move_scrap" position="before">
+                <field invisible="1" name="upstream_picking_ids"/>
+                <field invisible="1" name="upstream_picking_count"/>
+                <button class="oe_stat_button" icon="fa-pause" invisible="upstream_picking_count == 0" name="action_view_upstream_transfers" string="Upstream Transfer(s)" type="object">
+                </button>
+            </button></field>
+    </record>
+</odoo>


### PR DESCRIPTION
Ports **bemade_picking_upstream** (v19.0.1.0.0) into bemade-addons on 19.0, from the vendored 19.0-validated copy in DurPro (running in production on odoo19.durpro.com). Restores the single-source structure (symlinks DurPro addons/ -> bemade-addons/) as in 18.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)