### PR TITLE
[MIG] bemade_stock_quant_valuation: migrate to 19.0

### DIFF
--- a/bemade_stock_quant_valuation/__init__.py
+++ b/bemade_stock_quant_valuation/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/bemade_stock_quant_valuation/__manifest__.py
+++ b/bemade_stock_quant_valuation/__manifest__.py
@@ -1,0 +1,35 @@
+#
+#    Bemade Inc.
+#
+#    Copyright (C) September 2023 Bemade Inc. (<https://www.bemade.org>).
+#    Author: Marc Durepos (Contact : marc@bemade.org)
+#
+#    This program is under the terms of the Odoo Proprietary License v1.0 (OPL-1)
+#    It is forbidden to publish, distribute, sublicense, or sell copies of the Software
+#    or modified copies of the Software.
+#
+#    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+#    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+#    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+#    ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#    DEALINGS IN THE SOFTWARE.
+#
+{
+    "name": "Stock Quant Valuation",
+    "version": "19.0.1.0.0",
+    "summary": """
+    Adds valuation to stock quant for better inventory adjustment management'
+    """,
+    "description": "",
+    "category": "Inventory",
+    "author": "Bemade Inc.",
+    "website": "https://www.bemade.org",
+    "license": "OPL-1",
+    "depends": ["stock_account"],
+    "data": ["views/stock_account_views.xml"],
+    "demo": [],
+    "installable": True,
+    "auto_install": False,
+}

--- a/bemade_stock_quant_valuation/models/__init__.py
+++ b/bemade_stock_quant_valuation/models/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_quant

--- a/bemade_stock_quant_valuation/models/stock_quant.py
+++ b/bemade_stock_quant_valuation/models/stock_quant.py
@@ -1,0 +1,20 @@
+from odoo import models, fields, api
+
+
+class StockQuant(models.Model):
+    _inherit = 'stock.quant'
+
+    value_unit = fields.Float(related='product_id.standard_price', readonly=True,
+                              groups='stock.group_stock_manager', digits='Product Price')
+    value_difference = fields.Float(compute='_compute_difference_value',
+                                    help='The value of the difference between the '
+                                         'quantity on hand and the counted '
+                                         'quantity.',
+                                    groups='stock.group_stock_manager',
+                                    digits='Product Price',
+                                    store=True)
+
+    @api.depends('inventory_diff_quantity', 'value_unit')
+    def _compute_difference_value(self):
+        for rec in self.filtered(lambda r: r.inventory_quantity is not None):
+            rec.value_difference = rec.value_unit * rec.inventory_diff_quantity

--- a/bemade_stock_quant_valuation/views/stock_account_views.xml
+++ b/bemade_stock_quant_valuation/views/stock_account_views.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <data>
+        <record id="view_stock_quant_list_inventory_editable_inherit_bemade_stock_quant_valuation" model="ir.ui.view">
+            <field name="name">stock.quant.inventory.list.editable.inherit</field>
+            <field name="model">stock.quant</field>
+            <field name="inherit_id" ref="stock.view_stock_quant_tree_inventory_editable"></field>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='product_uom_id']" position="after">
+                    <field name="value_unit" optional="show"/>
+                    <field name="value" optional="hide"/>
+                </xpath>
+                <xpath expr="//field[@name='inventory_diff_quantity']" position="after">
+                    <field name="value_difference" optional="show"/>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
Ports **bemade_stock_quant_valuation** (v19.0.1.0.0) into bemade-addons on 19.0, from the vendored 19.0-validated copy in DurPro (running in production on odoo19.durpro.com). Restores the single-source structure (symlinks DurPro addons/ -> bemade-addons/) as in 18.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)