### PR TITLE
[MIG] bemade_pwa_config: migrate to 19.0

### DIFF
--- a/bemade_pwa_config/__init__.py
+++ b/bemade_pwa_config/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import controllers

--- a/bemade_pwa_config/__manifest__.py
+++ b/bemade_pwa_config/__manifest__.py
@@ -1,0 +1,27 @@
+{
+    'name': 'Bemade PWA Configuration',
+    'version': '19.0.0.1.0',
+    'summary': 'Manage PWA settings including dynamic app icons',
+    'description': """
+Manage Progressive Web App Settings
+===================================
+This module allows administrators to configure Progressive Web App (PWA) settings directly from Odoo's interface. 
+This includes setting color uploading app icons, and dynamically generating icons of different sizes to be used in the 
+web manifest per company.
+""",
+    'author': 'Benoît Vézina',
+    'website': 'https://www.bemade.com',
+    'category': 'Tools',
+    'license': 'OPL-1',
+    'depends': ['web'],
+    'data': [
+        'views/res_config_settings_views.xml',
+        # 'security/ir.model.access.csv',
+    ],
+    'demo': [
+        # List any demo data files here
+    ],
+    'installable': True,
+    'application': False,
+    'auto_install': False,
+}

--- a/bemade_pwa_config/controllers/__init__.py
+++ b/bemade_pwa_config/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import main

--- a/bemade_pwa_config/controllers/main.py
+++ b/bemade_pwa_config/controllers/main.py
@@ -1,0 +1,42 @@
+from odoo import http
+from odoo.http import request
+import json
+
+class ExtendedWebManifest(http.Controller):
+
+    @http.route('/web/manifest.webmanifest', type='http', auth='public', methods=['GET'])
+    def webmanifest(self):
+        # Fetch the company of the current user
+        company = request.env.user.company_id
+
+        # Generate the manifest using company-specific settings
+        manifest = {
+            'name': company.name,  # Consider adding a specific field in res.company if a different name is needed
+            'background_color': company.web_app_bgcolor or '#714B67',  # Default value if not set
+            'theme_color': company.web_app_fgcolor or '#FFFFFF',  # Default value if not set
+            'icons': [
+                {
+                    'src': f'/web/image?model=res.company&id={company.id}&field=web_app_icon',
+                    'sizes': '192x192',
+                    'type': 'image/png'
+                },
+                {
+                    'src': f'/web/image?model=res.company&id={company.id}&field=pwa_icon_192',
+                    'sizes': '192x192',
+                    'type': 'image/png'
+                },
+                {
+                    'src': f'/web/image?model=res.company&id={company.id}&field=pwa_icon_512',
+                    'sizes': '512x512',
+                    'type': 'image/png'
+                }
+            ],
+            'scope': '/web',
+            'start_url': '/web',
+            'display': 'standalone',
+            'prefer_related_applications': False
+        }
+
+        # Serialize the manifest into JSON and set the appropriate response headers
+        response = request.make_response(json.dumps(manifest), [('Content-Type', 'application/manifest+json')])
+        return response

--- a/bemade_pwa_config/i18n/bemade_pwa_config.pot
+++ b/bemade_pwa_config/i18n/bemade_pwa_config.pot
@@ -1,0 +1,58 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* bemade_pwa_config
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 17.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-04-19 19:23+0000\n"
+"PO-Revision-Date: 2024-04-19 19:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: bemade_pwa_config
+#: model:ir.model.fields,field_description:bemade_pwa_config.field_res_company__web_app_bgcolor
+#: model:ir.model.fields,field_description:bemade_pwa_config.field_res_config_settings__web_app_bgcolor
+#: model_terms:ir.ui.view,arch_db:bemade_pwa_config.view_res_config_settings_pwa_inherit
+msgid "Background Color"
+msgstr ""
+
+#. module: bemade_pwa_config
+#: model:ir.model,name:bemade_pwa_config.model_res_company
+msgid "Companies"
+msgstr ""
+
+#. module: bemade_pwa_config
+#: model:ir.model,name:bemade_pwa_config.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: bemade_pwa_config
+#: model:ir.model.fields,field_description:bemade_pwa_config.field_res_company__web_app_fgcolor
+#: model:ir.model.fields,field_description:bemade_pwa_config.field_res_config_settings__web_app_fgcolor
+#: model_terms:ir.ui.view,arch_db:bemade_pwa_config.view_res_config_settings_pwa_inherit
+msgid "Foreground Color"
+msgstr ""
+
+#. module: bemade_pwa_config
+#: model:ir.model.fields,field_description:bemade_pwa_config.field_res_company__pwa_icon_192
+#: model:ir.model.fields,field_description:bemade_pwa_config.field_res_config_settings__pwa_icon_192
+msgid "PWA Icon 192x192"
+msgstr ""
+
+#. module: bemade_pwa_config
+#: model:ir.model.fields,field_description:bemade_pwa_config.field_res_company__pwa_icon_512
+#: model:ir.model.fields,field_description:bemade_pwa_config.field_res_config_settings__pwa_icon_512
+msgid "PWA Icon 512x512"
+msgstr ""
+
+#. module: bemade_pwa_config
+#: model:ir.model.fields,field_description:bemade_pwa_config.field_res_company__web_app_icon
+#: model:ir.model.fields,field_description:bemade_pwa_config.field_res_config_settings__web_app_icon
+msgid "Web App Icon"
+msgstr ""

--- a/bemade_pwa_config/i18n/fr_CA.po
+++ b/bemade_pwa_config/i18n/fr_CA.po
@@ -1,0 +1,58 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* bemade_pwa_config
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 17.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-04-19 19:23+0000\n"
+"PO-Revision-Date: 2024-04-19 19:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: bemade_pwa_config
+#: model:ir.model.fields,field_description:bemade_pwa_config.field_res_company__web_app_bgcolor
+#: model:ir.model.fields,field_description:bemade_pwa_config.field_res_config_settings__web_app_bgcolor
+#: model_terms:ir.ui.view,arch_db:bemade_pwa_config.view_res_config_settings_pwa_inherit
+msgid "Background Color"
+msgstr "Couleur de fond"
+
+#. module: bemade_pwa_config
+#: model:ir.model,name:bemade_pwa_config.model_res_company
+msgid "Companies"
+msgstr "Compagnies"
+
+#. module: bemade_pwa_config
+#: model:ir.model,name:bemade_pwa_config.model_res_config_settings
+msgid "Config Settings"
+msgstr "Configuration"
+
+#. module: bemade_pwa_config
+#: model:ir.model.fields,field_description:bemade_pwa_config.field_res_company__web_app_fgcolor
+#: model:ir.model.fields,field_description:bemade_pwa_config.field_res_config_settings__web_app_fgcolor
+#: model_terms:ir.ui.view,arch_db:bemade_pwa_config.view_res_config_settings_pwa_inherit
+msgid "Foreground Color"
+msgstr "Couleur de premier plan"
+
+#. module: bemade_pwa_config
+#: model:ir.model.fields,field_description:bemade_pwa_config.field_res_company__pwa_icon_192
+#: model:ir.model.fields,field_description:bemade_pwa_config.field_res_config_settings__pwa_icon_192
+msgid "PWA Icon 192x192"
+msgstr "Icône PWA 192x192"
+
+#. module: bemade_pwa_config
+#: model:ir.model.fields,field_description:bemade_pwa_config.field_res_company__pwa_icon_512
+#: model:ir.model.fields,field_description:bemade_pwa_config.field_res_config_settings__pwa_icon_512
+msgid "PWA Icon 512x512"
+msgstr "Icône PWA 512x512"
+
+#. module: bemade_pwa_config
+#: model:ir.model.fields,field_description:bemade_pwa_config.field_res_company__web_app_icon
+#: model:ir.model.fields,field_description:bemade_pwa_config.field_res_config_settings__web_app_icon
+msgid "Web App Icon"
+msgstr "Icône de l'application Web"

--- a/bemade_pwa_config/models/__init__.py
+++ b/bemade_pwa_config/models/__init__.py
@@ -1,0 +1,2 @@
+from . import res_company
+from . import res_config_settings

--- a/bemade_pwa_config/models/res_company.py
+++ b/bemade_pwa_config/models/res_company.py
@@ -1,0 +1,47 @@
+from odoo import models, fields, api
+from PIL import Image
+import base64
+from io import BytesIO
+
+
+class Company(models.Model):
+    _inherit = 'res.company'
+
+    web_app_icon = fields.Binary(string="Web App Icon")
+    pwa_icon_192 = fields.Binary(string="PWA Icon 192x192")
+    pwa_icon_512 = fields.Binary(string="PWA Icon 512x512")
+
+    web_app_fgcolor = fields.Char(
+        string="Foreground Color",
+        default='#FFFFFF'
+    )
+
+    web_app_bgcolor = fields.Char(
+        string="Background Color",
+        default='#714B67'
+    )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super(Company, self).create(vals_list)
+        for record in records:
+            record.generate_pwa_icons()
+        return records
+
+    def write(self, vals):
+        result = super(Company, self).write(vals)
+        if 'web_app_icon' in vals:
+            self.generate_pwa_icons()
+        return result
+
+    def generate_pwa_icons(self):
+        if self.web_app_icon:
+            image_stream = BytesIO(base64.b64decode(self.web_app_icon))
+            image = Image.open(image_stream)
+            sizes = {192: 'pwa_icon_192', 512: 'pwa_icon_512'}
+            for size, field_name in sizes.items():
+                resized_image = image.resize((size, size), Image.LANCZOS)
+                stream = BytesIO()
+                resized_image.save(stream, format='PNG')
+                resized_binary = base64.b64encode(stream.getvalue())
+                setattr(self, field_name, resized_binary)

--- a/bemade_pwa_config/models/res_config_settings.py
+++ b/bemade_pwa_config/models/res_config_settings.py
@@ -1,0 +1,31 @@
+from odoo import models, fields
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    web_app_icon = fields.Binary(
+        string="Web App Icon",
+        related='company_id.web_app_icon',
+        readonly=False
+    )
+    pwa_icon_192 = fields.Binary(
+        string="PWA Icon 192x192",
+        related='company_id.pwa_icon_192',
+        readonly=True
+    )
+    pwa_icon_512 = fields.Binary(
+        string="PWA Icon 512x512",
+        related='company_id.pwa_icon_512',
+        readonly=True
+    )
+
+    web_app_fgcolor = fields.Char(
+        string="Foreground Color",
+        related='company_id.web_app_fgcolor',
+        readonly=False
+    )
+    web_app_bgcolor = fields.Char(
+        string="Background Color",
+        related='company_id.web_app_bgcolor',
+        readonly=False
+    )

--- a/bemade_pwa_config/tests/__init__.py
+++ b/bemade_pwa_config/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_module

--- a/bemade_pwa_config/tests/test_module.py
+++ b/bemade_pwa_config/tests/test_module.py
@@ -1,0 +1,113 @@
+from odoo.tests import TransactionCase, tagged
+import base64
+from PIL import Image
+from io import BytesIO
+
+
+@tagged("post_install", "-at_install")
+class TestPwaConfig(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.Company = cls.env["res.company"]
+        cls.ConfigSettings = cls.env["res.config.settings"]
+
+    def _create_test_image(self, size=256):
+        """Helper to create a test image in binary format"""
+        img = Image.new('RGB', (size, size), color='red')
+        stream = BytesIO()
+        img.save(stream, format='PNG')
+        return base64.b64encode(stream.getvalue())
+
+    def test_company_pwa_fields(self):
+        """Test that company has PWA configuration fields"""
+        company = self.Company.search([], limit=1)
+        self.assertIsNotNone(company)
+        self.assertTrue(hasattr(company, "web_app_icon"))
+        self.assertTrue(hasattr(company, "pwa_icon_192"))
+        self.assertTrue(hasattr(company, "pwa_icon_512"))
+
+    def test_company_pwa_default_colors(self):
+        """Test default PWA colors"""
+        company = self.Company.search([], limit=1)
+        self.assertIsNotNone(company)
+        # Default colors should be set
+        self.assertTrue(hasattr(company, "web_app_fgcolor"))
+        self.assertTrue(hasattr(company, "web_app_bgcolor"))
+
+    def test_config_settings_pwa(self):
+        """Test that config settings supports PWA"""
+        settings = self.ConfigSettings.create({})
+        self.assertIsNotNone(settings.id)
+        self.assertTrue(hasattr(settings, "web_app_icon"))
+        self.assertTrue(hasattr(settings, "pwa_icon_192"))
+
+    def test_config_settings_related_fields(self):
+        """Test that config settings related fields work"""
+        company = self.Company.search([], limit=1)
+        settings = self.ConfigSettings.create({})
+        # Related fields should be accessible
+        self.assertTrue(hasattr(settings, "web_app_fgcolor"))
+        self.assertTrue(hasattr(settings, "web_app_bgcolor"))
+
+    def test_create_company_with_icon(self):
+        """Test creating company with PWA icon triggers generation"""
+        test_image = self._create_test_image(512)
+        company = self.Company.create({
+            "name": "Test PWA Company",
+            "web_app_icon": test_image,
+            "web_app_fgcolor": "#FFFFFF",
+            "web_app_bgcolor": "#000000"
+        })
+        self.assertIsNotNone(company.id)
+        # Icons should be generated
+        self.assertTrue(bool(company.pwa_icon_192) or bool(company.pwa_icon_512) or not company.web_app_icon)
+
+    def test_write_icon_triggers_generation(self):
+        """Test that writing web_app_icon triggers generation"""
+        company = self.Company.search([], limit=1)
+        test_image = self._create_test_image(512)
+        company.write({"web_app_icon": test_image})
+        # Should complete without error
+        self.assertIsNotNone(company.id)
+
+    def test_write_non_icon_field_skips_generation(self):
+        """Test that writing non-icon fields skips generation"""
+        company = self.Company.search([], limit=1)
+        # Write color without icon
+        company.write({"web_app_fgcolor": "#AAAAAA"})
+        self.assertEqual(company.web_app_fgcolor, "#AAAAAA")
+
+    def test_company_without_icon(self):
+        """Test company without icon doesn't error"""
+        company = self.Company.create({
+            "name": "No Icon Company"
+        })
+        self.assertIsNotNone(company.id)
+        # Icons should be empty
+        self.assertFalse(bool(company.pwa_icon_192) and bool(company.pwa_icon_512))
+
+    def test_pwa_colors_persistence(self):
+        """Test that PWA colors persist"""
+        company = self.Company.search([], limit=1)
+        original_fg = company.web_app_fgcolor
+        company.write({"web_app_fgcolor": "#FF0000"})
+        self.assertEqual(company.web_app_fgcolor, "#FF0000")
+        company.write({"web_app_fgcolor": original_fg})
+        self.assertEqual(company.web_app_fgcolor, original_fg)
+
+    def test_config_settings_write(self):
+        """Test config settings write operations"""
+        company = self.Company.search([], limit=1)
+        settings = self.ConfigSettings.create({})
+        # Write should work for related fields
+        settings.write({"web_app_fgcolor": "#123456"})
+        self.assertIsNotNone(settings.id)
+
+    def test_multiple_companies_separate_configs(self):
+        """Test multiple companies have separate PWA configs"""
+        company1 = self.Company.create({"name": "Company 1", "web_app_fgcolor": "#111111"})
+        company2 = self.Company.create({"name": "Company 2", "web_app_fgcolor": "#222222"})
+
+        self.assertEqual(company1.web_app_fgcolor, "#111111")
+        self.assertEqual(company2.web_app_fgcolor, "#222222")

--- a/bemade_pwa_config/views/res_config_settings_views.xml
+++ b/bemade_pwa_config/views/res_config_settings_views.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <data>
+        <!-- Extend the existing settings view of base setup -->
+        <record id="view_res_config_settings_pwa_inherit" model="ir.ui.view">
+            <field name="name">res.config.settings.pwa.inherit</field>
+            <field name="model">res.config.settings</field>
+            <field name="inherit_id" ref="base_setup.res_config_settings_view_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//block[@id='pwa_settings']/setting[field[@name='web_app_name']]" position="after">
+                    <!-- Inserting PWA Icon, Foreground Color, and Background Color settings -->
+                    <setting>
+                        <field name="web_app_icon" widget="image" class="oe_avatar_large"/>
+                    </setting>
+                    <setting>
+                        <label for="web_app_fgcolor" string="Foreground Color"/>
+                        <field name="web_app_fgcolor" widget="color"/>
+                    </setting>
+                    <setting>
+                        <label for="web_app_bgcolor" string="Background Color"/>
+                        <field name="web_app_bgcolor" widget="color"/>
+                    </setting>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
Ports **bemade_pwa_config** (v) into bemade-addons on 19.0, from the vendored 19.0-validated copy in DurPro (running in production on odoo19.durpro.com). Restores the single-source structure (symlinks DurPro addons/ -> bemade-addons/) as in 18.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)