### PR TITLE
[MIG] fsm_product_category_flag: migrate to 19.0

### DIFF
--- a/fsm_product_category_flag/__init__.py
+++ b/fsm_product_category_flag/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/fsm_product_category_flag/__manifest__.py
+++ b/fsm_product_category_flag/__manifest__.py
@@ -1,0 +1,26 @@
+{
+    'name': 'FSM Product Category Flag',
+    'summary': 'Adds an FSM Product flag on product categories for use in FSM-related logic.',
+    'version': '19.0.1.0.0',
+    'author': 'Bemade Inc.',
+    'license': 'LGPL-3',
+    'website': 'https://www.bemade.org',
+    'category': 'Product',
+    'depends': ['product'],
+    'description': '''
+FSM Product Category Flag
+=========================
+
+This addon adds a simple **FSM Product** boolean on product categories.
+
+It is intended to be used by FSM-related reporting or business logic, such as
+the FSM Job Profitability module, to distinguish which product categories
+should be considered FSM service products when computing revenue or other
+metrics.
+''',
+    'data': [
+        'views/product_category_views.xml',
+    ],
+    'installable': True,
+    'application': False,
+}

--- a/fsm_product_category_flag/models/__init__.py
+++ b/fsm_product_category_flag/models/__init__.py
@@ -1,0 +1,1 @@
+from . import product_category

--- a/fsm_product_category_flag/models/product_category.py
+++ b/fsm_product_category_flag/models/product_category.py
@@ -1,0 +1,12 @@
+from odoo import fields, models
+
+
+class ProductCategory(models.Model):
+    _inherit = 'product.category'
+
+    is_fsm_product = fields.Boolean(
+        string='FSM Product',
+        help='If enabled, products in this category are considered FSM products and '
+             'their sales order lines are included in FSM-related revenue calculations '
+             'such as FSM job profitability.'
+    )

--- a/fsm_product_category_flag/tests/__init__.py
+++ b/fsm_product_category_flag/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_fsm_product_category_flag

--- a/fsm_product_category_flag/tests/test_fsm_product_category_flag.py
+++ b/fsm_product_category_flag/tests/test_fsm_product_category_flag.py
@@ -1,0 +1,222 @@
+from odoo.tests.common import TransactionCase
+
+
+class TestFsmProductCategoryFlag(TransactionCase):
+
+    def setUp(self):
+        super().setUp()
+        self.ProductCategory = self.env['product.category']
+
+    def test_module_installed(self):
+        """Test that the module is properly installed"""
+        # Verify that the is_fsm_product field exists on product.category
+        self.assertTrue(
+            hasattr(self.env['product.category'], '_fields'),
+            "product.category model should have fields"
+        )
+        self.assertIn(
+            'is_fsm_product',
+            self.env['product.category']._fields,
+            "is_fsm_product field should be present on product.category"
+        )
+
+    def test_create_fsm_category_enabled(self):
+        """Test creating a product category with is_fsm_product=True"""
+        category = self.ProductCategory.create({
+            'name': 'FSM Services',
+            'is_fsm_product': True,
+        })
+
+        self.assertTrue(category.is_fsm_product)
+        self.assertEqual(category.name, 'FSM Services')
+
+    def test_create_fsm_category_disabled(self):
+        """Test creating a product category with is_fsm_product=False"""
+        category = self.ProductCategory.create({
+            'name': 'Regular Products',
+            'is_fsm_product': False,
+        })
+
+        self.assertFalse(category.is_fsm_product)
+        self.assertEqual(category.name, 'Regular Products')
+
+    def test_default_is_fsm_product_false(self):
+        """Test that is_fsm_product defaults to False when not specified"""
+        category = self.ProductCategory.create({
+            'name': 'Default Category',
+        })
+
+        self.assertFalse(
+            category.is_fsm_product,
+            "is_fsm_product should default to False"
+        )
+
+    def test_update_fsm_product_flag_true_to_false(self):
+        """Test updating is_fsm_product from True to False"""
+        category = self.ProductCategory.create({
+            'name': 'Updatable Category',
+            'is_fsm_product': True,
+        })
+
+        self.assertTrue(category.is_fsm_product)
+
+        category.is_fsm_product = False
+        self.assertFalse(category.is_fsm_product)
+
+    def test_update_fsm_product_flag_false_to_true(self):
+        """Test updating is_fsm_product from False to True"""
+        category = self.ProductCategory.create({
+            'name': 'Non-FSM Category',
+            'is_fsm_product': False,
+        })
+
+        self.assertFalse(category.is_fsm_product)
+
+        category.is_fsm_product = True
+        self.assertTrue(category.is_fsm_product)
+
+    def test_multiple_fsm_categories(self):
+        """Test creating multiple categories with mixed FSM flags"""
+        fsm_cat = self.ProductCategory.create({
+            'name': 'FSM Category 1',
+            'is_fsm_product': True,
+        })
+        non_fsm_cat = self.ProductCategory.create({
+            'name': 'Non-FSM Category 1',
+            'is_fsm_product': False,
+        })
+        another_fsm_cat = self.ProductCategory.create({
+            'name': 'FSM Category 2',
+            'is_fsm_product': True,
+        })
+
+        self.assertTrue(fsm_cat.is_fsm_product)
+        self.assertFalse(non_fsm_cat.is_fsm_product)
+        self.assertTrue(another_fsm_cat.is_fsm_product)
+
+    def test_search_fsm_categories(self):
+        """Test searching for FSM product categories"""
+        fsm_cat1 = self.ProductCategory.create({
+            'name': 'FSM Category A',
+            'is_fsm_product': True,
+        })
+        non_fsm_cat = self.ProductCategory.create({
+            'name': 'Non-FSM Category A',
+            'is_fsm_product': False,
+        })
+        fsm_cat2 = self.ProductCategory.create({
+            'name': 'FSM Category B',
+            'is_fsm_product': True,
+        })
+
+        fsm_categories = self.ProductCategory.search([
+            ('is_fsm_product', '=', True)
+        ])
+
+        self.assertIn(fsm_cat1, fsm_categories)
+        self.assertNotIn(non_fsm_cat, fsm_categories)
+        self.assertIn(fsm_cat2, fsm_categories)
+
+    def test_search_non_fsm_categories(self):
+        """Test searching for non-FSM product categories"""
+        fsm_cat = self.ProductCategory.create({
+            'name': 'FSM Category',
+            'is_fsm_product': True,
+        })
+        non_fsm_cat1 = self.ProductCategory.create({
+            'name': 'Non-FSM Category 1',
+            'is_fsm_product': False,
+        })
+        non_fsm_cat2 = self.ProductCategory.create({
+            'name': 'Non-FSM Category 2',
+            'is_fsm_product': False,
+        })
+
+        non_fsm_categories = self.ProductCategory.search([
+            ('is_fsm_product', '=', False)
+        ])
+
+        self.assertNotIn(fsm_cat, non_fsm_categories)
+        self.assertIn(non_fsm_cat1, non_fsm_categories)
+        self.assertIn(non_fsm_cat2, non_fsm_categories)
+
+    def test_parent_child_category_fsm_flag(self):
+        """Test that parent and child categories have independent FSM flags"""
+        parent_fsm = self.ProductCategory.create({
+            'name': 'Parent FSM',
+            'is_fsm_product': True,
+        })
+        child_non_fsm = self.ProductCategory.create({
+            'name': 'Child Non-FSM',
+            'parent_id': parent_fsm.id,
+            'is_fsm_product': False,
+        })
+
+        self.assertTrue(parent_fsm.is_fsm_product)
+        self.assertFalse(child_non_fsm.is_fsm_product)
+
+    def test_parent_child_category_both_fsm(self):
+        """Test parent and child categories both with FSM flag enabled"""
+        parent_fsm = self.ProductCategory.create({
+            'name': 'Parent FSM',
+            'is_fsm_product': True,
+        })
+        child_fsm = self.ProductCategory.create({
+            'name': 'Child FSM',
+            'parent_id': parent_fsm.id,
+            'is_fsm_product': True,
+        })
+
+        self.assertTrue(parent_fsm.is_fsm_product)
+        self.assertTrue(child_fsm.is_fsm_product)
+
+    def test_product_in_fsm_category(self):
+        """Test that products in FSM categories are correctly associated"""
+        fsm_category = self.ProductCategory.create({
+            'name': 'FSM Services',
+            'is_fsm_product': True,
+        })
+
+        product = self.env['product.product'].create({
+            'name': 'FSM Service Product',
+            'type': 'service',
+            'categ_id': fsm_category.id,
+        })
+
+        self.assertEqual(product.categ_id, fsm_category)
+        self.assertTrue(product.categ_id.is_fsm_product)
+
+    def test_product_category_switch_flag(self):
+        """Test switching a product category FSM flag after creating products in it"""
+        category = self.ProductCategory.create({
+            'name': 'Service Products',
+            'is_fsm_product': False,
+        })
+
+        product = self.env['product.product'].create({
+            'name': 'Service Product',
+            'type': 'service',
+            'categ_id': category.id,
+        })
+
+        # Initially not FSM
+        self.assertFalse(product.categ_id.is_fsm_product)
+
+        # Switch the flag
+        category.is_fsm_product = True
+
+        # Now the product's category is FSM
+        self.assertTrue(product.categ_id.is_fsm_product)
+
+    def test_write_multiple_categories_fsm_flag(self):
+        """Test bulk updating FSM flag on multiple categories"""
+        categories = self.ProductCategory.create([
+            {'name': 'Cat 1', 'is_fsm_product': False},
+            {'name': 'Cat 2', 'is_fsm_product': False},
+            {'name': 'Cat 3', 'is_fsm_product': False},
+        ])
+
+        categories.write({'is_fsm_product': True})
+
+        for category in categories:
+            self.assertTrue(category.is_fsm_product)

--- a/fsm_product_category_flag/views/product_category_views.xml
+++ b/fsm_product_category_flag/views/product_category_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="view_product_category_form_fsm_flag" model="ir.ui.view">
+            <field name="name">product.category.form.fsm.flag</field>
+            <field name="model">product.category</field>
+            <field name="inherit_id" ref="product.product_category_form_view"/>
+            <field name="arch" type="xml">
+                <xpath expr="//group" position="inside">
+                    <field name="is_fsm_product"/>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
Ports **fsm_product_category_flag** (v) into bemade-addons on 19.0, from the vendored 19.0-validated copy in DurPro (running in production on odoo19.durpro.com). Restores the single-source structure (symlinks DurPro addons/ -> bemade-addons/) as in 18.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)