### PR TITLE
[MIG] fsm_job_profitability: migrate to 19.0

### DIFF
--- a/fsm_job_profitability/README.rst
+++ b/fsm_job_profitability/README.rst
@@ -1,0 +1,176 @@
+FSM Job Profitability
+=====================
+
+Overview
+--------
+
+``fsm_job_profitability`` provides **read-only job profitability analysis**
+for Field Service (FSM) engagements. It leverages existing project, timesheet
+and sales data to expose actionable KPIs at both **job** (sale order) and
+**technician** levels, without creating any accounting entries.
+
+Implemented Features
+--------------------
+
+Read-only reporting layer
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- No accounting postings; all data comes from existing Odoo models:
+  ``project.task``, ``sale.order``, ``sale.order.line``,
+  ``account.analytic_line`` and FSM-related extensions.
+- Implemented entirely as SQL views, exposed through pivot and graph views
+  under Field Service → Reporting.
+
+Job-level FSM profitability (``report.fsm.job``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Grain: one row per FSM sale order / job.
+- Revenue basis: ordered, pre-tax amount from related sale order lines.
+- FSM revenue filtering:
+
+  - Only lines whose product categories are flagged as FSM products via the
+    companion addon ``fsm_product_category_flag``
+    (boolean ``product.category.is_fsm_product``) are included.
+  - If no categories are flagged for a company, the report falls back to the
+    full sale order untaxed amount.
+
+- Time basis: effective hours aggregated from FSM tasks linked to the sale
+  order.
+- Core indicators:
+
+  - ``job_revenue`` (FSM revenue for the job).
+  - ``job_effective_hours`` (sum of effective hours on linked FSM tasks).
+  - ``job_revenue_per_hour`` with safe division-by-zero handling.
+    In pivot views this is exposed as an *average* ratio; sums of revenue
+    and hours remain the authoritative basis for further analysis.
+
+- Reporting UX:
+
+  - Pivot and graph views accessible from Field Service → Reporting →
+    *Job Profitability*.
+  - Grouping by customer, sales order, order date and other common
+    dimensions.
+
+Technician-level FSM profitability (``report.fsm.tech.job``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Grain: one row per **(FSM sale order, technician)** pair.
+- Hours source:
+
+  - Timesheet lines (``account.analytic_line``) linked to FSM tasks.
+  - Grouped by ``user_id`` (Odoo user) and optionally ``employee_id``
+    (HR employee).
+
+- Revenue allocation:
+
+  - Each job’s FSM revenue (as defined above) is allocated to technicians
+    **proportionally to their share of effective hours** on that job.
+
+- Core indicators:
+
+  - Technician effective hours on the job.
+  - Allocated job revenue per technician.
+  - Job revenue (for reconciliation with the job-level report).
+
+- Reporting UX:
+
+  - Dedicated pivot and graph action under Field Service → Reporting →
+    *Technician Profitability*.
+  - Useful group-bys: technician (user/employee), customer, sales order,
+    order month, etc.
+
+Security and access
+~~~~~~~~~~~~~~~~~~~
+
+- Both models are read-only SQL views.
+- Access is granted to Field Service managers and users via ACLs on
+  ``report.fsm.job`` and ``report.fsm.tech.job`` (using FSM groups from
+  the `[industry_fsm](cci:7://file:///Users/ddurepos/src/durpro-18/enterprise/industry_fsm:0:0-0:0)` module).
+
+Prerequisites & Data Quality Expectations
+-----------------------------------------
+
+The module assumes certain data hygiene in your FSM / sales / timesheet
+processes to produce meaningful results:
+
+- FSM jobs (top-level FSM tasks) should be properly linked to the relevant
+  sales order / sales order line so that revenue attribution makes sense.
+- Allocated / planned hours on FSM jobs should be reasonably maintained,
+  so comparisons against actual timesheet effort are meaningful.
+- When using service backorders or splitting work across multiple FSM tasks,
+  links to the original job scope (sale order / sale order line) should be
+  preserved.
+- Timesheet practices (e.g. whether to include prep and travel time) should
+  be consistent with how job allocations are defined.
+- Product categories used for FSM services should be flagged correctly via
+  ``fsm_product_category_flag`` so that revenue filtering behaves as
+  expected.
+
+Backlog / Future Enhancements
+-----------------------------
+
+The following items were considered in early design discussions but are
+**not implemented in v1**. They remain candidates for future work:
+
+Task- and project-level profitability fields
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Adding read-only profitability fields on:
+
+  - ``project.task`` forms for FSM tasks.
+  - ``project.project`` for FSM projects.
+
+- Examples: ``fsm_revenue``, ``fsm_revenue_per_hour``, and margin fields.
+
+Extending existing FSM analysis views
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Injecting profitability fields directly into
+  ``report.project.task.user.fsm``-based analysis views, instead of relying
+  solely on the separate SQL reporting models.
+
+Advanced filters and audit-style reports
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Predefined filters such as “Unprofitable jobs” or “Low revenue per hour”.
+- Audit lists for:
+
+  - Jobs still open long after their planned start/visit date.
+  - Jobs closed without any related timesheets.
+  - Jobs with large variance between planned and actual hours.
+
+Configurable revenue basis and tax handling
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Company-level settings to choose:
+
+  - Ordered vs delivered vs invoiced revenue.
+  - Whether to include taxes.
+
+Cost and margin analysis
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Integration with employee cost (``hr_hourly_cost`` / analytic costs) to
+  compute:
+
+  - Technician and job-level cost.
+  - Gross margin and margin rate KPIs.
+
+Project-level aggregates and dashboards
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Higher-level aggregates across projects / customers, and dedicated
+  dashboard-style views or spreadsheets built on top of the SQL views.
+
+Stronger process enforcement and tooling
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Additional tooling or constraints to improve data quality, for example:
+
+  - Ensuring all FSM jobs have proper SO / SO-line links and reasonable
+    allocated hours.
+  - More automation around backorders and job templates.
+
+For now, this module focuses on providing reliable, read-only KPIs that
+can feed spreadsheets, dashboards and further custom reporting.
+```~~

--- a/fsm_job_profitability/__init__.py
+++ b/fsm_job_profitability/__init__.py
@@ -1,0 +1,2 @@
+from . import report
+

--- a/fsm_job_profitability/__manifest__.py
+++ b/fsm_job_profitability/__manifest__.py
@@ -1,0 +1,82 @@
+{
+    "name": "FSM Job Profitability",
+    "summary": "FSM job profitability analysis (revenue per hour, margin, KPIs) for field service projects",
+    "version": "19.0.1.0.2",
+    "author": "Bemade Inc.",
+    "license": "LGPL-3",
+    "website": "https://www.bemade.org",
+    "category": "Services/Field Service",
+    "depends": [
+        "project",
+        "hr_timesheet",
+        "hr_hourly_cost",
+        "sale_project",
+        "sale_timesheet",
+        "industry_fsm",
+        "industry_fsm_sale",
+        "fsm_product_category_flag",
+    ],
+    "description": """
+FSM Job Profitability
+=====================
+
+This module adds read-only job profitability reporting for Field Service (FSM)
+engagements.
+
+Key features
+------------
+
+Job-level profitability (model ``report.fsm.job``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- One row per FSM sale order / job.
+- Revenue basis: ordered, pre-tax amount from related sale order lines.
+- Revenue filtering: only products whose category is flagged as FSM Product
+  (boolean ``product.category.is_fsm_product`` from addon
+  ``fsm_product_category_flag``).
+- Time basis: effective hours coming from FSM tasks linked to the sale order.
+- Measures include ``job_revenue``, ``job_effective_hours`` and
+  ``job_revenue_per_hour``.
+
+Technician-level profitability (model ``report.fsm.tech.job``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- One row per (FSM sale order, technician) pair.
+- Hours source: timesheets (``account.analytic.line``) linked to FSM tasks.
+- Revenue allocation: job revenue is allocated to technicians proportionally
+  to their share of effective hours on the job.
+- Measures include technician effective hours, allocated revenue, job revenue
+  (for reconciliation), and average technician revenue per hour.
+
+Read-only reporting
+~~~~~~~~~~~~~~~~~~~
+
+- Implemented via SQL views only; the module does not create or modify
+  accounting entries.
+- Metrics are derived from existing Odoo objects such as ``project.task``,
+  ``sale.order``, ``sale.order.line`` and ``account.analytic.line``.
+
+Intended usage
+--------------
+
+- Analyze revenue and time spent per job, and how revenue is attributed to
+  technicians, without changing core FSM or accounting behavior.
+- Export results to spreadsheets or dashboards for further KPI analysis.
+
+Prerequisites & data quality
+----------------------------
+
+- FSM jobs (top-level FSM tasks) should be linked to the relevant sales order
+  and/or sales order line so revenue attribution makes sense.
+- Planned hours should be reasonably maintained to compare planned vs actual.
+- Backorders or split work should preserve links to the original job scope.
+- Timesheet practices should be consistent with how allocations are defined.
+""",
+    "data": [
+        "security/ir.model.access.csv",
+        "report/project_report_views.xml",
+        "report/tech_report_views.xml",
+    ],
+    "installable": True,
+    "application": False,
+}

--- a/fsm_job_profitability/models/__init__.py
+++ b/fsm_job_profitability/models/__init__.py
@@ -1,0 +1,5 @@
+"""Model package for fsm_job_profitability.
+
+Currently, all field extensions used by this module are provided by
+dependency addons such as fsm_product_category_flag.
+"""

--- a/fsm_job_profitability/report/__init__.py
+++ b/fsm_job_profitability/report/__init__.py
@@ -1,0 +1,3 @@
+from . import report_fsm_job
+from . import report_fsm_tech_job
+

--- a/fsm_job_profitability/report/project_report_views.xml
+++ b/fsm_job_profitability/report/project_report_views.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <!-- Pivot view for FSM Job Profitability -->
+        <record id="view_fsm_job_pivot" model="ir.ui.view">
+            <field name="name">report.fsm.job.pivot</field>
+            <field name="model">report.fsm.job</field>
+            <field name="arch" type="xml">
+                <pivot string="FSM Job Profitability">
+                    <field name="date_order" interval="month" type="row"/>
+
+                    <field name="job_allocated_hours" type="measure"/>
+                    <field name="job_effective_hours" type="measure"/>
+                    <field name="job_revenue" type="measure"/>
+                    <field name="job_revenue_per_hour" type="measure"/>
+                </pivot>
+            </field>
+        </record>
+
+        <!-- Graph view for FSM Job Profitability -->
+        <record id="view_fsm_job_graph" model="ir.ui.view">
+            <field name="name">report.fsm.job.graph</field>
+            <field name="model">report.fsm.job</field>
+            <field name="arch" type="xml">
+                <graph string="FSM Job Profitability" type="bar">
+                    <field name="date_order" interval="month" type="row"/>
+                    <field name="job_revenue" type="measure"/>
+                </graph>
+            </field>
+        </record>
+
+        <!-- Basic search view for FSM Job Profitability -->
+        <record id="view_fsm_job_search" model="ir.ui.view">
+            <field name="name">report.fsm.job.search</field>
+            <field name="model">report.fsm.job</field>
+            <field name="arch" type="xml">
+                <search string="Search FSM Jobs">
+                    <field name="sale_order_id"/>
+                    <field name="partner_id"/>
+                    <field name="date_order"/>
+
+                    <!-- Date filters -->
+                    <!-- Jobs in the current calendar year (from Jan 1st of this year) -->
+                    <filter name="this_year" string="This Year"
+                            domain="[( 'date_order', '&gt;=', (context_today().strftime('%Y-01-01')))]"/>
+                </search>
+            </field>
+        </record>
+
+        <!-- Action for FSM Job Profitability report -->
+        <record id="action_report_fsm_job" model="ir.actions.act_window">
+            <field name="name">FSM Job Profitability</field>
+            <field name="res_model">report.fsm.job</field>
+            <field name="view_mode">pivot,graph</field>
+            <field name="view_id" ref="view_fsm_job_pivot"/>
+            <field name="search_view_id" ref="view_fsm_job_search"/>
+            <field name="context">{
+                'group_by': [],
+                'search_default_this_year': 1,
+                'pivot_measures': [
+                    '__count',
+                    'job_allocated_hours',
+                    'job_effective_hours',
+                    'job_revenue',
+                    'job_revenue_per_hour',
+                ],
+            }</field>
+            <field name="help" type="html">
+                <p class="o_view_nocontent_empty_folder">
+                    No data yet!
+                </p>
+                <p>
+                    Analyze the profitability of your FSM jobs by customer, period and
+                    other dimensions.
+                </p>
+                <p class="text-muted">
+                    Job revenue is based on sales order lines whose product categories are
+                    flagged as "FSM Product". If no categories are flagged as FSM Product
+                    in the database, the report falls back to using the full Sales Order
+                    untaxed amount (all order lines) as job revenue.
+                </p>
+            </field>
+        </record>
+
+        <!-- Menu entry under FSM Reporting (reuses the main FSM reporting menu) -->
+        <menuitem id="fsm_menu_reporting_job_profitability"
+                  name="Job Profitability"
+                  parent="industry_fsm.fsm_menu_reporting"
+                  action="action_report_fsm_job"
+                  sequence="20"/>
+    </data>
+</odoo>

--- a/fsm_job_profitability/report/report_fsm_job.py
+++ b/fsm_job_profitability/report/report_fsm_job.py
@@ -1,0 +1,102 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models, tools
+
+
+class ReportFsmJob(models.Model):
+    """FSM Job-level profitability analysis.
+
+    Grain: one row per sale order (job). Revenue comes from the sale order's
+    untaxed amount, and hours are aggregated from linked FSM tasks via the
+    existing report.project.task.user.fsm view.
+    """
+
+    _name = 'report.fsm.job'
+    _description = 'FSM Job Profitability'
+    _auto = False
+
+    sale_order_id = fields.Many2one('sale.order', string='Sales Order', readonly=True)
+    partner_id = fields.Many2one('res.partner', string='Customer', readonly=True)
+    date_order = fields.Datetime(string='Order Date', readonly=True)
+    company_id = fields.Many2one('res.company', string='Company', readonly=True)
+
+    job_effective_hours = fields.Float(string='Effective Hours', readonly=True, aggregator='sum')
+    job_allocated_hours = fields.Float(string='Planned Hours', readonly=True, aggregator='sum')
+    job_revenue = fields.Float(string='Job Revenue (Ordered, Pre-tax)', readonly=True, aggregator='sum')
+    job_revenue_per_hour = fields.Float(
+        string='Avg Job Revenue per Hour',
+        readonly=True,
+        aggregator='avg',
+    )
+
+    def _select(self):
+        return """
+                so.id AS id,
+                so.id AS sale_order_id,
+                so.partner_id AS partner_id,
+                so.date_order AS date_order,
+                so.company_id AS company_id,
+                COALESCE(SUM(ft.effective_hours), 0) AS job_effective_hours,
+                COALESCE(SUM(ft.allocated_hours), 0) AS job_allocated_hours,
+                COALESCE(MAX(rev.job_revenue), 0) AS job_revenue,
+                CASE
+                    WHEN COALESCE(SUM(ft.effective_hours), 0) > 0 THEN
+                        COALESCE(MAX(rev.job_revenue), 0) / SUM(ft.effective_hours)
+                    ELSE 0
+                END AS job_revenue_per_hour
+        """
+
+    def _from(self):
+        return """
+                sale_order so
+                LEFT JOIN (
+                    SELECT
+                        so2.id AS sale_order_id,
+                        COALESCE(SUM(
+                            CASE
+                                WHEN pc.is_fsm_product THEN sol2.price_subtotal
+                                ELSE 0
+                            END
+                        ), 0) AS job_revenue
+                      FROM sale_order so2
+                      LEFT JOIN sale_order_line sol2
+                        ON sol2.order_id = so2.id
+                      LEFT JOIN product_product pp
+                        ON sol2.product_id = pp.id
+                      LEFT JOIN product_template pt
+                        ON pp.product_tmpl_id = pt.id
+                      LEFT JOIN product_category pc
+                        ON pc.id = pt.categ_id
+                  GROUP BY so2.id
+                ) AS rev
+                    ON rev.sale_order_id = so.id
+                LEFT JOIN report_project_task_user_fsm ft
+                    ON ft.sale_order_id = so.id
+        """
+
+    def _group_by(self):
+        return """
+                so.id,
+                so.partner_id,
+                so.date_order,
+                so.company_id,
+                so.amount_untaxed
+        """
+
+    def _where(self):
+        # Restrict to orders that have at least one linked FSM task entry.
+        return """
+                ft.id IS NOT NULL
+        """
+
+    def init(self):
+        tools.drop_view_if_exists(self.env.cr, self._table)
+        self.env.cr.execute(
+            f"""
+            CREATE VIEW {self._table} AS
+                SELECT {self._select()}
+                  FROM {self._from()}
+                 WHERE {self._where()}
+              GROUP BY {self._group_by()}
+            """
+        )

--- a/fsm_job_profitability/report/report_fsm_tech_job.py
+++ b/fsm_job_profitability/report/report_fsm_tech_job.py
@@ -1,0 +1,150 @@
+from odoo import fields, models, tools
+
+
+class ReportFsmTechJob(models.Model):
+    """Technician-level FSM job profitability.
+
+    Grain: one row per (sale order, technician). Revenue is the job-level FSM
+    revenue allocated to each technician in proportion to their share of
+    effective hours on that job.
+    """
+
+    _name = "report.fsm.tech.job"
+    _description = "FSM Technician Job Profitability"
+    _auto = False
+
+    sale_order_id = fields.Many2one("sale.order", string="Sales Order", readonly=True)
+    partner_id = fields.Many2one("res.partner", string="Customer", readonly=True)
+    date_order = fields.Datetime(string="Order Date", readonly=True)
+    company_id = fields.Many2one("res.company", string="Company", readonly=True)
+
+    user_id = fields.Many2one("res.users", string="Technician (User)", readonly=True)
+    employee_id = fields.Many2one(
+        "hr.employee", string="Technician (Employee)", readonly=True
+    )
+
+    tech_effective_hours = fields.Float(
+        string="Technician Effective Hours", readonly=True, aggregator="sum"
+    )
+    tech_allocated_hours = fields.Float(
+        string="Technician Planned Hours", readonly=True, aggregator="sum"
+    )
+    job_revenue = fields.Float(
+        string="Job Revenue (Ordered, Pre-tax)", readonly=True, aggregator="sum"
+    )
+    tech_revenue = fields.Float(
+        string="Technician Revenue (Allocated)", readonly=True, aggregator="sum"
+    )
+    tech_revenue_per_hour = fields.Float(
+        string="Avg Technician Revenue per Hour",
+        readonly=True,
+        aggregator="avg",
+    )
+
+    def _select(self):
+        return """
+                MIN(aal.id) AS id,
+                so.id AS sale_order_id,
+                so.partner_id AS partner_id,
+                so.date_order AS date_order,
+                so.company_id AS company_id,
+                aal.user_id AS user_id,
+                aal.employee_id AS employee_id,
+                COALESCE(SUM(aal.unit_amount), 0) AS tech_effective_hours,
+                0.0 AS tech_allocated_hours,
+                COALESCE(MAX(rev.job_revenue), 0) AS job_revenue,
+                CASE
+                    WHEN COALESCE(MAX(ht.total_effective_hours), 0) > 0 THEN
+                        COALESCE(MAX(rev.job_revenue), 0)
+                        * COALESCE(SUM(aal.unit_amount), 0)
+                        / COALESCE(MAX(ht.total_effective_hours), 0)
+                    ELSE 0
+                END AS tech_revenue,
+                CASE
+                    WHEN COALESCE(SUM(aal.unit_amount), 0) > 0
+                         AND COALESCE(MAX(ht.total_effective_hours), 0) > 0 THEN
+                        (COALESCE(MAX(rev.job_revenue), 0)
+                         * COALESCE(SUM(aal.unit_amount), 0)
+                         / COALESCE(MAX(ht.total_effective_hours), 0))
+                        / COALESCE(SUM(aal.unit_amount), 0)
+                    ELSE 0
+                END AS tech_revenue_per_hour
+        """
+
+    def _from(self):
+        return """
+                account_analytic_line aal
+                JOIN project_task t
+                    ON aal.task_id = t.id
+                JOIN sale_order so
+                    ON t.sale_order_id = so.id
+                LEFT JOIN (
+                    SELECT
+                        so2.id AS sale_order_id,
+                        COALESCE(SUM(
+                            CASE
+                                WHEN pc.is_fsm_product THEN sol2.price_subtotal
+                                ELSE 0
+                            END
+                        ), 0) AS job_revenue
+                      FROM sale_order so2
+                      LEFT JOIN sale_order_line sol2
+                        ON sol2.order_id = so2.id
+                      LEFT JOIN product_product pp
+                        ON sol2.product_id = pp.id
+                      LEFT JOIN product_template pt
+                        ON pp.product_tmpl_id = pt.id
+                      LEFT JOIN product_category pc
+                        ON pc.id = pt.categ_id
+                  GROUP BY so2.id
+                ) AS rev
+                    ON rev.sale_order_id = so.id
+                LEFT JOIN (
+                    SELECT
+                        t2.sale_order_id AS sale_order_id,
+                        COALESCE(SUM(aal2.unit_amount), 0) AS total_effective_hours
+                      FROM account_analytic_line aal2
+                      JOIN project_task t2
+                        ON aal2.task_id = t2.id
+                  GROUP BY t2.sale_order_id
+                ) AS ht
+                    ON ht.sale_order_id = so.id
+        """
+
+    def _group_by(self):
+        return """
+                so.id,
+                so.partner_id,
+                so.date_order,
+                so.company_id,
+                aal.user_id,
+                aal.employee_id
+        """
+
+    def _where(self):
+        # is_fsm is computed: True if any order line has a service product with
+        # service_tracking = 'task_global_project'
+        return """
+                EXISTS (
+                    SELECT 1
+                      FROM sale_order_line sol
+                      JOIN product_product pp ON sol.product_id = pp.id
+                      JOIN product_template pt ON pp.product_tmpl_id = pt.id
+                     WHERE sol.order_id = so.id
+                       AND pt.type = 'service'
+                       AND pt.service_tracking = 'task_global_project'
+                )
+                AND aal.unit_amount IS NOT NULL
+        """
+
+    def init(self):
+        tools.drop_view_if_exists(self.env.cr, self._table)
+        self.env.cr.execute(
+            f"""
+            CREATE VIEW {self._table} AS
+                SELECT {self._select()}
+                  FROM {self._from()}
+                 WHERE {self._where()}
+              GROUP BY {self._group_by()}
+            """
+        )

--- a/fsm_job_profitability/report/tech_report_views.xml
+++ b/fsm_job_profitability/report/tech_report_views.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <!-- Pivot view for FSM Technician Job Profitability -->
+        <record id="view_fsm_tech_job_pivot" model="ir.ui.view">
+            <field name="name">report.fsm.tech.job.pivot</field>
+            <field name="model">report.fsm.tech.job</field>
+            <field name="arch" type="xml">
+                <pivot string="FSM Technician Profitability">
+                    <field name="user_id" type="row"/>
+                    <field name="date_order" interval="month" type="row"/>
+
+                    <field name="tech_allocated_hours" type="measure"/>
+                    <field name="tech_effective_hours" type="measure"/>
+                    <field name="job_revenue" type="measure"/>
+                    <field name="tech_revenue" type="measure"/>
+                    <field name="tech_revenue_per_hour" type="measure"/>
+                </pivot>
+            </field>
+        </record>
+
+        <!-- Graph view (optional) -->
+        <record id="view_fsm_tech_job_graph" model="ir.ui.view">
+            <field name="name">report.fsm.tech.job.graph</field>
+            <field name="model">report.fsm.tech.job</field>
+            <field name="arch" type="xml">
+                <graph string="FSM Technician Profitability" type="bar">
+                    <field name="user_id" type="row"/>
+                    <field name="date_order" interval="month" type="col"/>
+                    <field name="tech_revenue" type="measure"/>
+                </graph>
+            </field>
+        </record>
+
+        <!-- Search view -->
+        <record id="view_fsm_tech_job_search" model="ir.ui.view">
+            <field name="name">report.fsm.tech.job.search</field>
+            <field name="model">report.fsm.tech.job</field>
+            <field name="arch" type="xml">
+                <search string="Search Technician Profitability">
+                    <field name="user_id"/>
+                    <field name="employee_id"/>
+                    <field name="partner_id"/>
+                    <field name="sale_order_id"/>
+                    <field name="date_order"/>
+
+                    <filter name="this_year" string="This Year"
+                            domain="[( 'date_order', '&gt;=', (context_today().strftime('%Y-01-01')))]"/>
+                    <filter name="group_by_user" string="Technician" context="{'group_by': 'user_id'}"/>
+                    <filter name="group_by_partner" string="Customer" context="{'group_by': 'partner_id'}"/>
+                    <filter name="group_by_order" string="Sales Order" context="{'group_by': 'sale_order_id'}"/>
+                    <filter name="group_by_month" string="Order Month" context="{'group_by': 'date_order:month'}"/>
+                </search>
+            </field>
+        </record>
+
+        <!-- Action and menu item under FSM Reporting -->
+        <record id="action_fsm_tech_job_report" model="ir.actions.act_window">
+            <field name="name">FSM Technician Profitability</field>
+            <field name="res_model">report.fsm.tech.job</field>
+            <field name="view_mode">pivot,graph</field>
+            <field name="search_view_id" ref="view_fsm_tech_job_search"/>
+            <field name="context">{
+                'group_by': [],
+                'search_default_this_year': 1,
+                'pivot_measures': [
+                    '__count',
+                    'tech_allocated_hours',
+                    'tech_effective_hours',
+                    'job_revenue',
+                    'tech_revenue',
+                    'tech_revenue_per_hour',
+                ],
+            }</field>
+            <field name="help" type="html">
+                <p class="o_view_nocontent_empty_folder">
+                    No data yet!
+                </p><p>
+                    Analyze job-level revenue and hours allocated to each technician
+                    based on their share of effective hours on FSM jobs.
+                </p>
+            </field>
+        </record>
+
+        <menuitem id="fsm_menu_reporting_tech_profitability"
+                  name="Technician Profitability"
+                  sequence="20"
+                  action="action_fsm_tech_job_report"
+                  parent="industry_fsm.fsm_menu_reporting"/>
+    </data>
+</odoo>

--- a/fsm_job_profitability/security/ir.model.access.csv
+++ b/fsm_job_profitability/security/ir.model.access.csv
@@ -1,0 +1,5 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_report_fsm_job_manager,access_report_fsm_job_manager,model_report_fsm_job,industry_fsm.group_fsm_manager,1,0,0,0
+access_report_fsm_job_user,access_report_fsm_job_user,model_report_fsm_job,industry_fsm.group_fsm_user,1,0,0,0
+access_report_fsm_tech_job_manager,access_report_fsm_tech_job_manager,model_report_fsm_tech_job,industry_fsm.group_fsm_manager,1,0,0,0
+access_report_fsm_tech_job_user,access_report_fsm_tech_job_user,model_report_fsm_tech_job,industry_fsm.group_fsm_user,1,0,0,0

--- a/fsm_job_profitability/tests/__init__.py
+++ b/fsm_job_profitability/tests/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_fsm_job_profitability

--- a/fsm_job_profitability/tests/test_fsm_job_profitability.py
+++ b/fsm_job_profitability/tests/test_fsm_job_profitability.py
@@ -1,0 +1,187 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.fields import Command
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestFsmJobProfitability(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.fsm_project = cls.env.ref("industry_fsm.fsm_project")
+        cls.partner = cls.env["res.partner"].create({"name": "FSM Customer"})
+        cls.categ_fsm = cls.env["product.category"].create(
+            {"name": "FSM Parts", "is_fsm_product": True}
+        )
+        cls.categ_other = cls.env["product.category"].create({"name": "Other"})
+        cls.fsm_service = cls.env["product.product"].create(
+            {
+                "name": "FSM Intervention",
+                "type": "service",
+                "list_price": 500.0,
+                "categ_id": cls.categ_fsm.id,
+                "service_tracking": "task_global_project",
+                "project_id": cls.fsm_project.id,
+            }
+        )
+        cls.other_product = cls.env["product.product"].create(
+            {
+                "name": "Non FSM Item",
+                "type": "consu",
+                "list_price": 100.0,
+                "categ_id": cls.categ_other.id,
+            }
+        )
+        cls.user_tech1 = cls.env["res.users"].create(
+            {"name": "Tech One", "login": "tech1@example.com"}
+        )
+        cls.employee1 = cls.env["hr.employee"].create(
+            {"name": "Tech One", "user_id": cls.user_tech1.id}
+        )
+        cls.employee2 = cls.env["hr.employee"].create({"name": "Tech Two"})
+
+        cls.order = cls.env["sale.order"].create(
+            {
+                "partner_id": cls.partner.id,
+                "order_line": [
+                    Command.create(
+                        {
+                            "product_id": cls.fsm_service.id,
+                            "product_uom_qty": 1.0,
+                            "price_unit": 500.0,
+                        }
+                    ),
+                    Command.create(
+                        {
+                            "product_id": cls.other_product.id,
+                            "product_uom_qty": 1.0,
+                            "price_unit": 100.0,
+                        }
+                    ),
+                ],
+            }
+        )
+        cls.order.action_confirm()
+        cls.task = cls.env["project.task"].search(
+            [("sale_line_id", "=", cls.order.order_line[0].id)]
+        )
+        cls.task.user_ids = cls.user_tech1
+        cls.task.allocated_hours = 10.0
+        cls.env["account.analytic.line"].create(
+            [
+                {
+                    "name": "morning work",
+                    "project_id": cls.task.project_id.id,
+                    "task_id": cls.task.id,
+                    "employee_id": cls.employee1.id,
+                    "unit_amount": 6.0,
+                },
+                {
+                    "name": "afternoon work",
+                    "project_id": cls.task.project_id.id,
+                    "task_id": cls.task.id,
+                    "employee_id": cls.employee2.id,
+                    "unit_amount": 2.0,
+                },
+            ]
+        )
+
+    def _job_rows(self, order):
+        self.env.flush_all()
+        return self.env["report.fsm.job"].search(
+            [("sale_order_id", "=", order.id)]
+        )
+
+    def _tech_rows(self, order):
+        self.env.flush_all()
+        return self.env["report.fsm.tech.job"].search(
+            [("sale_order_id", "=", order.id)]
+        )
+
+    def test_job_report_values(self):
+        rows = self._job_rows(self.order)
+        self.assertEqual(len(rows), 1)
+        row = rows[0]
+        self.assertEqual(row.partner_id, self.partner)
+        # Only the line in an FSM-flagged category counts as revenue.
+        self.assertAlmostEqual(row.job_revenue, 500.0)
+        self.assertAlmostEqual(row.job_effective_hours, 8.0)
+        self.assertAlmostEqual(row.job_allocated_hours, 10.0)
+        self.assertAlmostEqual(row.job_revenue_per_hour, 62.5)
+
+    def test_job_report_excludes_order_without_fsm_task(self):
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "order_line": [
+                    Command.create(
+                        {
+                            "product_id": self.other_product.id,
+                            "product_uom_qty": 1.0,
+                            "price_unit": 100.0,
+                        }
+                    ),
+                ],
+            }
+        )
+        order.action_confirm()
+        self.assertFalse(self._job_rows(order))
+        self.assertFalse(self._tech_rows(order))
+
+    def test_tech_report_allocation(self):
+        rows = self._tech_rows(self.order)
+        self.assertEqual(len(rows), 2)
+        row1 = rows.filtered(lambda r: r.employee_id == self.employee1)
+        row2 = rows.filtered(lambda r: r.employee_id == self.employee2)
+        self.assertAlmostEqual(row1.tech_effective_hours, 6.0)
+        self.assertAlmostEqual(row2.tech_effective_hours, 2.0)
+        # Revenue is allocated proportionally to hours: 500 * 6/8 and 500 * 2/8.
+        self.assertAlmostEqual(row1.tech_revenue, 375.0)
+        self.assertAlmostEqual(row2.tech_revenue, 125.0)
+        for row in rows:
+            self.assertAlmostEqual(row.job_revenue, 500.0)
+            self.assertAlmostEqual(row.tech_revenue_per_hour, 62.5)
+
+    def test_tech_report_excludes_non_global_project_orders(self):
+        # A service tracked in a dedicated project (not the global FSM
+        # project) must not appear in the technician report.
+        service = self.env["product.product"].create(
+            {
+                "name": "Dedicated Project Service",
+                "type": "service",
+                "list_price": 200.0,
+                "categ_id": self.categ_other.id,
+                "service_tracking": "task_in_project",
+            }
+        )
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "order_line": [
+                    Command.create(
+                        {
+                            "product_id": service.id,
+                            "product_uom_qty": 1.0,
+                            "price_unit": 200.0,
+                        }
+                    ),
+                ],
+            }
+        )
+        order.action_confirm()
+        task = self.env["project.task"].search(
+            [("sale_line_id", "=", order.order_line.id)]
+        )
+        self.assertTrue(task)
+        task.project_id.allow_timesheets = True
+        self.env["account.analytic.line"].create(
+            {
+                "name": "work",
+                "project_id": task.project_id.id,
+                "task_id": task.id,
+                "employee_id": self.employee1.id,
+                "unit_amount": 3.0,
+            }
+        )
+        self.assertFalse(self._tech_rows(order))


### PR DESCRIPTION
Ports **fsm_job_profitability** (v19.0.1.0.2) into bemade-addons on 19.0, from the vendored 19.0-validated copy in DurPro (running in production on odoo19.durpro.com). Restores the single-source structure (symlinks DurPro addons/ -> bemade-addons/) as in 18.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)