### PR TITLE
[MIG] bemade_search_supplier_code: migrate to 19.0

### DIFF
--- a/bemade_search_supplier_code/__init__.py
+++ b/bemade_search_supplier_code/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+from . import models
+
+
+

--- a/bemade_search_supplier_code/__manifest__.py
+++ b/bemade_search_supplier_code/__manifest__.py
@@ -1,0 +1,21 @@
+{
+    "name": "Bemade Search Supplier Code",
+    "version": "19.0.1.0.1",
+    "summary": "Search for products by supplier code",
+    "sequence": 10,
+    "description": """
+        This module adds the ability to search for products by supplier code.
+        """,
+    "category": "Inventory/Purchase",
+    "author": "Bemade",
+    "website": "https://www.bemade.org",
+    "depends": ["purchase", "product"],
+    "data": [
+        "views/product_product_views.xml",
+    ],
+    "demo": [],
+    "installable": True,
+    "application": False,
+    "auto_install": False,
+    "license": "LGPL-3",
+}

--- a/bemade_search_supplier_code/models/__init__.py
+++ b/bemade_search_supplier_code/models/__init__.py
@@ -1,0 +1,1 @@
+from . import product_product

--- a/bemade_search_supplier_code/models/product_product.py
+++ b/bemade_search_supplier_code/models/product_product.py
@@ -1,0 +1,26 @@
+from odoo import models, fields, api
+
+
+class ProductProduct(models.Model):
+    _inherit = 'product.product'
+
+    supplier_codes = fields.Char(
+        compute='_compute_supplier_codes',
+        string='Supplier Codes',
+        store=True,
+        search='_search_supplier_codes')
+
+    @api.depends('variant_seller_ids', 'variant_seller_ids.product_code')
+    def _compute_supplier_codes(self):
+        for product in self:
+            codes = filter(lambda x: isinstance(x, str), product.variant_seller_ids.mapped('product_code'))
+            product.supplier_codes = ', '.join(codes)
+
+    def _search_supplier_codes(self, operator, value):
+        if not value:
+            return []
+
+        supplierinfo_ids = self.env['product.supplierinfo'].search([('product_code', operator, value)])
+        product_ids = supplierinfo_ids.mapped('product_id.id')
+
+        return [('id', 'in', product_ids)]

--- a/bemade_search_supplier_code/tests/__init__.py
+++ b/bemade_search_supplier_code/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_module

--- a/bemade_search_supplier_code/tests/test_module.py
+++ b/bemade_search_supplier_code/tests/test_module.py
@@ -1,0 +1,55 @@
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestSearchSupplierCode(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.Product = cls.env["product.product"]
+        cls.Supplier = cls.env["res.partner"]
+        cls.SupplierInfo = cls.env["product.supplierinfo"]
+
+    def test_product_model_extended(self):
+        """Test that product.product model is extended"""
+        self.assertIsNotNone(self.Product)
+
+    def test_product_creation(self):
+        """Test product creation"""
+        product = self.Product.create({
+            "name": "Test Product",
+            "type": "consu",
+        })
+        self.assertIsNotNone(product.id)
+
+    def test_supplier_code_field(self):
+        """Test supplier code in product"""
+        supplier = self.Supplier.create({
+            "name": "Supplier",
+            "supplier_rank": 1
+        })
+
+        product = self.Product.create({
+            "name": "Product with Supplier",
+            "type": "consu",
+        })
+
+        self.assertIsNotNone(product.id)
+
+    def test_multiple_suppliers(self):
+        """Test product with multiple suppliers"""
+        supplier1 = self.Supplier.create({
+            "name": "Supplier 1",
+            "supplier_rank": 1
+        })
+        supplier2 = self.Supplier.create({
+            "name": "Supplier 2",
+            "supplier_rank": 2
+        })
+
+        product = self.Product.create({
+            "name": "Multi-Supplier Product",
+            "type": "consu",
+        })
+
+        self.assertIsNotNone(product.id)

--- a/bemade_search_supplier_code/views/product_product_views.xml
+++ b/bemade_search_supplier_code/views/product_product_views.xml
@@ -1,0 +1,12 @@
+<odoo>
+    <record id="view_product_product_search" model="ir.ui.view">
+        <field name="name">product.product.search.inherit</field>
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_search_form_view"/>
+        <field name="arch" type="xml">
+            <field name="name" position="after">
+                <field name="supplier_codes"/>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Ports **bemade_search_supplier_code** (v19.0.1.0.1) into bemade-addons on 19.0, from the vendored 19.0-validated copy in DurPro (running in production on odoo19.durpro.com). Restores the single-source structure (symlinks DurPro addons/ -> bemade-addons/) as in 18.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)