### PR TITLE
[MIG] bemade_reordering_rules_chatter: migrate to 19.0

### DIFF
--- a/bemade_reordering_rules_chatter/__init__.py
+++ b/bemade_reordering_rules_chatter/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+from . import models
+
+
+

--- a/bemade_reordering_rules_chatter/__manifest__.py
+++ b/bemade_reordering_rules_chatter/__manifest__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "Chatter on the Reordering Rules",
+    "version": "19.0.0.0.2",
+    "category": "Extra Tools",
+    "license": "GPL-3",
+    "summary": "Add chatter on the reordering rules",
+    "description": """
+    Add chatter on the reordering rules
+    """,
+    "author": "Bemade",
+    "website": "https://www.bemade.org",
+    "depends": [
+        "stock",
+    ],
+    "data": [
+        # BV : FOR MIGRATION
+        "views/stock_warehouse_orderpoint.xml",
+    ],
+    "auto_install": False,
+    "installable": True,
+}

--- a/bemade_reordering_rules_chatter/models/__init__.py
+++ b/bemade_reordering_rules_chatter/models/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_warehouse_orderpoint

--- a/bemade_reordering_rules_chatter/models/stock_warehouse_orderpoint.py
+++ b/bemade_reordering_rules_chatter/models/stock_warehouse_orderpoint.py
@@ -1,0 +1,18 @@
+from odoo import models, fields
+
+class StockWarehouseOrderpoint(models.Model):
+    _name = 'stock.warehouse.orderpoint'
+    _inherit = ['stock.warehouse.orderpoint', 'mail.thread', 'mail.activity.mixin']
+
+    name = fields.Char(tracking=True)
+    trigger = fields.Selection(tracking=True)
+    active = fields.Boolean(tracking=True)
+    snoozed_until = fields.Date(tracking=True)
+    location_id = fields.Many2one(tracking=True)
+    product_tmpl_id = fields.Many2one(tracking=True)
+    product_id = fields.Many2one(tracking=True)
+    product_min_qty = fields.Float(tracking=True)
+    product_max_qty = fields.Float(tracking=True)
+    qty_multiple = fields.Float(tracking=True)
+    company_id = fields.Many2one(tracking=True)
+    route_id = fields.Many2one(tracking=True)

--- a/bemade_reordering_rules_chatter/tests/__init__.py
+++ b/bemade_reordering_rules_chatter/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_stock_warehouse_orderpoint

--- a/bemade_reordering_rules_chatter/tests/test_stock_warehouse_orderpoint.py
+++ b/bemade_reordering_rules_chatter/tests/test_stock_warehouse_orderpoint.py
@@ -1,0 +1,15 @@
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestStockWarehouseOrderpoint(TransactionCase):
+    def test_orderpoint_model_loaded(self):
+        """Test that stock.warehouse.orderpoint model is loaded"""
+        orderpoint_model = self.env["stock.warehouse.orderpoint"]
+        self.assertIsNotNone(orderpoint_model)
+
+    def test_orderpoint_has_chatter_fields(self):
+        """Test that orderpoint has mail.thread fields"""
+        orderpoint_model = self.env["stock.warehouse.orderpoint"]
+        self.assertTrue(hasattr(orderpoint_model, "message_ids"))
+        self.assertTrue(hasattr(orderpoint_model, "activity_ids"))

--- a/bemade_reordering_rules_chatter/views/stock_warehouse_orderpoint.xml
+++ b/bemade_reordering_rules_chatter/views/stock_warehouse_orderpoint.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_warehouse_orderpoint_list_editable_config_chatter" model="ir.ui.view">
+        <field name="name">stock.warehouse.orderpoint.list.editable.config.chatter</field>
+        <field name="model">stock.warehouse.orderpoint</field>
+        <field name="inherit_id" ref="stock.view_warehouse_orderpoint_tree_editable"/>
+        <field name="arch" type="xml">
+            <xpath expr="//list" position="attributes">
+                <attribute name="editable"/>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_warehouse_orderpoint_form_chatter" model="ir.ui.view">
+        <field name="name">stock.warehouse.orderpoint.form.chatter</field>
+        <field name="model">stock.warehouse.orderpoint</field>
+        <field name="inherit_id" ref="stock.view_warehouse_orderpoint_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//form/sheet" position="after">
+                <chatter/>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Ports **bemade_reordering_rules_chatter** (v19.0.0.0.2) into bemade-addons on 19.0, from the vendored 19.0-validated copy in DurPro (running in production on odoo19.durpro.com). Restores the single-source structure (symlinks DurPro addons/ -> bemade-addons/) as in 18.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)