### PR TITLE
[MIG] bemade_user_password_bundle: migrate to 19.0

### DIFF
--- a/bemade_user_password_bundle/__init__.py
+++ b/bemade_user_password_bundle/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/bemade_user_password_bundle/__manifest__.py
+++ b/bemade_user_password_bundle/__manifest__.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+{
+    'name': "User Password Bundle",
+
+    'summary': """
+        Module to create password bundles and provide access to them for admins of a newly created user.
+    """,
+
+    'description': """
+        This module automate the creation of a password bundle for new users in Odoo 15 and changes the default admin 
+        ownership of bundle to admin/setting group instead of the bundle creator.
+    """,
+
+    'author': "Bemade",
+    'website': "https://www.bemade.org",
+    'category': 'Technical',
+    'version': '19.0.1.0.0',
+    'license': 'LGPL-3',
+    'depends': [
+        'odoo_password_manager',
+        'hr',
+    ],
+
+    'data': [
+    ],
+    'demo': [
+    ],
+}

--- a/bemade_user_password_bundle/models/__init__.py
+++ b/bemade_user_password_bundle/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+from . import hr_employee
+from . import password_bundle

--- a/bemade_user_password_bundle/models/hr_employee.py
+++ b/bemade_user_password_bundle/models/hr_employee.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from odoo import models, fields, api
+
+
+class HrEmployee(models.Model):
+    _inherit = 'hr.employee'
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        new_employees = super().create(vals_list)
+        for newemployee in new_employees:
+            pw_bundle = self.env['password.bundle'].create({
+                'name': newemployee.name,
+                'notes': f"Created new employee Password Bundle for {newemployee.name}"
+            })
+            self.env['password.access'].create({
+                'bundle_id': pw_bundle.id,
+                'user_id': newemployee.user_id.id,
+                'access_level': 'full',
+            })
+        return new_employees

--- a/bemade_user_password_bundle/models/password_bundle.py
+++ b/bemade_user_password_bundle/models/password_bundle.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+from odoo import models, fields, api
+
+
+class password_bundle(models.Model):
+    _inherit = 'password.bundle'
+    _name = 'password.bundle'
+
+    @api.model
+    def _default_access_admin_ids(self):
+        """
+        Default method for access_ids
+        """
+        values = {
+            'access_level': 'admin',
+            'group_id': self.env.ref('base.group_system').id,
+        }
+        return [(0, 0, values)]
+
+    # BV: UGLY HACK
+    # I should be able to remove this field, but I can't just override the default function
+    # _default_access_ids, so I rename it _default_access_admin_ids and override the th field
+
+    access_ids = fields.One2many(
+        "password.access",
+        "bundle_id",
+        default=_default_access_admin_ids,
+    )
+

--- a/bemade_user_password_bundle/tests/__init__.py
+++ b/bemade_user_password_bundle/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_module

--- a/bemade_user_password_bundle/tests/test_module.py
+++ b/bemade_user_password_bundle/tests/test_module.py
@@ -1,0 +1,44 @@
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestPasswordBundle(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.HrEmployee = cls.env["hr.employee"]
+        cls.PasswordBundle = cls.env.get("password.bundle")
+        cls.User = cls.env["res.users"]
+
+    def test_hr_employee_model_extended(self):
+        """Test that hr.employee is extended"""
+        self.assertIsNotNone(self.HrEmployee)
+
+    def test_employee_creation_with_password(self):
+        """Test employee creation"""
+        employee = self.HrEmployee.create({
+            "name": "Test Employee"
+        })
+        self.assertIsNotNone(employee.id)
+
+    def test_password_bundle_model_exists(self):
+        """Test that password.bundle model exists if installed"""
+        if self.PasswordBundle:
+            self.assertIsNotNone(self.PasswordBundle)
+
+    def test_employee_password_fields(self):
+        """Test employee has password-related fields"""
+        employee = self.HrEmployee.create({
+            "name": "Password Employee"
+        })
+        # Check that employee can be created without errors
+        self.assertTrue(employee.id > 0)
+
+    def test_multiple_employees(self):
+        """Test creating multiple employees"""
+        employees = self.HrEmployee.create([
+            {"name": "Emp1"},
+            {"name": "Emp2"},
+            {"name": "Emp3"},
+        ])
+        self.assertEqual(len(employees), 3)


### PR DESCRIPTION
Ports **bemade_user_password_bundle** (v) into bemade-addons on 19.0, from the vendored 19.0-validated copy in DurPro (running in production on odoo19.durpro.com). Restores the single-source structure (symlinks DurPro addons/ -> bemade-addons/) as in 18.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)