### PR TITLE
odoo_herd_portal: client self-service portal (v1 epic)

### DIFF
--- a/odoo_herd_portal/__init__.py
+++ b/odoo_herd_portal/__init__.py
@@ -1,0 +1,1 @@
+# Odoo Herd Portal -- scaffolding pending spec sign-off (see docs/SPEC.md).

--- a/odoo_herd_portal/__init__.py
+++ b/odoo_herd_portal/__init__.py
@@ -1,3 +1,3 @@
-# Part of Odoo Herd Portal. See LICENSE file for full copyright and licensing details.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 from . import models
 from . import controllers

--- a/odoo_herd_portal/__manifest__.py
+++ b/odoo_herd_portal/__manifest__.py
@@ -48,6 +48,7 @@ See ``docs/SPEC.md`` for the full epic specification.
     "data": [
         "security/ir.model.access.csv",
         "security/k8s_portal_security.xml",
+        "views/k8s_odoo_instance_views.xml",
         "views/portal_templates.xml",
     ],
     "assets": {

--- a/odoo_herd_portal/__manifest__.py
+++ b/odoo_herd_portal/__manifest__.py
@@ -48,6 +48,7 @@ See ``docs/SPEC.md`` for the full epic specification.
     "data": [
         "security/ir.model.access.csv",
         "security/k8s_portal_security.xml",
+        "views/portal_templates.xml",
     ],
     "demo": [],
     "installable": True,

--- a/odoo_herd_portal/__manifest__.py
+++ b/odoo_herd_portal/__manifest__.py
@@ -1,0 +1,53 @@
+{
+    "name": "Odoo Herd Portal",
+    "version": "19.0.1.0.0",
+    "category": "Administration/Kubernetes",
+    "summary": "Client self-service portal for Bemade-hosted Odoo instances",
+    "description": """
+Odoo Herd Portal
+================
+
+Client self-service portal for Bemade-hosted Odoo instances. Extends
+``odoo_herd`` to give hosting customers scoped, read-mostly access to the
+instances they own, surfaced through the Odoo customer portal (``/my``).
+
+Each ``k8s.odoo.instance`` gains an ``allowed_partner_ids`` link; a portal
+user sees an instance only when their commercial partner is among the
+allowed partners.
+
+Version 1 features
+------------------
+* **Access & ownership** -- per-instance ``allowed_partner_ids`` with portal
+  record rules scoped to the user's commercial partner.
+* **Instance overview** -- instances grouped into Production and Staging
+  (from the existing ``environment`` field), showing status, version and URL.
+* **Live log viewer** -- live tail of an instance's web and cron pods with
+  in-browser search and filtering, streamed by a separate sidecar service and
+  authorised by a short-lived signed token. Recent logs only.
+* **Backups** -- list and download backups; trigger a backup; restore is
+  self-service on staging and back-office only on production.
+* **Self-service lifecycle** -- module upgrade and staging refresh, with an
+  auto-backup-before-upgrade guardrail and an action audit trail.
+
+Planned (v2)
+------------
+* Client-initiated staging *creation* within a quota.
+* Historical log search backed by Loki.
+* Instance restart, implemented as an operator-reconciled action on the
+  ``OdooInstance`` CRD.
+
+See ``docs/SPEC.md`` for the full epic specification.
+""",
+    "author": "Bemade Inc.",
+    "website": "https://www.bemade.org",
+    "license": "LGPL-3",
+    "depends": [
+        "odoo_herd",
+        "portal",
+    ],
+    "data": [],
+    "demo": [],
+    "installable": True,
+    "application": False,
+    "auto_install": False,
+}

--- a/odoo_herd_portal/__manifest__.py
+++ b/odoo_herd_portal/__manifest__.py
@@ -50,6 +50,11 @@ See ``docs/SPEC.md`` for the full epic specification.
         "security/k8s_portal_security.xml",
         "views/portal_templates.xml",
     ],
+    "assets": {
+        "web.assets_frontend": [
+            "odoo_herd_portal/static/src/js/log_viewer.js",
+        ],
+    },
     "demo": [],
     "installable": True,
     "application": False,

--- a/odoo_herd_portal/__manifest__.py
+++ b/odoo_herd_portal/__manifest__.py
@@ -45,7 +45,10 @@ See ``docs/SPEC.md`` for the full epic specification.
         "odoo_herd",
         "portal",
     ],
-    "data": [],
+    "data": [
+        "security/ir.model.access.csv",
+        "security/k8s_portal_security.xml",
+    ],
     "demo": [],
     "installable": True,
     "application": False,

--- a/odoo_herd_portal/controllers/__init__.py
+++ b/odoo_herd_portal/controllers/__init__.py
@@ -1,2 +1,2 @@
-# Part of Odoo Herd Portal. See LICENSE file for full copyright and licensing details.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 from . import portal

--- a/odoo_herd_portal/controllers/__init__.py
+++ b/odoo_herd_portal/controllers/__init__.py
@@ -1,3 +1,2 @@
 # Part of Odoo Herd Portal. See LICENSE file for full copyright and licensing details.
-from . import models
-from . import controllers
+from . import portal

--- a/odoo_herd_portal/controllers/portal.py
+++ b/odoo_herd_portal/controllers/portal.py
@@ -66,20 +66,41 @@ class CustomerPortal(CustomerPortal):
     def portal_my_instance_detail(self, instance_id, access_token=None, **kw):
         """Render the detail page for one owned instance.
 
-        Uses the standard ``_document_check_access`` pattern: a foreign or
-        non-existent instance raises ``AccessError`` / ``MissingError`` (the
+        ``_document_check_access`` is used ONLY as the access *check*: a foreign
+        or non-existent instance raises ``AccessError`` / ``MissingError`` (the
         record rule empties/denies it), which we map to a redirect to the
         instances list rather than leaking any data.
+
+        It returns the record **sudoed**, on which BOTH Feature A's field
+        ``groups=`` and the record rule are bypassed. We therefore re-browse the
+        record AS THE PORTAL USER for rendering, so the field-level secrecy and
+        the record rule are reinstated on the detail page -- the template's
+        secrecy no longer hinges on which fields it happens to reference.
         """
         try:
-            instance_sudo = self._document_check_access(
+            self._document_check_access(
                 "k8s.odoo.instance", instance_id, access_token
             )
         except (AccessError, MissingError):
             return request.redirect("/my/instances")
+        # Re-browse in the portal user's context (NOT sudo): field groups= and
+        # the record rule now apply on the rendered record.
+        instance = request.env["k8s.odoo.instance"].browse(instance_id)
+        # The source production instance is a cross-record reference that is NOT
+        # constrained to share this instance's allowed_partner_ids, so it may be
+        # owned by another company. Reading ``.name`` on a non-readable related
+        # record raises AccessError under the record rule, so resolve it through
+        # an explicit read-access filter and only pass the name when the user
+        # may actually read that record. ``name`` (never ``display_name``, which
+        # leaks under su/k8s context) is used.
+        prod_source_name = False
+        prod_source = instance.production_instance_id
+        if prod_source and prod_source._filtered_access("read"):
+            prod_source_name = prod_source.name
         values = {
             "page_name": "instance_detail",
-            "instance": instance_sudo,
+            "instance": instance,
+            "prod_source_name": prod_source_name,
         }
         return request.render(
             "odoo_herd_portal.portal_instance_detail", values

--- a/odoo_herd_portal/controllers/portal.py
+++ b/odoo_herd_portal/controllers/portal.py
@@ -297,6 +297,169 @@ class CustomerPortal(CustomerPortal):
             )
         return request.redirect("/my/instances/%d/backups" % target.id)
 
+    # ==================================================================
+    # Feature E -- self-serve lifecycle (upgrade + staging-refresh)
+    # ==================================================================
+    # The portal triggers the instance's STANDARD upgrade: ``odoo -u all``
+    # (upgrade every already-installed module). The module list is a
+    # SERVER-FIXED constant, never derived from the request, so the portal can
+    # never be used as an install-anything vector (no modules_install reaches
+    # the k8s call). See the "safe targets" decision in the module docs.
+    _UPGRADE_STANDARD_MODULES = "all"
+
+    def _subscribe_allowed_partners(self, instance):
+        """Subscribe the instance's allowed partners as chatter followers.
+
+        Called (under sudo) when a lifecycle action is initiated so the
+        completion/failure notification posted on the terminal-state transition
+        reaches the client. ``instance`` must already be a sudoed recordset.
+        """
+        partner_ids = instance.allowed_partner_ids.ids
+        if partner_ids:
+            instance.message_subscribe(partner_ids=partner_ids)
+
+    @http.route(
+        ["/my/instances/<int:instance_id>/upgrade"],
+        type="http",
+        auth="user",
+        methods=["POST"],
+        website=True,
+    )
+    def portal_instance_upgrade(self, instance_id, **post):
+        """Trigger the instance's STANDARD upgrade (CSRF-protected POST).
+
+        Guardrails:
+
+        * Ownership is checked AS THE USER first; a non-owned instance id is
+          refused without creating anything (IDOR protection).
+        * **Auto-backup first:** a backup of the instance is created (reusing
+          Feature D's k8s.backup.wizard path) BEFORE the upgrade, so the upgrade
+          always follows a fresh backup.
+        * **Safe target only:** the upgrade module list is the server-fixed
+          ``_UPGRADE_STANDARD_MODULES`` constant; NOTHING from the request body
+          reaches the upgrade job. ``modules_install`` is always empty.
+
+        Only after the ownership check do we escalate to ``sudo()`` to reuse the
+        existing wizard/job pipeline (we never reimplement the k8s call).
+        """
+        instance = self._check_instance_access(instance_id)
+        if instance is None:
+            return request.redirect("/my/instances")
+        try:
+            sudo_instance = instance.sudo()
+            # Subscribe the client so they receive the terminal notification.
+            self._subscribe_allowed_partners(sudo_instance)
+            # GUARDRAIL 1 -- auto-backup BEFORE the upgrade.
+            backup_wizard = (
+                request.env["k8s.backup.wizard"]
+                .sudo()
+                .create(
+                    {
+                        "instance_id": instance.id,
+                        "format": "zip",
+                        "with_filestore": True,
+                    }
+                )
+            )
+            backup_wizard.action_create_backup()
+            # GUARDRAIL 2 -- standard upgrade, server-fixed module list only.
+            upgrade_wizard = (
+                request.env["k8s.upgrade.wizard"]
+                .sudo()
+                .create(
+                    {
+                        "instance_id": instance.id,
+                        "modules": self._UPGRADE_STANDARD_MODULES,
+                        "modules_install": "",
+                    }
+                )
+            )
+            upgrade_wizard.action_upgrade()
+            _portal_audit(
+                sudo_instance,
+                _("Module upgrade (standard, after auto-backup)"),
+            )
+        except (UserError, AccessError) as exc:
+            _logger.warning(
+                "Portal upgrade failed for instance %s: %s", instance_id, exc
+            )
+            return request.redirect(
+                "/my/instances/%d?error=upgrade" % instance_id
+            )
+        return request.redirect("/my/instances/%d" % instance_id)
+
+    @http.route(
+        ["/my/instances/<int:instance_id>/refresh-staging"],
+        type="http",
+        auth="user",
+        methods=["POST"],
+        website=True,
+    )
+    def portal_instance_refresh_staging(self, instance_id, **post):
+        """Refresh a staging instance from its prod source (CSRF POST).
+
+        Valid ONLY when the target is a staging instance the user owns AND it
+        has a ``production_instance_id`` the user also owns. The target's
+        ``environment == 'staging'`` is asserted server-side: a production
+        target is refused outright (the control is never exposed on production).
+        Source is bound server-side to ``production_instance_id`` -- never from
+        the request. Ownership of BOTH target and source is checked as the user
+        before escalating to ``sudo()`` to reuse the existing refresh wizard.
+        """
+        target = self._check_instance_access(instance_id)
+        if target is None:
+            return request.redirect("/my/instances")
+        # Environment gate: staging refresh is NEVER offered on production.
+        if target.environment != "staging":
+            _logger.warning(
+                "Portal staging-refresh refused: instance %s is not staging.",
+                target.id,
+            )
+            return request.redirect(
+                "/my/instances/%d?error=not_staging" % target.id
+            )
+        # Source is the configured production_instance_id; ownership-check it AS
+        # THE USER too (it may belong to another company).
+        source = self._check_instance_access(target.production_instance_id.id)
+        if source is None:
+            _logger.warning(
+                "Portal staging-refresh refused: no owned production source "
+                "for instance %s.",
+                target.id,
+            )
+            return request.redirect(
+                "/my/instances/%d?error=no_source" % target.id
+            )
+        try:
+            sudo_target = target.sudo()
+            self._subscribe_allowed_partners(sudo_target)
+            wizard = (
+                request.env["k8s.staging.refresh.wizard"]
+                .sudo()
+                .create(
+                    {
+                        "target_instance_id": target.id,
+                        "source_instance_id": source.id,
+                        "confirmation_name": sudo_target.name,
+                    }
+                )
+            )
+            wizard.action_refresh()
+            _portal_audit(
+                sudo_target,
+                _("Staging refresh from %s") % source.sudo().name,
+            )
+        except (UserError, AccessError) as exc:
+            _logger.warning(
+                "Portal staging-refresh failed for instance %s: %s",
+                instance_id,
+                exc,
+            )
+            return request.redirect(
+                "/my/instances/%d?error=refresh" % target.id
+            )
+        return request.redirect("/my/instances/%d" % target.id)
+
     @http.route(
         ["/my/instances/backup/<int:backup_id>/download"],
         type="http",

--- a/odoo_herd_portal/controllers/portal.py
+++ b/odoo_herd_portal/controllers/portal.py
@@ -48,6 +48,37 @@ def _portal_audit(instance, action):
     )
 
 
+def _record_portal_initiator(model_name, instance_id, partner_id):
+    """Stamp ``portal_initiator_id`` on the job just created by a wizard.
+
+    The wizard actions (``action_create_backup`` / ``action_upgrade`` /
+    ``action_refresh``) return an action dict, not the created job, and we must
+    not modify the base ``odoo_herd`` wizards. The job is created synchronously
+    in this same transaction, so the most-recent job for ``instance_id`` is the
+    one we just triggered; stamp the acting portal user's partner on it so the
+    terminal-state notification can address the initiator directly.
+
+    The terminal CR-creation hook fires during ``create`` (before this write),
+    so stamping the initiator afterwards is safe. ``instance_field`` differs by
+    model (``instance_id`` vs ``target_instance_id``); both are passed by key.
+    """
+    if not partner_id:
+        return
+    Job = request.env[model_name].sudo()
+    instance_field = (
+        "target_instance_id"
+        if model_name == "k8s.odoo.staging.refresh"
+        else "instance_id"
+    )
+    job = Job.search(
+        [(instance_field, "=", instance_id)],
+        order="id desc",
+        limit=1,
+    )
+    if job:
+        job.portal_initiator_id = partner_id
+
+
 class CustomerPortal(CustomerPortal):
     def _prepare_home_portal_values(self, counters):
         """Add the instance count to the portal home cards."""
@@ -256,6 +287,8 @@ class CustomerPortal(CustomerPortal):
         instance = self._check_instance_access(instance_id)
         if instance is None:
             return request.redirect("/my/instances")
+        # Capture the acting portal user's partner BEFORE escalating to sudo.
+        initiator_partner_id = request.env.user.partner_id.id
         fmt = post.get("format") or "zip"
         if fmt not in ("zip", "dump", "sql"):
             fmt = "zip"
@@ -272,6 +305,9 @@ class CustomerPortal(CustomerPortal):
                 )
             )
             wizard.action_create_backup()
+            _record_portal_initiator(
+                "k8s.odoo.backup", instance.id, initiator_partner_id
+            )
             # Audit on the sudoed instance, authored by the portal user.
             _portal_audit(
                 instance.sudo(),
@@ -382,6 +418,8 @@ class CustomerPortal(CustomerPortal):
         instance = self._check_instance_access(instance_id)
         if instance is None:
             return request.redirect("/my/instances")
+        # Capture the acting portal user's partner BEFORE escalating to sudo.
+        initiator_partner_id = request.env.user.partner_id.id
         try:
             sudo_instance = instance.sudo()
             # GUARDRAIL 1 -- auto-backup BEFORE the upgrade.
@@ -397,6 +435,9 @@ class CustomerPortal(CustomerPortal):
                 )
             )
             backup_wizard.action_create_backup()
+            _record_portal_initiator(
+                "k8s.odoo.backup", instance.id, initiator_partner_id
+            )
             # GUARDRAIL 2 -- standard upgrade, server-fixed module list only.
             upgrade_wizard = (
                 request.env["k8s.upgrade.wizard"]
@@ -410,6 +451,9 @@ class CustomerPortal(CustomerPortal):
                 )
             )
             upgrade_wizard.action_upgrade()
+            _record_portal_initiator(
+                "k8s.odoo.upgrade", instance.id, initiator_partner_id
+            )
             _portal_audit(
                 sudo_instance,
                 _("Module upgrade (standard, after auto-backup)"),
@@ -465,6 +509,8 @@ class CustomerPortal(CustomerPortal):
             return request.redirect(
                 "/my/instances/%d?error=no_source" % target.id
             )
+        # Capture the acting portal user's partner BEFORE escalating to sudo.
+        initiator_partner_id = request.env.user.partner_id.id
         try:
             sudo_target = target.sudo()
             wizard = (
@@ -479,6 +525,9 @@ class CustomerPortal(CustomerPortal):
                 )
             )
             wizard.action_refresh()
+            _record_portal_initiator(
+                "k8s.odoo.staging.refresh", target.id, initiator_partner_id
+            )
             _portal_audit(
                 sudo_target,
                 _("Staging refresh from %s") % source.sudo().name,

--- a/odoo_herd_portal/controllers/portal.py
+++ b/odoo_herd_portal/controllers/portal.py
@@ -134,6 +134,54 @@ class CustomerPortal(CustomerPortal):
         )
 
     # ==================================================================
+    # Feature C -- live log viewer (token mint + iframe/postMessage handoff)
+    # ==================================================================
+    # ir.config_parameter key for the sidecar SPA base URL (e.g.
+    # ``https://logs.bemade.org``). The token is NEVER placed in this URL.
+    _LOG_VIEWER_URL_PARAM = "odoo_herd_portal.log_viewer_url"
+
+    @http.route(
+        ["/my/instances/<int:instance_id>/logs"],
+        type="http",
+        auth="user",
+        website=True,
+    )
+    def portal_instance_logs(self, instance_id, **kw):
+        """Render the live log viewer page for one owned instance.
+
+        Ownership is checked AS THE USER first (``_check_instance_access``):
+        a foreign/non-existent id yields ``None`` and we redirect WITHOUT
+        minting a token (IDOR guard -- no scope token, no namespace leak).
+
+        Only after that check do we mint the short-lived signed scope token
+        (``_mint_log_token`` reads the group-hidden namespace/name under sudo).
+        The token is handed to the iframe via ``postMessage`` (see the static
+        JS asset); it is embedded in a data attribute, NEVER in the iframe
+        ``src`` / query string -- so it is not logged by proxies. The signing
+        secret never reaches the page.
+        """
+        instance = self._check_instance_access(instance_id)
+        if instance is None:
+            return request.redirect("/my/instances")
+        # Token mint happens strictly after the ownership check above.
+        log_token = instance._mint_log_token()
+        viewer_url = (
+            request.env["ir.config_parameter"]
+            .sudo()
+            .get_param(self._LOG_VIEWER_URL_PARAM)
+            or ""
+        )
+        values = {
+            "page_name": "instance_logs",
+            "instance": instance,
+            "log_token": log_token,
+            "log_viewer_url": viewer_url,
+        }
+        return request.render(
+            "odoo_herd_portal.portal_instance_logs", values
+        )
+
+    # ==================================================================
     # Feature D -- backups self-service
     # ==================================================================
     def _check_instance_access(self, instance_id):

--- a/odoo_herd_portal/controllers/portal.py
+++ b/odoo_herd_portal/controllers/portal.py
@@ -307,17 +307,6 @@ class CustomerPortal(CustomerPortal):
     # the k8s call). See the "safe targets" decision in the module docs.
     _UPGRADE_STANDARD_MODULES = "all"
 
-    def _subscribe_allowed_partners(self, instance):
-        """Subscribe the instance's allowed partners as chatter followers.
-
-        Called (under sudo) when a lifecycle action is initiated so the
-        completion/failure notification posted on the terminal-state transition
-        reaches the client. ``instance`` must already be a sudoed recordset.
-        """
-        partner_ids = instance.allowed_partner_ids.ids
-        if partner_ids:
-            instance.message_subscribe(partner_ids=partner_ids)
-
     @http.route(
         ["/my/instances/<int:instance_id>/upgrade"],
         type="http",
@@ -347,8 +336,6 @@ class CustomerPortal(CustomerPortal):
             return request.redirect("/my/instances")
         try:
             sudo_instance = instance.sudo()
-            # Subscribe the client so they receive the terminal notification.
-            self._subscribe_allowed_partners(sudo_instance)
             # GUARDRAIL 1 -- auto-backup BEFORE the upgrade.
             backup_wizard = (
                 request.env["k8s.backup.wizard"]
@@ -432,7 +419,6 @@ class CustomerPortal(CustomerPortal):
             )
         try:
             sudo_target = target.sudo()
-            self._subscribe_allowed_partners(sudo_target)
             wizard = (
                 request.env["k8s.staging.refresh.wizard"]
                 .sudo()

--- a/odoo_herd_portal/controllers/portal.py
+++ b/odoo_herd_portal/controllers/portal.py
@@ -14,11 +14,38 @@ ORM auto-scopes to the user's commercial partner. The controller never reads a
 non-whitelisted field, so it can rely on the field-level secrecy too.
 """
 
-from odoo import http
-from odoo.exceptions import AccessError, MissingError
+import logging
+
+from odoo import _, http
+from odoo.exceptions import AccessError, MissingError, UserError
 from odoo.http import request
 
 from odoo.addons.portal.controllers.portal import CustomerPortal
+
+_logger = logging.getLogger(__name__)
+
+
+def _portal_audit(instance, action):
+    """Post a lightweight audit message to an instance's chatter.
+
+    Reusable by Feature E (lifecycle actions). ``instance`` is a sudoed
+    recordset (chatter posting needs write access the portal user lacks), but
+    the author is forced to the *acting* portal user's partner so the chatter
+    records WHO performed the action -- ``who/what/when`` per SPEC §5. The body
+    states the action came from the self-service portal.
+    """
+    user = request.env.user
+    instance.message_post(
+        body=_(
+            "Portal self-service action: %(action)s "
+            "(initiated by %(user)s via the client portal).",
+            action=action,
+            user=user.name,
+        ),
+        author_id=user.partner_id.id,
+        message_type="comment",
+        subtype_xmlid="mail.mt_note",
+    )
 
 
 class CustomerPortal(CustomerPortal):
@@ -105,3 +132,206 @@ class CustomerPortal(CustomerPortal):
         return request.render(
             "odoo_herd_portal.portal_instance_detail", values
         )
+
+    # ==================================================================
+    # Feature D -- backups self-service
+    # ==================================================================
+    def _check_instance_access(self, instance_id):
+        """Return the instance browsed AS THE PORTAL USER, or None.
+
+        The read happens in the user's own env so the Feature A record rule
+        applies: a foreign/non-existent id yields an empty/denied recordset and
+        we return ``None``. Callers MUST treat ``None`` as "refuse" and only
+        escalate to ``sudo()`` once a non-None instance is returned. This is the
+        ownership-check-as-user-THEN-sudo pattern that prevents IDOR.
+        """
+        instance = request.env["k8s.odoo.instance"].browse(instance_id)
+        try:
+            if not instance.exists() or not instance._filtered_access("read"):
+                return None
+        except (AccessError, MissingError):
+            return None
+        return instance
+
+    def _check_backup_access(self, backup_id):
+        """Return the backup browsed AS THE PORTAL USER, or None (refuse)."""
+        backup = request.env["k8s.odoo.backup"].browse(backup_id)
+        try:
+            if not backup.exists() or not backup._filtered_access("read"):
+                return None
+        except (AccessError, MissingError):
+            return None
+        return backup
+
+    @http.route(
+        ["/my/instances/<int:instance_id>/backups"],
+        type="http",
+        auth="user",
+        website=True,
+    )
+    def portal_instance_backups(self, instance_id, **kw):
+        """List the backups of one owned instance (whitelisted fields only).
+
+        The backup record rule auto-scopes ``search`` to backups whose instance
+        the user owns; we additionally constrain to this instance.
+        """
+        instance = self._check_instance_access(instance_id)
+        if instance is None:
+            return request.redirect("/my/instances")
+        backups = request.env["k8s.odoo.backup"].search(
+            [("instance_id", "=", instance.id)]
+        )
+        values = {
+            "page_name": "instance_backups",
+            "instance": instance,
+            "backups": backups,
+            "default_url": "/my/instances/%d/backups" % instance.id,
+        }
+        return request.render(
+            "odoo_herd_portal.portal_instance_backups", values
+        )
+
+    @http.route(
+        ["/my/instances/<int:instance_id>/backup"],
+        type="http",
+        auth="user",
+        methods=["POST"],
+        website=True,
+    )
+    def portal_instance_backup_now(self, instance_id, **post):
+        """Trigger a new backup for an owned instance (CSRF-protected POST).
+
+        Ownership is checked AS THE USER first; only then do we reuse the
+        existing k8s.backup.wizard logic under ``sudo()``. A non-owned instance
+        id is refused without creating anything (IDOR protection).
+        """
+        instance = self._check_instance_access(instance_id)
+        if instance is None:
+            return request.redirect("/my/instances")
+        fmt = post.get("format") or "zip"
+        if fmt not in ("zip", "dump", "sql"):
+            fmt = "zip"
+        try:
+            wizard = (
+                request.env["k8s.backup.wizard"]
+                .sudo()
+                .create(
+                    {
+                        "instance_id": instance.id,
+                        "format": fmt,
+                        "with_filestore": fmt == "zip",
+                    }
+                )
+            )
+            wizard.action_create_backup()
+            # Audit on the sudoed instance, authored by the portal user.
+            _portal_audit(
+                instance.sudo(),
+                _("Backup requested (format %s)") % fmt.upper(),
+            )
+        except (UserError, AccessError) as exc:
+            _logger.warning(
+                "Portal backup-now failed for instance %s: %s",
+                instance_id,
+                exc,
+            )
+            return request.redirect(
+                "/my/instances/%d/backups?error=backup" % instance_id
+            )
+        return request.redirect("/my/instances/%d/backups" % instance_id)
+
+    @http.route(
+        ["/my/instances/backup/<int:backup_id>/restore"],
+        type="http",
+        auth="user",
+        methods=["POST"],
+        website=True,
+    )
+    def portal_backup_restore(self, backup_id, **post):
+        """Restore a backup onto its instance -- STAGING ONLY (CSRF POST).
+
+        Ownership of the backup is checked AS THE USER; then the TARGET
+        instance's environment must be ``staging`` -- a production target is
+        refused outright (never exposed). On staging, the existing
+        k8s.restore.backup.wizard flow is reused under ``sudo()``.
+        """
+        backup = self._check_backup_access(backup_id)
+        if backup is None:
+            return request.redirect("/my/instances")
+        # Re-derive the target instance via an owned read (record rule applies).
+        target = self._check_instance_access(backup.instance_id.id)
+        if target is None:
+            return request.redirect("/my/instances")
+        # Environment gate: production restore is NEVER self-service.
+        if target.environment != "staging":
+            _logger.warning(
+                "Portal restore refused: target instance %s is not staging.",
+                target.id,
+            )
+            return request.redirect(
+                "/my/instances/%d/backups?error=prod_restore" % target.id
+            )
+        try:
+            wizard = (
+                request.env["k8s.restore.backup.wizard"]
+                .sudo()
+                .create(
+                    {
+                        "backup_id": backup.id,
+                        "target_instance_id": target.id,
+                        "confirmation_name": target.sudo().name,
+                    }
+                )
+            )
+            wizard.action_restore()
+            _portal_audit(
+                target.sudo(),
+                _("Staging restore from backup %s") % backup.sudo().name,
+            )
+        except (UserError, AccessError) as exc:
+            _logger.warning(
+                "Portal restore failed for backup %s: %s", backup_id, exc
+            )
+            return request.redirect(
+                "/my/instances/%d/backups?error=restore" % target.id
+            )
+        return request.redirect("/my/instances/%d/backups" % target.id)
+
+    @http.route(
+        ["/my/instances/backup/<int:backup_id>/download"],
+        type="http",
+        auth="user",
+        website=True,
+    )
+    def portal_backup_download(self, backup_id, **kw):
+        """Redirect to a fresh S3 pre-signed URL for an owned backup.
+
+        Ownership is checked AS THE USER first; only then, under ``sudo()``, is
+        a pre-signed URL generated (reading S3 creds from the cluster secret).
+        Portal users NEVER read the S3 credentials or the stored download_url --
+        the presign is minted server-side and only the resulting URL is exposed
+        via a redirect. A non-owned backup id is refused (no presign).
+        """
+        backup = self._check_backup_access(backup_id)
+        if backup is None:
+            return request.redirect("/my/instances")
+        if backup.state != "completed":
+            return request.redirect(
+                "/my/instances/%d/backups?error=not_ready"
+                % backup.instance_id.id
+            )
+        try:
+            url = backup.sudo()._generate_presigned_url()
+        except (UserError, AccessError) as exc:
+            _logger.warning(
+                "Portal download presign failed for backup %s: %s",
+                backup_id,
+                exc,
+            )
+            return request.redirect(
+                "/my/instances/%d/backups?error=download"
+                % backup.instance_id.id
+            )
+        # local=False: the presigned URL is an external S3/MinIO endpoint, so
+        # the host must be preserved (the default local=True would strip it).
+        return request.redirect(url, local=False)

--- a/odoo_herd_portal/controllers/portal.py
+++ b/odoo_herd_portal/controllers/portal.py
@@ -1,4 +1,4 @@
-# Part of Odoo Herd Portal. See LICENSE file for full copyright and licensing details.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 """Feature B -- client-facing instance overview portal controller.
 
 Extends the standard ``CustomerPortal`` with:

--- a/odoo_herd_portal/controllers/portal.py
+++ b/odoo_herd_portal/controllers/portal.py
@@ -1,0 +1,86 @@
+# Part of Odoo Herd Portal. See LICENSE file for full copyright and licensing details.
+"""Feature B -- client-facing instance overview portal controller.
+
+Extends the standard ``CustomerPortal`` with:
+
+* an "Odoo Instances" card + count on ``/my`` (the portal home);
+* ``/my/instances`` -- the user's instances grouped into Production and
+  Staging by the ``environment`` field;
+* ``/my/instances/<id>`` -- a per-instance detail page.
+
+Isolation is enforced entirely by Feature A's record rule: the controller
+issues an ordinary ``search([])`` / ``browse()`` as the portal user, so the
+ORM auto-scopes to the user's commercial partner. The controller never reads a
+non-whitelisted field, so it can rely on the field-level secrecy too.
+"""
+
+from odoo import http
+from odoo.exceptions import AccessError, MissingError
+from odoo.http import request
+
+from odoo.addons.portal.controllers.portal import CustomerPortal
+
+
+class CustomerPortal(CustomerPortal):
+    def _prepare_home_portal_values(self, counters):
+        """Add the instance count to the portal home cards."""
+        values = super()._prepare_home_portal_values(counters)
+        if "instance_count" in counters:
+            # Record rule scopes the count to the user's own instances.
+            values["instance_count"] = request.env[
+                "k8s.odoo.instance"
+            ].search_count([])
+        return values
+
+    @http.route(["/my/instances"], type="http", auth="user", website=True)
+    def portal_my_instances(self, **kw):
+        """List the user's instances grouped into Production and Staging.
+
+        The Feature A record rule auto-scopes ``search([])`` to the portal
+        user's owned instances, so no manual partner filter is needed.
+        """
+        Instance = request.env["k8s.odoo.instance"]
+        instances = Instance.search([])
+        production = instances.filtered(
+            lambda inst: inst.environment == "production"
+        )
+        staging = instances.filtered(
+            lambda inst: inst.environment == "staging"
+        )
+        values = {
+            "page_name": "instances",
+            "production_instances": production,
+            "staging_instances": staging,
+            "default_url": "/my/instances",
+        }
+        return request.render(
+            "odoo_herd_portal.portal_my_instances", values
+        )
+
+    @http.route(
+        ["/my/instances/<int:instance_id>"],
+        type="http",
+        auth="user",
+        website=True,
+    )
+    def portal_my_instance_detail(self, instance_id, access_token=None, **kw):
+        """Render the detail page for one owned instance.
+
+        Uses the standard ``_document_check_access`` pattern: a foreign or
+        non-existent instance raises ``AccessError`` / ``MissingError`` (the
+        record rule empties/denies it), which we map to a redirect to the
+        instances list rather than leaking any data.
+        """
+        try:
+            instance_sudo = self._document_check_access(
+                "k8s.odoo.instance", instance_id, access_token
+            )
+        except (AccessError, MissingError):
+            return request.redirect("/my/instances")
+        values = {
+            "page_name": "instance_detail",
+            "instance": instance_sudo,
+        }
+        return request.render(
+            "odoo_herd_portal.portal_instance_detail", values
+        )

--- a/odoo_herd_portal/docs/SIDECAR.md
+++ b/odoo_herd_portal/docs/SIDECAR.md
@@ -1,0 +1,238 @@
+# Log-Stream Sidecar — Design (Feature C companion)
+
+**Status:** DESIGN ONLY. The Odoo side of Feature C (token mint + portal page)
+lives in this module and is tested in `tests/test_log_viewer.py`. The streaming
+service described here is a **separate** deployable (`odoo-herd-log-sidecar`)
+that has **not** been verified against a cluster. This document is the
+contract the sidecar must honour; the scaffold implementation lives in its own
+repo (`~/src/odoo-herd-log-sidecar/`, local-only at time of writing).
+
+---
+
+## 1. Why a separate service
+
+Odoo must never hold a live, long-lived streaming connection open per portal
+user, and must never carry a cluster credential that can `get pods/log`. The
+log-stream sidecar is a small, single-purpose Go service that:
+
+- runs **in** the RKE2 cluster with its own **least-privilege** ServiceAccount
+  (`get,list,watch` on `pods`, `get` on `pods/log` — nothing else);
+- accepts a request only if it carries a **valid, unexpired, signed scope
+  token** minted by Odoo;
+- derives *all* scoping (namespace + label selector) **from the verified token
+  payload** — never from any request parameter;
+- discovers the matching pods, tails their logs, multiplexes them into one
+  stream, and writes merged lines back to the browser.
+
+The trust boundary is the HMAC: Odoo and the sidecar share a 64-hex-char secret
+(via a k8s `Secret`); possession of a freshly minted token is the *only* thing
+that authorises a stream, and the token already encodes exactly what the
+authenticated, record-rule-checked portal user is allowed to see.
+
+---
+
+## 2. Request flow
+
+```
+  Browser (portal)                 Odoo                       Sidecar (in-cluster)
+  ----------------                 ----                       --------------------
+  GET /my/instances/<id>/logs ───▶ record-rule ownership
+                                   check (IDOR guard);
+                                   _mint_log_token() under
+                                   sudo reads ns + name
+                                   AFTER ownership proven
+                                ◀── HTML page: <iframe src=
+                                    "https://logs.bemade.org">
+                                    + token in data-log-scope
+                                    (NOT in the iframe URL)
+
+  page JS: postMessage(token) ───▶ iframe (logs.bemade.org SPA)
+
+  iframe SPA: fetch("/stream",
+    headers:{Authorization:
+      "Bearer <token>"})       ───────────────────────────────▶ verify token (HMAC,
+                                                                   exp); derive ns+sel
+                                                                   from PAYLOAD ONLY
+                                                                 list pods by ns+sel
+                                                                 (informer); Follow:true
+                                                                 log per pod; fan-in
+                              ◀───────────────────────────────── chunked/streamed
+                                  ReadableStream of merged lines
+  react-logviewer renders +
+  client-side search/filter
+```
+
+Key properties of the handoff:
+
+- The token is delivered to the iframe via **`postMessage`**, and sent to the
+  sidecar in an **`Authorization: Bearer`** header — it is therefore **never** a
+  URL query parameter (no token in access logs, referrers, or browser history).
+  The Odoo test (`test_logs_page_owned_renders_iframe_no_leak`) asserts the
+  token is absent from the iframe `src` and that `token=` does not appear in the
+  iframe tag.
+- The iframe is served from a **different origin** (`logs.bemade.org`), so the
+  parent page hands the token across with a targeted `postMessage` (the SPA must
+  validate `event.origin` against the expected Odoo origin before accepting it).
+
+---
+
+## 3. Token-verification contract (VERBATIM — the sidecar MUST implement this)
+
+The mint side is `K8sOdooInstance._mint_log_token` in
+`models/k8s_odoo_instance.py`. The reference verifier is `_verify_token` in
+`tests/test_log_viewer.py`. Both are stdlib-only; no JWT library.
+
+### Wire format
+
+```
+token = b64url(payload_json) + "." + b64url( HMAC_SHA256(secret, b64url(payload_json)) )
+```
+
+- **`b64url`** = URL-safe base64 with the `=` padding **stripped**.
+- **`payload_json`** = `json.dumps(payload, separators=(",",":"), sort_keys=True)`
+  — i.e. compact separators, keys sorted, UTF-8 bytes.
+- **The HMAC is computed over the ASCII bytes of the b64url payload _string_**
+  (the first token segment as text), **not** over the raw payload JSON bytes.
+  This is the single most important detail to get right.
+- **`secret`** = the UTF-8 bytes of a 64-hex-char string (256 bits). Shared with
+  Odoo out of band via a k8s `Secret`. Odoo stores it in
+  `ir.config_parameter` under key `odoo_herd_portal.log_token_secret` and
+  generates it on first use (`secrets.token_hex(32)`).
+
+### Payload claims
+
+```json
+{
+  "exp": <epoch int>,                         // iat + 120
+  "iat": <epoch int>,
+  "iid": <instance id int>,
+  "ns":  "<namespace>",
+  "sel": "bemade.org/instance=<instance name>"
+}
+```
+
+(Keys are emitted sorted; do not rely on order when parsing — parse as a map.)
+
+### Verify algorithm
+
+1. Split the token on the **first** `.` into `payload_b64` and `sig_b64`.
+   Reject if there is not exactly one separator.
+2. Recompute `expected = HMAC_SHA256(secret_utf8, payload_b64_ascii)` (digest =
+   raw 32 bytes).
+3. `b64url`-decode `sig_b64` (re-pad to a multiple of 4 with `=` first) → `got`.
+4. **Constant-time compare** `expected` vs `got` (`hmac.compare_digest` /
+   `crypto/hmac.Equal` / `subtle.ConstantTimeCompare`). Reject on mismatch.
+5. `b64url`-decode `payload_b64` (re-pad first) and JSON-parse it.
+6. Reject if `exp < now` (expired).
+7. **Trust ONLY `ns` and `sel` from the verified payload for scoping. Never read
+   namespace/selector/instance from any request parameter, header, query, or
+   body.** `iid` is informational/audit only.
+
+Re-padding rule (matches `_b64url_decode` in the test):
+`pad = "=" * (-len(segment) % 4)`.
+
+---
+
+## 4. Pod discovery + multiplex (Stern pattern)
+
+### Cluster facts
+
+- Per-instance pods carry the label **`bemade.org/instance=<name>`**. This
+  covers the web pod, the `<name>-cron` pod, and transient Job pods — all share
+  it.
+- Namespaces are **per-client**, so multiple instances can live in one
+  namespace. Scope must use **both** the namespace (`ns`) **and** the label
+  selector (`sel`); the namespace alone is not sufficient isolation.
+
+### Design
+
+1. From the verified token take `ns` and `sel`.
+2. Start a **pod informer** (or a `Watch` + initial `List`) scoped to namespace
+   `ns` with label selector `sel`. This gives add/update/delete events as pods
+   come and go (rollouts, cron pods spinning up, Job pods finishing).
+3. For each **Running** pod (and each container, if multi-container), spawn a
+   goroutine that opens a log stream with `Follow: true` (and a small
+   `TailLines`/`SinceSeconds` so the user sees recent context, not the whole
+   history). Each goroutine reads lines and pushes
+   `{pod, container, ts, line}` records onto a shared **fan-in channel**.
+4. A single writer goroutine drains the fan-in channel and writes merged,
+   labelled lines to the HTTP response, flushing as it goes.
+5. On pod **delete**, cancel that pod's goroutine (context cancellation). On
+   pod **add**, attach a new goroutine. This is the **Stern** model: the set of
+   tailed pods tracks the live selector, so a rolling deploy seamlessly moves
+   the stream from old to new pods.
+6. When the client disconnects (request context cancelled) or the token would
+   expire mid-stream, tear everything down: cancel all per-pod contexts, stop
+   the informer, close the fan-in channel.
+
+Notes:
+
+- Tokens are short-lived (~120 s). The stream itself may outlive the token; the
+  intended posture is **re-mint on (re)connect** — the SPA fetches a fresh token
+  from Odoo when it (re)opens the stream. (Optionally the sidecar may also drop
+  the connection at `exp` to force a re-mint; decide during review.)
+- The `iid` claim is useful as a log/audit correlation id only.
+
+---
+
+## 5. Streaming + frontend
+
+- Transport: a single HTTP response that **streams** (chunked / flush-per-line).
+  The browser consumes it with `fetch()` + `ReadableStream` reader (so the token
+  travels in the `Authorization` header rather than a URL — SSE/`EventSource`
+  cannot set arbitrary headers, which is why plain `fetch` streaming is chosen).
+- Frontend: a small **react-logviewer** SPA served from `logs.bemade.org`. It:
+  - receives the token via `postMessage` (origin-checked);
+  - opens the stream;
+  - renders lines with **client-side search / filter / highlight** (no
+    server-side query needed for the recent window it holds);
+  - shows the **"recent logs only"** notice.
+- The SPA is **described here but not built** in the scaffold.
+
+---
+
+## 6. Retention caveat
+
+This sidecar tails **live** pod logs via the Kubernetes API — it shows **recent
+logs only** (what kubelet currently holds for running pods, plus a small tail
+window). It is **not** a historical log store: rotated/old logs and logs from
+deleted pods are gone. **Historical search is out of scope** and belongs to a
+separate Loki-backed path (call it "v2"). The portal page carries an explicit
+"recent logs only" notice for this reason (asserted by the Odoo test).
+
+---
+
+## 7. Security properties
+
+- **Scope is authority-derived, not caller-derived.** The namespace and label
+  selector come *only* from the HMAC-verified token payload. No request
+  parameter can widen or redirect scope. An attacker cannot point the stream at
+  another client's namespace without forging an HMAC over the shared secret.
+- **Least-privilege ServiceAccount.** The sidecar's `ClusterRole` grants only
+  `get,list,watch` on `pods` and `get` on `pods/log`. It can **never** exec into
+  pods, read `secrets`, read `configmaps`, or touch the operator kubeconfig. A
+  full compromise of the sidecar leaks *pod logs*, not cluster control.
+- **Short-lived tokens.** ~120 s TTL bounds replay; `exp` is enforced.
+- **Constant-time signature compare** prevents timing oracles on the MAC.
+- **No token in URLs.** Bearer header + `postMessage` keep it out of logs,
+  referrers, and history.
+- **TLS end-to-end.** `logs.bemade.org` is fronted by Traefik with a
+  cert-manager-issued certificate; the browser↔sidecar hop is HTTPS.
+- **Shared secret handling.** The HMAC secret is a k8s `Secret` mounted into the
+  sidecar as `LOG_TOKEN_SECRET`; it is the *same* value Odoo holds in
+  `ir.config_parameter`. It must never be logged and never reach the browser
+  (Odoo tests assert it is absent from the rendered page).
+- **Origin checks.** The SPA must verify `event.origin` on the incoming
+  `postMessage` before trusting the token.
+
+---
+
+## 8. Open items for human review
+
+- Token-expiry-mid-stream policy (drop at `exp` vs. let the live stream run until
+  client disconnect and rely on re-mint at reconnect).
+- Whether to bound concurrent streams / pods per request (DoS guard).
+- `TailLines` / `SinceSeconds` defaults for the "recent" window.
+- Multi-container pods: stream all containers vs. a known primary.
+- ClusterRole vs. namespaced Role(s): a ClusterRole is simplest given clients
+  span many namespaces, but a tighter posture could enumerate allowed namespaces.

--- a/odoo_herd_portal/docs/SPEC.md
+++ b/odoo_herd_portal/docs/SPEC.md
@@ -184,6 +184,10 @@ Loki (v2).
     operator stamps the owned Deployments' pod-template annotation
     (`bemade.org/restarted-at`) → rolling restart. (CRDs can't have custom verbs;
     this declarative-trigger pattern is the idiomatic equivalent.)
+  - **Portal upgrade → mirror the backend wizard.** v1 triggers a fixed
+    `-u all` (update all installed modules, no installs). v2 should mirror
+    `odoo_herd`'s `k8s.upgrade.wizard`: module selection, scheduling, and an
+    image/version bump — rather than the hardcoded standard upgrade.
   - Possibly metrics/health (Prometheus) and self-service production restore.
 
 ---

--- a/odoo_herd_portal/docs/SPEC.md
+++ b/odoo_herd_portal/docs/SPEC.md
@@ -1,0 +1,203 @@
+# Epic: `odoo_herd_portal`
+
+**Status:** Draft — requirements agreed, awaiting manifest sign-off before scaffolding.
+**Module:** `odoo_herd_portal` (Odoo 19.0, LGPL-3, depends `odoo_herd` + `portal`)
+**Companion:** a separate, non-Odoo **log-stream sidecar** service repo (see §6).
+
+---
+
+## 1. Purpose
+
+A client-facing portal layer over `odoo_herd`. A Bemade hosting customer logs
+into the central Bemade Odoo (`odoo.bemade.org`, where `odoo_herd` runs) and can
+observe and — within guardrails — act on the instances their company owns,
+without a support ticket and without ever seeing another client's data.
+
+`odoo_herd` today is internal-only: no client/partner linkage, global record
+rules, all access via the `K8s User` / `K8s Manager` groups. This module adds the
+ownership model, portal surface, and customer-safe actions on top of it.
+
+---
+
+## 2. Locked scope decisions
+
+| Decision | Choice |
+| --- | --- |
+| v1 features | A access · B overview · C live logs · D backups · E self-serve lifecycle |
+| Portal host | Central Bemade Odoo — broad ServiceAccount, **in-code** per-instance isolation |
+| Ownership | `allowed_partner_ids` (M2M) on the instance; match user's `commercial_partner_id` |
+| Self-serve actions | upgrade, staging-refresh (restart deferred to v2) |
+| Restore | self-service on **staging**; **production** restore is back-office only |
+| Log transport | dedicated sidecar + iframe; **search + filtering required** (not tail-only) |
+| Live-log scope | live + recent only (node log retention); history search is v2 (Loki) |
+| License | LGPL-3 |
+| Code layout | `odoo_herd_portal` addon + separate sidecar repo |
+
+---
+
+## 3. Ownership model (the keystone)
+
+Everything portal-facing depends on this; build it first.
+
+- **New field** on `k8s.odoo.instance`: `allowed_partner_ids = Many2many('res.partner')`.
+  Entries are normalised to commercial partners on grant.
+- **Record rule** (portal group, read):
+  `[('allowed_partner_ids', 'in', user.partner_id.commercial_partner_id.ids)]`
+  so any contact of an allowed company matches.
+- **Provisioning:** standard Odoo portal grant on the client contact + populate
+  `allowed_partner_ids` on their instances. No new login system.
+- **Field exposure:** the portal ACL/templates expose a whitelist only — never
+  `kubeconfig`, `spec`, `webhook_token`, or other internal fields.
+
+> Check `feat/portal-partner-manager` branch before implementing — it may already
+> cover portal↔partner wiring.
+
+---
+
+## 4. Feature breakdown (stories → acceptance criteria → builds-on / gaps)
+
+### A — Access & ownership *(keystone)*
+- *As a portal user I only ever see instances my company owns; another client's
+  instances are invisible at the ORM layer.*
+- **AC:** record rule enforces commercial-partner match; portal group has
+  read-only ACL on a curated field subset; a user with no owned instances sees
+  an empty, non-erroring portal; secrets never exposed.
+- **Builds on:** nothing — all new (`allowed_partner_ids`, portal group, record
+  rules, portal mixin).
+
+### B — Instance overview
+- *As a client I see my instances grouped into Production and Staging, with
+  status, version/image, and URL.*
+- **AC:** `/my/instances` list + detail driven by `environment`; staging entries
+  link to their prod source via `production_instance_id`; shows `phase`,
+  ready/available replicas, `ingress_url`; no internal fields leak.
+- **Builds on:** existing instance data only. **No model changes.**
+
+### C — Live log viewer
+- *As a technical client I tail my instance's web + cron logs live, and
+  search/filter what's on screen.*
+- **AC:** selector `bemade.org/instance=<name>` multiplexes the web and `-cron`
+  pods (and transient lifecycle Job pods); live tail via streamed HTTP;
+  in-browser search + level/text/pod filter over the buffered window; scope comes
+  **only** from an Odoo-signed short-lived token, never request params; the kube
+  token never reaches the browser; UI clearly marks "recent only".
+- **Builds on:** existing `action_view_logs()` / `CoreV1Api` as reference.
+- **Gaps:** the sidecar (§6); JWT mint/verify; `@melloware/react-logviewer`;
+  iframe embed. History search beyond retention = Loki (v2).
+
+### D — Backups self-service
+- *As a client I list and download my backups, trigger a backup, and restore
+  staging myself.*
+- **AC:** list owned-instance backups (state/size/time); download via S3
+  pre-signed URL through an auth-checked portal endpoint; "Backup now" creates an
+  `OdooBackupJob` and shows live state via the operator webhook; **restore is
+  self-service only when `target.environment == 'staging'`**; production restore
+  is not exposed in the portal.
+- **Builds on:** `k8s.odoo.backup` (`download_url`, `state`, `size_bytes`),
+  `k8s.backup.wizard`, `k8s.odoo.restore`, `k8s.s3.config`.
+- **Gaps:** portal download endpoint + presign exposure; portal-safe backup-now;
+  environment gate on restore.
+
+### E — Self-serve lifecycle (upgrade, staging-refresh)
+- *As a client I upgrade modules or refresh staging from prod myself, with
+  guardrails.*
+- **AC:** each action confirms intent and posts to the existing job pipeline;
+  **upgrade auto-takes a backup first** and is restricted to safe targets;
+  staging-refresh reuses existing wizard logic pre-bound to owned source/target;
+  every action writes an **audit record (who/what/when)** and notifies the client
+  on completion/failure.
+- **Builds on:** `k8s.odoo.upgrade` + `k8s.upgrade.wizard`,
+  `k8s.odoo.staging.refresh` + wizard.
+- **Gaps:** audit trail is new (today only `create_uid`/`write_uid`); guardrails
+  (auto-backup-before-upgrade, confirmation).
+
+---
+
+## 5. Cross-cutting / non-functional
+
+- **Security:** in-code scoping is the only barrier between clients — hardened
+  record rules + portal controller; field whitelist; never expose secrets.
+- **Audit:** lightweight audit on every client-initiated action — foundational
+  for self-serve trust.
+- **Notifications:** post to the client (mail/activity) on job completion/failure
+  (`mail.thread` already on the instance).
+- **Token minting:** Odoo signs short-lived (~2 min) scope-bound tokens with a
+  shared secret (HMAC/stdlib — no new Python dep) after the record-rule check.
+
+---
+
+## 6. The log-stream sidecar (separate repo)
+
+A small standalone web service whose only job is turning "a client wants their
+instance's logs" into a safe, live, multiplexed stream — without Odoo holding the
+connection and without the browser touching a kube token.
+
+**Stack:** Go (native `client-go`, cheap goroutine fan-in, single static binary)
+serving the `react-logviewer` SPA as static assets. (Node/TS is the alternative.)
+
+```
+Browser — portal page (Odoo, OWL)
+  │  Odoo controller checks record rule, mints short-lived JWT
+  │    claims: { ns, selector: "bemade.org/instance=<name>", exp: +120s }
+  │  parent page → iframe via postMessage(token)   (not in a URL → not logged)
+  ▼
+iframe → logs.bemade.org   (React + react-logviewer, served by the sidecar)
+  │  fetch('/stream', { headers: { Authorization: 'Bearer <JWT>' } })
+  │  (fetch + ReadableStream, not EventSource — lets us send the auth header)
+  ▼
+Sidecar (Go) — own ServiceAccount, least-privilege
+  │  1. verify JWT (sig + exp) → trust ONLY ns + selector from the token
+  │  2. pod informer: discover web + -cron (+ Job) pods, attach/detach as they come/go (Stern pattern)
+  │  3. one goroutine per pod: Pods(ns).GetLogs(pod, {Follow:true}) → tag line → fan-in channel
+  │  4. stream merged lines back to the browser
+  ▼
+Kube API → kubelet → container log files
+```
+
+**Safety properties:**
+1. Scope comes only from the signed token; client cannot request another
+   namespace/instance. Tokens short-lived and scope-bound.
+2. Own minimal ServiceAccount: `get,list,watch pods` + `get pods/log`,
+   read-only. No exec, no secrets, not `odoo_herd`'s broad kubeconfig.
+   (ClusterRole for pods/log read vs per-namespace RoleBindings — lean ClusterRole
+   since read-only and the token already enforces scope.)
+3. Traefik + cert-manager TLS; same-origin iframe; JWT secret via k8s Secret.
+
+**Search/filtering:** v1 is client-side over the live buffer (react-logviewer
+highlight-search + a level/substring/pod filter box); the sidecar may grep
+server-side via a token claim for chatty instances. Searching beyond retention is
+Loki (v2).
+
+---
+
+## 7. Phasing
+
+- **v1:** A → (B, C, D, E in parallel once A lands).
+- **v2:**
+  - Client-initiated staging *creation* within a quota.
+  - **Log history search (Loki):** add a one-line Alloy relabel forwarding
+    `bemade.org/instance` → `odoo_instance` Loki label; per-client Grafana org +
+    datasource (OSS Grafana — no LBAC). Currently Loki only scopes by `namespace`
+    (= client), not per-instance, until that label is added.
+  - **Instance restart** as an operator-reconciled CRD action: add a trigger
+    field/annotation (e.g. `restartNonce`) to `OdooInstanceSpec`; on change the
+    operator stamps the owned Deployments' pod-template annotation
+    (`bemade.org/restarted-at`) → rolling restart. (CRDs can't have custom verbs;
+    this declarative-trigger pattern is the idiomatic equivalent.)
+  - Possibly metrics/health (Prometheus) and self-service production restore.
+
+---
+
+## 8. Cluster facts this design relies on (verified)
+
+- **Namespaces are per-client, not per-instance** — e.g. `pneumac` holds both
+  `pneumac-prod` and `pneumac-staging`. So namespace scopes a *client*; the
+  per-instance key is the `bemade.org/instance` label.
+- Each `OdooInstance` owns two Deployments: `<name>` (web, HTTP 8069 + WS 8072 in
+  one container) and `<name>-cron` (runs `ir.cron`, `--no-http`). Crons are a pod,
+  not k8s CronJobs.
+- The operator stamps `bemade.org/instance=<name>` uniformly on **all** owned
+  pods (web, cron, lifecycle Jobs) — the clean per-instance selector.
+- Alloy → Loki currently forwards `namespace, pod, container, app, cluster`;
+  `bemade.org/instance` is **not** yet a Loki label (hence v2 relabel).
+- Loki is single-tenant `bemade`; Grafana is OSS 10.4.9 (no LBAC).

--- a/odoo_herd_portal/models/__init__.py
+++ b/odoo_herd_portal/models/__init__.py
@@ -1,2 +1,3 @@
 # Part of Odoo Herd Portal. See LICENSE file for full copyright and licensing details.
 from . import k8s_odoo_instance
+from . import k8s_cluster

--- a/odoo_herd_portal/models/__init__.py
+++ b/odoo_herd_portal/models/__init__.py
@@ -1,3 +1,4 @@
 # Part of Odoo Herd Portal. See LICENSE file for full copyright and licensing details.
 from . import k8s_odoo_instance
 from . import k8s_cluster
+from . import k8s_odoo_backup

--- a/odoo_herd_portal/models/__init__.py
+++ b/odoo_herd_portal/models/__init__.py
@@ -2,3 +2,5 @@
 from . import k8s_odoo_instance
 from . import k8s_cluster
 from . import k8s_odoo_backup
+from . import k8s_odoo_upgrade
+from . import k8s_odoo_staging_refresh

--- a/odoo_herd_portal/models/__init__.py
+++ b/odoo_herd_portal/models/__init__.py
@@ -1,4 +1,4 @@
-# Part of Odoo Herd Portal. See LICENSE file for full copyright and licensing details.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 from . import k8s_odoo_instance
 from . import k8s_cluster
 from . import k8s_odoo_backup

--- a/odoo_herd_portal/models/__init__.py
+++ b/odoo_herd_portal/models/__init__.py
@@ -1,2 +1,2 @@
 # Part of Odoo Herd Portal. See LICENSE file for full copyright and licensing details.
-from . import models
+from . import k8s_odoo_instance

--- a/odoo_herd_portal/models/k8s_cluster.py
+++ b/odoo_herd_portal/models/k8s_cluster.py
@@ -1,0 +1,31 @@
+# Part of Odoo Herd Portal. See LICENSE file for full copyright and licensing details.
+from odoo import fields, models
+
+_K8S_GROUP = "odoo_herd.group_k8s_user"
+
+
+class K8sCluster(models.Model):
+    """Restrict cluster credentials and connection details to K8s users.
+
+    Defense in depth against related-field traversal: even if a portal user can
+    read a ``k8s.odoo.instance`` record, the path ``cluster_id.kubeconfig`` (and
+    its sibling secrets/connection fields) must not leak the cluster master
+    credential. The missing portal ACL on ``k8s.cluster`` does NOT block a
+    related read from a readable instance, so we gate the fields themselves with
+    ``groups="odoo_herd.group_k8s_user"``.
+    """
+
+    _inherit = "k8s.cluster"
+
+    # Master credential and auth token -- the crown jewels.
+    kubeconfig = fields.Text(groups=_K8S_GROUP)
+    instance_webhook_token = fields.Char(groups=_K8S_GROUP)
+
+    # Connection / infra details that should not be exposed to clients.
+    api_endpoint = fields.Char(groups=_K8S_GROUP)
+    default_namespace = fields.Char(groups=_K8S_GROUP)
+    verify_ssl = fields.Boolean(groups=_K8S_GROUP)
+    webhook_base_url = fields.Char(groups=_K8S_GROUP)
+    connection_error = fields.Text(groups=_K8S_GROUP)
+    connection_status = fields.Selection(groups=_K8S_GROUP)
+    last_sync = fields.Datetime(groups=_K8S_GROUP)

--- a/odoo_herd_portal/models/k8s_cluster.py
+++ b/odoo_herd_portal/models/k8s_cluster.py
@@ -1,4 +1,4 @@
-# Part of Odoo Herd Portal. See LICENSE file for full copyright and licensing details.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 from odoo import fields, models
 
 _K8S_GROUP = "odoo_herd.group_k8s_user"

--- a/odoo_herd_portal/models/k8s_odoo_backup.py
+++ b/odoo_herd_portal/models/k8s_odoo_backup.py
@@ -74,28 +74,31 @@ class K8sOdooBackup(models.Model):
     schedule_id = fields.Many2one(groups=_K8S_GROUP)
     available = fields.Boolean(groups=_K8S_GROUP)
 
-    def _notify_instance_terminal(self, outcome, message=None):
-        """Best-effort completion/failure note to the instance chatter.
+    def _notify_instance_terminal(self, outcome):
+        """Best-effort: STATUS-ONLY completion/failure comment to the client.
 
         Fires only on the real terminal-state transition (the operator webhook
-        drives ``mark_completed`` / ``mark_failed`` in prod). The instance is a
-        ``mail.thread``; its followers (incl. the allowed partners subscribed
-        when a backup-now was initiated) receive the message. Wrapped so a
-        notification failure never blocks the state write.
+        drives ``mark_completed`` / ``mark_failed`` in prod). Addressed directly
+        to the instance's ``allowed_partner_ids`` via the client-visible
+        ``mail.mt_comment`` subtype (per-message recipients, NO standing
+        follower subscription). The raw operator ``message`` blob is never
+        included. Wrapped so a failure never blocks the state write.
         """
         for record in self:
             instance = record.instance_id.sudo()
             if not instance:
                 continue
-            verb = "completed" if outcome == "completed" else "failed"
-            body = "Backup %s %s." % (record.name, verb)
-            if message:
-                body += " %s" % message
+            partner_ids = instance.allowed_partner_ids.ids
+            if outcome == "completed":
+                body = "Backup completed."
+            else:
+                body = "Backup failed — Bemade has been notified."
             try:
                 instance.message_post(
                     body=body,
+                    partner_ids=partner_ids,
                     message_type="comment",
-                    subtype_xmlid="mail.mt_note",
+                    subtype_xmlid="mail.mt_comment",
                 )
             except Exception:  # noqa: BLE001 -- notification is best-effort
                 continue
@@ -106,10 +109,10 @@ class K8sOdooBackup(models.Model):
             message=message,
             object_key=object_key,
         )
-        self._notify_instance_terminal("completed", message)
+        self._notify_instance_terminal("completed")
         return res
 
     def mark_failed(self, message=None, completion_time=None):
         res = super().mark_failed(message=message, completion_time=completion_time)
-        self._notify_instance_terminal("failed", message)
+        self._notify_instance_terminal("failed")
         return res

--- a/odoo_herd_portal/models/k8s_odoo_backup.py
+++ b/odoo_herd_portal/models/k8s_odoo_backup.py
@@ -1,0 +1,75 @@
+# Part of Odoo Herd Portal. See LICENSE file for full copyright and licensing details.
+from odoo import fields, models
+
+# Single source of truth for the portal-visible backup field whitelist. Any
+# field on k8s.odoo.backup NOT listed here is hidden from portal users
+# (deny-by-default via groups= on the field). Kept in the model so the
+# drift-guard test imports the exact same set the code enforces.
+#
+# instance_id is included for record-rule scoping (the rule traverses
+# instance_id.allowed_partner_ids); templates render only instance_id.name.
+PORTAL_VISIBLE_BACKUP_FIELDS = frozenset(
+    {
+        "id",
+        "name",
+        "display_name",
+        "state",
+        "format",
+        "with_filestore",
+        "size_bytes",
+        "start_time",
+        "completion_time",
+        "instance_id",
+    }
+)
+
+# Group whose members (internal K8s users) keep full field access. Hiding a
+# field from everyone else is done by redefining it with this group.
+_K8S_GROUP = "odoo_herd.group_k8s_user"
+
+
+class K8sOdooBackup(models.Model):
+    """Field-level secrecy for k8s.odoo.backup, for the client portal.
+
+    Mirrors Feature A's k8s.odoo.instance secrecy model: a deny-by-default
+    *whitelist*. Only the fields in ``PORTAL_VISIBLE_BACKUP_FIELDS`` are
+    readable by portal users; every other field -- the webhook token, the
+    pre-signed ``download_url`` (which would let anyone with the link fetch the
+    raw DB+filestore), the k8s job names, and all S3/cluster internals (bucket,
+    endpoint, object_key, region, s3_config_id, cluster_id) -- is redefined
+    here with ``groups="odoo_herd.group_k8s_user"`` so a portal user cannot
+    read it even via the ORM.
+
+    New fields added to the base model later default to hidden until explicitly
+    added to the whitelist; the drift-guard test enforces this.
+
+    Note the portal NEVER renders ``download_url`` directly: downloads go
+    through an auth-checked controller that generates a *fresh* pre-signed URL
+    under sudo, so the stored URL (and the S3 credentials behind it) never
+    reach a portal user.
+    """
+
+    _inherit = "k8s.odoo.backup"
+
+    # --- Field-level secrecy: WHITELIST (deny-by-default) -------------------
+    # Pre-signed download URL -- a bearer credential to the raw backup object.
+    download_url = fields.Char(groups=_K8S_GROUP)
+    # Webhook token -- shared secret with the operator.
+    webhook_token = fields.Char(groups=_K8S_GROUP)
+    # Kubernetes job identifiers.
+    job_name = fields.Char(groups=_K8S_GROUP)
+    backup_job_name = fields.Char(groups=_K8S_GROUP)
+    job_uid = fields.Char(groups=_K8S_GROUP)
+    # S3 / object-store internals.
+    bucket = fields.Char(groups=_K8S_GROUP)
+    object_key = fields.Char(groups=_K8S_GROUP)
+    endpoint = fields.Char(groups=_K8S_GROUP)
+    region = fields.Char(groups=_K8S_GROUP)
+    s3_config_id = fields.Many2one(groups=_K8S_GROUP)
+    # Cluster traversal -- hidden so portal can't reach cluster credentials.
+    cluster_id = fields.Many2one(groups=_K8S_GROUP)
+    # Operator-side message blob (may carry internal paths / errors).
+    message = fields.Text(groups=_K8S_GROUP)
+    # Schedule + availability flag -- internal scheduling metadata.
+    schedule_id = fields.Many2one(groups=_K8S_GROUP)
+    available = fields.Boolean(groups=_K8S_GROUP)

--- a/odoo_herd_portal/models/k8s_odoo_backup.py
+++ b/odoo_herd_portal/models/k8s_odoo_backup.py
@@ -73,3 +73,43 @@ class K8sOdooBackup(models.Model):
     # Schedule + availability flag -- internal scheduling metadata.
     schedule_id = fields.Many2one(groups=_K8S_GROUP)
     available = fields.Boolean(groups=_K8S_GROUP)
+
+    def _notify_instance_terminal(self, outcome, message=None):
+        """Best-effort completion/failure note to the instance chatter.
+
+        Fires only on the real terminal-state transition (the operator webhook
+        drives ``mark_completed`` / ``mark_failed`` in prod). The instance is a
+        ``mail.thread``; its followers (incl. the allowed partners subscribed
+        when a backup-now was initiated) receive the message. Wrapped so a
+        notification failure never blocks the state write.
+        """
+        for record in self:
+            instance = record.instance_id.sudo()
+            if not instance:
+                continue
+            verb = "completed" if outcome == "completed" else "failed"
+            body = "Backup %s %s." % (record.name, verb)
+            if message:
+                body += " %s" % message
+            try:
+                instance.message_post(
+                    body=body,
+                    message_type="comment",
+                    subtype_xmlid="mail.mt_note",
+                )
+            except Exception:  # noqa: BLE001 -- notification is best-effort
+                continue
+
+    def mark_completed(self, completion_time=None, message=None, object_key=None):
+        res = super().mark_completed(
+            completion_time=completion_time,
+            message=message,
+            object_key=object_key,
+        )
+        self._notify_instance_terminal("completed", message)
+        return res
+
+    def mark_failed(self, message=None, completion_time=None):
+        res = super().mark_failed(message=message, completion_time=completion_time)
+        self._notify_instance_terminal("failed", message)
+        return res

--- a/odoo_herd_portal/models/k8s_odoo_backup.py
+++ b/odoo_herd_portal/models/k8s_odoo_backup.py
@@ -1,4 +1,4 @@
-# Part of Odoo Herd Portal. See LICENSE file for full copyright and licensing details.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 from odoo import fields, models
 
 # Single source of truth for the portal-visible backup field whitelist. Any

--- a/odoo_herd_portal/models/k8s_odoo_backup.py
+++ b/odoo_herd_portal/models/k8s_odoo_backup.py
@@ -20,6 +20,9 @@ PORTAL_VISIBLE_BACKUP_FIELDS = frozenset(
         "start_time",
         "completion_time",
         "instance_id",
+        # The portal user who triggered the job; notified directly on terminal
+        # state.
+        "portal_initiator_id",
     }
 )
 
@@ -73,22 +76,28 @@ class K8sOdooBackup(models.Model):
     # Schedule + availability flag -- internal scheduling metadata.
     schedule_id = fields.Many2one(groups=_K8S_GROUP)
     available = fields.Boolean(groups=_K8S_GROUP)
+    # The portal user (partner) who triggered the job. Set by the portal
+    # controller at create time; unset for herd-/operator-driven jobs.
+    portal_initiator_id = fields.Many2one("res.partner")
 
     def _notify_instance_terminal(self, outcome):
         """Best-effort: STATUS-ONLY completion/failure comment to the client.
 
         Fires only on the real terminal-state transition (the operator webhook
-        drives ``mark_completed`` / ``mark_failed`` in prod). Addressed directly
-        to the instance's ``allowed_partner_ids`` via the client-visible
-        ``mail.mt_comment`` subtype (per-message recipients, NO standing
-        follower subscription). The raw operator ``message`` blob is never
-        included. Wrapped so a failure never blocks the state write.
+        drives ``mark_completed`` / ``mark_failed`` in prod). The direct
+        recipient (``partner_ids``) is the recorded ``portal_initiator_id`` --
+        ONLY that partner, never the whole ``allowed_partner_ids`` set. Posting
+        with the ``mail.mt_comment`` subtype additionally reaches the instance's
+        EXISTING followers (intended). If no initiator was recorded, followers
+        are notified but no direct ``partner_ids`` recipient is set. NO standing
+        follower subscription is added; the raw operator ``message`` blob is
+        never included. Wrapped so a failure never blocks the state write.
         """
         for record in self:
             instance = record.instance_id.sudo()
             if not instance:
                 continue
-            partner_ids = instance.allowed_partner_ids.ids
+            initiator = record.sudo().portal_initiator_id
             if outcome == "completed":
                 body = "Backup completed."
             else:
@@ -96,7 +105,7 @@ class K8sOdooBackup(models.Model):
             try:
                 instance.message_post(
                     body=body,
-                    partner_ids=partner_ids,
+                    partner_ids=initiator.ids,
                     message_type="comment",
                     subtype_xmlid="mail.mt_comment",
                 )

--- a/odoo_herd_portal/models/k8s_odoo_instance.py
+++ b/odoo_herd_portal/models/k8s_odoo_instance.py
@@ -1,4 +1,4 @@
-# Part of Odoo Herd Portal. See LICENSE file for full copyright and licensing details.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 import base64
 import hashlib
 import hmac

--- a/odoo_herd_portal/models/k8s_odoo_instance.py
+++ b/odoo_herd_portal/models/k8s_odoo_instance.py
@@ -1,5 +1,19 @@
 # Part of Odoo Herd Portal. See LICENSE file for full copyright and licensing details.
+import base64
+import hashlib
+import hmac
+import json
+import secrets
+import time
+
 from odoo import api, fields, models
+
+# ir.config_parameter key holding the HMAC secret shared (out of band, via a
+# k8s Secret) with the log-stream sidecar. Generated on first use if unset.
+LOG_TOKEN_SECRET_PARAM = "odoo_herd_portal.log_token_secret"
+
+# Short-lived token validity window, in seconds (~2 min per SPEC §5).
+LOG_TOKEN_TTL = 120
 
 # Single source of truth for the portal-visible field whitelist. Any field on
 # k8s.odoo.instance NOT listed here is hidden from portal users (deny-by-default
@@ -233,3 +247,68 @@ class K8sOdooInstance(models.Model):
         if "allowed_partner_ids" in vals:
             vals = self._normalise_allowed_partner_commands(vals)
         return super().write(vals)
+
+    # ==================================================================
+    # Feature C -- live log viewer: signed short-lived scope token mint
+    # ==================================================================
+    @staticmethod
+    def _b64url(raw):
+        """Unpadded urlsafe base64 of ``raw`` bytes, as an ASCII str."""
+        return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+    @api.model
+    def _get_log_token_secret(self):
+        """Return the HMAC secret, generating a strong one on first use.
+
+        The secret lives in ``ir.config_parameter`` under
+        ``LOG_TOKEN_SECRET_PARAM`` and is shared (out of band) with the sidecar.
+        It is read/written under ``sudo`` because portal users have no access to
+        ``ir.config_parameter`` -- and the secret must NEVER reach the browser.
+        """
+        Param = self.env["ir.config_parameter"].sudo()
+        secret = Param.get_param(LOG_TOKEN_SECRET_PARAM)
+        if not secret:
+            # 64 hex chars (256 bits) -- a strong, URL-safe shared secret.
+            secret = secrets.token_hex(32)
+            Param.set_param(LOG_TOKEN_SECRET_PARAM, secret)
+        return secret
+
+    def _mint_log_token(self):
+        """Mint a short-lived signed scope token for this owned instance.
+
+        Token wire format (stdlib only -- no JWT dependency)::
+
+            b64url(payload_json) . b64url(hmac_sha256(secret, b64url_payload))
+
+        Payload claims::
+
+            {"ns": <namespace>, "sel": "bemade.org/instance=<name>",
+             "exp": now + 120, "iat": now, "iid": <instance id>}
+
+        The caller MUST have already established that the *portal user* owns this
+        instance (record-rule read access). The namespace and name -- both
+        group-hidden infra fields -- are read under ``sudo`` here, only AFTER
+        that ownership check, never from request params.
+        """
+        self.ensure_one()
+        sudo_self = self.sudo()
+        now = int(time.time())
+        payload = {
+            "ns": sudo_self.namespace,
+            "sel": "bemade.org/instance=%s" % sudo_self.name,
+            "exp": now + LOG_TOKEN_TTL,
+            "iat": now,
+            "iid": self.id,
+        }
+        payload_b64 = self._b64url(
+            json.dumps(payload, separators=(",", ":"), sort_keys=True).encode(
+                "utf-8"
+            )
+        )
+        secret = self._get_log_token_secret()
+        signature = hmac.new(
+            secret.encode("utf-8"),
+            payload_b64.encode("utf-8"),
+            hashlib.sha256,
+        ).digest()
+        return "%s.%s" % (payload_b64, self._b64url(signature))

--- a/odoo_herd_portal/models/k8s_odoo_instance.py
+++ b/odoo_herd_portal/models/k8s_odoo_instance.py
@@ -44,10 +44,11 @@ _K8S_GROUP = "odoo_herd.group_k8s_user"
 class K8sOdooInstance(models.Model):
     """Add client ownership and field-level secrecy to k8s.odoo.instance.
 
-    ``allowed_partner_ids`` links an instance to the commercial partners
-    (companies) whose portal users may see it. Entries are normalised to
-    commercial partners on write so that any contact of an allowed company
-    matches the portal record rule.
+    ``allowed_partner_ids`` links an instance to the specific partners
+    (people) whose portal users may see it. Access is granted person by
+    person: a portal user matches the record rule only when their OWN
+    ``partner_id`` is listed -- a colleague at the same company does not
+    inherit access unless they are also added.
 
     Field-level secrecy follows a **whitelist / deny-by-default** model: only
     the fields in ``PORTAL_VISIBLE_FIELDS`` are readable by portal users; every
@@ -76,9 +77,10 @@ class K8sOdooInstance(models.Model):
         string="Allowed Partners",
         groups=_K8S_GROUP,
         help=(
-            "Commercial partners (companies) whose portal users may view this "
-            "instance. Contacts are normalised to their commercial partner on "
-            "write, so any contact of an allowed company matches."
+            "Specific partners (people) whose portal users may view this "
+            "instance. Access is granted person by person: only a portal user "
+            "whose own partner is listed here gets access -- a colleague at the "
+            "same company does not, unless added explicitly."
         ),
     )
 
@@ -170,10 +172,15 @@ class K8sOdooInstance(models.Model):
         # default order before reaching here, so we detect the default (or any
         # order touching a hidden field) and substitute a portal-safe order on a
         # visible field for non-k8s users.
-        if not bypass_access and not self._user_is_k8s():
-            effective = order or self._order
+        #
+        # search_count() reaches us with order=None (it never orders); we must
+        # leave it None so no ORDER BY is emitted into the COUNT query --
+        # "SELECT COUNT(*) ... ORDER BY name" is rejected by Postgres
+        # (column "name" must appear in the GROUP BY clause). Only substitute
+        # when an order is actually requested (the list/fetch path).
+        if not bypass_access and order and not self._user_is_k8s():
             if any(
-                hidden in effective
+                hidden in order
                 for hidden in ("cluster_id", "namespace")
             ):
                 order = "name"
@@ -196,57 +203,6 @@ class K8sOdooInstance(models.Model):
             return super()._compute_display_name()
         for instance in self:
             instance.display_name = instance.name
-
-    @api.model
-    def _normalise_allowed_partner_commands(self, vals):
-        """Rewrite allowed_partner_ids commands to use commercial partners.
-
-        Handles the link/replace forms that carry partner ids (Command.set /
-        Command.link). For each such command the referenced partners are
-        mapped to their ``commercial_partner_id`` before being passed to
-        super(). Other command forms (unlink/clear, and Command.create which
-        builds a brand-new partner from a values dict rather than referencing
-        an existing id) are left untouched. Returns ``vals`` (a mutated copy)
-        ready to pass to super().
-        """
-        commands = vals.get("allowed_partner_ids")
-        if not commands:
-            return vals
-        Partner = self.env["res.partner"]
-        new_commands = []
-        for command in commands:
-            # x2many commands are 3-tuples/lists: (code, id, values)
-            if isinstance(command, (list, tuple)) and len(command) == 3:
-                code = command[0]
-                if code in (fields.Command.SET, fields.Command.LINK):
-                    if code == fields.Command.SET:
-                        ids = command[2] or []
-                    else:
-                        ids = [command[1]]
-                    partners = Partner.browse(ids).exists()
-                    commercial = partners.commercial_partner_id
-                    if code == fields.Command.SET:
-                        new_commands.append(fields.Command.set(commercial.ids))
-                    else:
-                        for pid in commercial.ids:
-                            new_commands.append(fields.Command.link(pid))
-                    continue
-            new_commands.append(command)
-        vals = dict(vals)
-        vals["allowed_partner_ids"] = new_commands
-        return vals
-
-    @api.model_create_multi
-    def create(self, vals_list):
-        vals_list = [
-            self._normalise_allowed_partner_commands(vals) for vals in vals_list
-        ]
-        return super().create(vals_list)
-
-    def write(self, vals):
-        if "allowed_partner_ids" in vals:
-            vals = self._normalise_allowed_partner_commands(vals)
-        return super().write(vals)
 
     # ==================================================================
     # Feature C -- live log viewer: signed short-lived scope token mint

--- a/odoo_herd_portal/models/k8s_odoo_instance.py
+++ b/odoo_herd_portal/models/k8s_odoo_instance.py
@@ -1,0 +1,84 @@
+# Part of Odoo Herd Portal. See LICENSE file for full copyright and licensing details.
+from odoo import api, fields, models
+
+
+class K8sOdooInstance(models.Model):
+    """Add client ownership and field-level secrecy to k8s.odoo.instance.
+
+    ``allowed_partner_ids`` links an instance to the commercial partners
+    (companies) whose portal users may see it. Entries are normalised to
+    commercial partners on write so that any contact of an allowed company
+    matches the portal record rule.
+
+    Sensitive fields (raw spec/status JSON, deployment conditions) are
+    redefined with ``groups="odoo_herd.group_k8s_user"`` so that portal users
+    cannot read them even via the ORM -- defense in depth on top of the record
+    rule and ACL.
+    """
+
+    _inherit = "k8s.odoo.instance"
+
+    allowed_partner_ids = fields.Many2many(
+        "res.partner",
+        "k8s_odoo_instance_allowed_partner_rel",
+        "instance_id",
+        "partner_id",
+        string="Allowed Partners",
+        help=(
+            "Commercial partners (companies) whose portal users may view this "
+            "instance. Contacts are normalised to their commercial partner on "
+            "write, so any contact of an allowed company matches."
+        ),
+    )
+
+    # Field-level secrecy: restrict the raw internal blobs to K8s users.
+    spec = fields.Text(groups="odoo_herd.group_k8s_user")
+    status = fields.Text(groups="odoo_herd.group_k8s_user")
+    conditions = fields.Text(groups="odoo_herd.group_k8s_user")
+
+    @api.model
+    def _normalise_allowed_partner_commands(self, vals):
+        """Rewrite allowed_partner_ids commands to use commercial partners.
+
+        Handles the link/replace forms that carry partner ids (Command.set /
+        Command.link / Command.create-by-id). Unlink/clear forms are left
+        untouched. Returns ``vals`` (mutated copy) ready to pass to super().
+        """
+        commands = vals.get("allowed_partner_ids")
+        if not commands:
+            return vals
+        Partner = self.env["res.partner"]
+        new_commands = []
+        for command in commands:
+            # x2many commands are 3-tuples/lists: (code, id, values)
+            if isinstance(command, (list, tuple)) and len(command) == 3:
+                code = command[0]
+                if code in (fields.Command.SET, fields.Command.LINK):
+                    if code == fields.Command.SET:
+                        ids = command[2] or []
+                    else:
+                        ids = [command[1]]
+                    partners = Partner.browse(ids).exists()
+                    commercial = partners.commercial_partner_id
+                    if code == fields.Command.SET:
+                        new_commands.append(fields.Command.set(commercial.ids))
+                    else:
+                        for pid in commercial.ids:
+                            new_commands.append(fields.Command.link(pid))
+                    continue
+            new_commands.append(command)
+        vals = dict(vals)
+        vals["allowed_partner_ids"] = new_commands
+        return vals
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        vals_list = [
+            self._normalise_allowed_partner_commands(vals) for vals in vals_list
+        ]
+        return super().create(vals_list)
+
+    def write(self, vals):
+        if "allowed_partner_ids" in vals:
+            vals = self._normalise_allowed_partner_commands(vals)
+        return super().write(vals)

--- a/odoo_herd_portal/models/k8s_odoo_instance.py
+++ b/odoo_herd_portal/models/k8s_odoo_instance.py
@@ -1,6 +1,31 @@
 # Part of Odoo Herd Portal. See LICENSE file for full copyright and licensing details.
 from odoo import api, fields, models
 
+# Single source of truth for the portal-visible field whitelist. Any field on
+# k8s.odoo.instance NOT listed here is hidden from portal users (deny-by-default
+# via groups= on the field). Kept in the model so the drift-guard test imports
+# the exact same set the code enforces.
+PORTAL_VISIBLE_FIELDS = frozenset(
+    {
+        "name",
+        "display_name",
+        "id",
+        "environment",
+        "phase",
+        "url",
+        "ingress_url",
+        "ready_replicas",
+        "available_replicas",
+        "image",
+        "production_instance_id",
+        "last_updated",
+    }
+)
+
+# Group whose members (internal K8s users) keep full field access. Hiding a
+# field from everyone else is done by redefining it with this group.
+_K8S_GROUP = "odoo_herd.group_k8s_user"
+
 
 class K8sOdooInstance(models.Model):
     """Add client ownership and field-level secrecy to k8s.odoo.instance.
@@ -10,10 +35,21 @@ class K8sOdooInstance(models.Model):
     commercial partners on write so that any contact of an allowed company
     matches the portal record rule.
 
-    Sensitive fields (raw spec/status JSON, deployment conditions) are
-    redefined with ``groups="odoo_herd.group_k8s_user"`` so that portal users
-    cannot read them even via the ORM -- defense in depth on top of the record
-    rule and ACL.
+    Field-level secrecy follows a **whitelist / deny-by-default** model: only
+    the fields in ``PORTAL_VISIBLE_FIELDS`` are readable by portal users; every
+    other field on the instance (raw spec/status JSON, the odoo.conf
+    ``config_options`` blob, cluster/database/image-pull-secret references and
+    all infra sizing/probe/rollout knobs) is redefined with
+    ``groups="odoo_herd.group_k8s_user"`` so a portal user cannot read it even
+    via the ORM -- defense in depth on top of the record rule and ACL. New
+    fields added to the base model later default to hidden until explicitly
+    added to the whitelist; the drift-guard test enforces this.
+
+    The cluster master credential is severed two ways: ``cluster_id`` itself is
+    hidden here (portal has no need for it), and ``k8s.cluster.kubeconfig`` (and
+    its sibling secrets) are group-restricted in this module, so a related-field
+    traversal from a readable instance to ``cluster_id.kubeconfig`` raises
+    AccessError rather than leaking.
     """
 
     _inherit = "k8s.odoo.instance"
@@ -24,6 +60,7 @@ class K8sOdooInstance(models.Model):
         "instance_id",
         "partner_id",
         string="Allowed Partners",
+        groups=_K8S_GROUP,
         help=(
             "Commercial partners (companies) whose portal users may view this "
             "instance. Contacts are normalised to their commercial partner on "
@@ -31,18 +68,132 @@ class K8sOdooInstance(models.Model):
         ),
     )
 
-    # Field-level secrecy: restrict the raw internal blobs to K8s users.
-    spec = fields.Text(groups="odoo_herd.group_k8s_user")
-    status = fields.Text(groups="odoo_herd.group_k8s_user")
-    conditions = fields.Text(groups="odoo_herd.group_k8s_user")
+    # --- Field-level secrecy: WHITELIST (deny-by-default) -------------------
+    # Every sensitive/infra/cluster field is redefined here with its correct
+    # type and groups=_K8S_GROUP. Anything NOT redefined and NOT in
+    # PORTAL_VISIBLE_FIELDS (e.g. framework audit + group_user-gated mail
+    # fields) is already inaccessible to portal users.
+
+    # Cluster traversal -- hidden so portal can't even reach cluster_id (the
+    # k8s.cluster credentials are ALSO group-restricted in this module).
+    cluster_id = fields.Many2one(groups=_K8S_GROUP)
+
+    # Raw k8s blobs / internal references.
+    spec = fields.Text(groups=_K8S_GROUP)
+    status = fields.Text(groups=_K8S_GROUP)
+    conditions = fields.Text(groups=_K8S_GROUP)
+    namespace = fields.Char(groups=_K8S_GROUP)
+    deployment_state = fields.Selection(groups=_K8S_GROUP)
+    ingress_hosts_editable = fields.Text(groups=_K8S_GROUP)
+
+    # Container / image-pull configuration (mixin).
+    image_pull_secret = fields.Char(groups=_K8S_GROUP)
+    replicas = fields.Integer(groups=_K8S_GROUP)
+    cluster_issuer = fields.Char(groups=_K8S_GROUP)
+
+    # Storage configuration (mixin).
+    filestore_size = fields.Char(groups=_K8S_GROUP)
+    filestore_storage_class = fields.Char(groups=_K8S_GROUP)
+
+    # Resource configuration (mixin).
+    cpu_request = fields.Char(groups=_K8S_GROUP)
+    memory_request = fields.Char(groups=_K8S_GROUP)
+    cpu_limit = fields.Char(groups=_K8S_GROUP)
+    memory_limit = fields.Char(groups=_K8S_GROUP)
+
+    # Raw odoo.conf options -- can contain admin_passwd etc. (mixin).
+    config_options = fields.Text(groups=_K8S_GROUP)
+
+    # Database / deployment-strategy configuration (mixin).
+    database_cluster = fields.Char(groups=_K8S_GROUP)
+    deployment_strategy_type = fields.Selection(groups=_K8S_GROUP)
+    rolling_update_max_unavailable = fields.Char(groups=_K8S_GROUP)
+    rolling_update_max_surge = fields.Char(groups=_K8S_GROUP)
+
+    # Health-probe configuration (mixin).
+    probe_startup_path = fields.Char(groups=_K8S_GROUP)
+    probe_liveness_path = fields.Char(groups=_K8S_GROUP)
+    probe_readiness_path = fields.Char(groups=_K8S_GROUP)
+
+    # Computed "current_*" reflections of the live spec -- same sensitivity as
+    # the stored infra fields above, so hidden too.
+    current_image = fields.Char(groups=_K8S_GROUP)
+    current_replicas = fields.Integer(groups=_K8S_GROUP)
+    current_ingress_hosts = fields.Text(groups=_K8S_GROUP)
+    current_cpu_request = fields.Char(groups=_K8S_GROUP)
+    current_cpu_limit = fields.Char(groups=_K8S_GROUP)
+    current_memory_request = fields.Char(groups=_K8S_GROUP)
+    current_memory_limit = fields.Char(groups=_K8S_GROUP)
+    current_filestore_size = fields.Char(groups=_K8S_GROUP)
+    current_filestore_storage_class = fields.Char(groups=_K8S_GROUP)
+    current_config_options = fields.Text(groups=_K8S_GROUP)
+    current_database_cluster = fields.Char(groups=_K8S_GROUP)
+    current_deployment_strategy = fields.Selection(groups=_K8S_GROUP)
+    current_rolling_update_max_unavailable = fields.Char(groups=_K8S_GROUP)
+    current_rolling_update_max_surge = fields.Char(groups=_K8S_GROUP)
+    current_probe_startup_path = fields.Char(groups=_K8S_GROUP)
+    current_probe_liveness_path = fields.Char(groups=_K8S_GROUP)
+    current_probe_readiness_path = fields.Char(groups=_K8S_GROUP)
+
+    def _user_is_k8s(self):
+        """True when the current user may read the hidden infra fields."""
+        return self.env.su or self.env.user.has_group(_K8S_GROUP)
+
+    @api.model
+    def _search(
+        self,
+        domain,
+        offset=0,
+        limit=None,
+        order=None,
+        *,
+        active_test=True,
+        bypass_access=False,
+    ):
+        # The base model orders by "cluster_id, namespace, name", but both
+        # cluster_id and namespace are hidden from portal users -- ordering by
+        # them in SQL raises AccessError. search()/search_fetch() resolve the
+        # default order before reaching here, so we detect the default (or any
+        # order touching a hidden field) and substitute a portal-safe order on a
+        # visible field for non-k8s users.
+        if not bypass_access and not self._user_is_k8s():
+            effective = order or self._order
+            if any(
+                hidden in effective
+                for hidden in ("cluster_id", "namespace")
+            ):
+                order = "name"
+        return super()._search(
+            domain,
+            offset=offset,
+            limit=limit,
+            order=order,
+            active_test=active_test,
+            bypass_access=bypass_access,
+        )
+
+    @api.depends("name", "namespace", "cluster_id.name")
+    def _compute_display_name(self):
+        # For portal users the namespace and cluster name are hidden; exposing
+        # them via display_name would defeat the secrecy. Show only the
+        # instance's own name to non-k8s users; internal users keep the full
+        # cluster/namespace/name path computed by super().
+        if self._user_is_k8s():
+            return super()._compute_display_name()
+        for instance in self:
+            instance.display_name = instance.name
 
     @api.model
     def _normalise_allowed_partner_commands(self, vals):
         """Rewrite allowed_partner_ids commands to use commercial partners.
 
         Handles the link/replace forms that carry partner ids (Command.set /
-        Command.link / Command.create-by-id). Unlink/clear forms are left
-        untouched. Returns ``vals`` (mutated copy) ready to pass to super().
+        Command.link). For each such command the referenced partners are
+        mapped to their ``commercial_partner_id`` before being passed to
+        super(). Other command forms (unlink/clear, and Command.create which
+        builds a brand-new partner from a values dict rather than referencing
+        an existing id) are left untouched. Returns ``vals`` (a mutated copy)
+        ready to pass to super().
         """
         commands = vals.get("allowed_partner_ids")
         if not commands:

--- a/odoo_herd_portal/models/k8s_odoo_staging_refresh.py
+++ b/odoo_herd_portal/models/k8s_odoo_staging_refresh.py
@@ -1,0 +1,83 @@
+# Part of Odoo Herd Portal. See LICENSE file for full copyright and licensing details.
+"""Feature E -- field secrecy + notification for k8s.odoo.staging.refresh.
+
+Deny-by-default whitelist, mirroring the upgrade model. Only the fields in
+``PORTAL_VISIBLE_REFRESH_FIELDS`` are readable by portal users; the webhook
+token, all k8s job names, the temp DB name, the source/rollback snapshots, the
+operator message blob, the cluster reference and the operator-strategy knobs
+(filestore method / skip-filestore / neutralize) are hidden behind the K8s
+group so a portal user cannot read them even via the ORM.
+
+``target_instance_id`` and ``source_instance_id`` are whitelisted: both are
+record-rule-scoped to instances the user owns (Feature A), so exposing the
+FK -- and rendering only ``.name`` off it -- is safe and needed for scoping.
+"""
+from odoo import fields, models
+
+PORTAL_VISIBLE_REFRESH_FIELDS = frozenset(
+    {
+        "id",
+        "name",
+        "display_name",
+        "state",
+        "start_time",
+        "completion_time",
+        "target_instance_id",
+        "source_instance_id",
+    }
+)
+
+_K8S_GROUP = "odoo_herd.group_k8s_user"
+
+
+class K8sOdooStagingRefresh(models.Model):
+    _inherit = "k8s.odoo.staging.refresh"
+
+    # --- Field-level secrecy: WHITELIST (deny-by-default) -------------------
+    webhook_token = fields.Char(groups=_K8S_GROUP)
+    refresh_job_name = fields.Char(groups=_K8S_GROUP)
+    db_job_name = fields.Char(groups=_K8S_GROUP)
+    filestore_job_name = fields.Char(groups=_K8S_GROUP)
+    neutralize_job_name = fields.Char(groups=_K8S_GROUP)
+    temp_db_name = fields.Char(groups=_K8S_GROUP)
+    source_snapshot = fields.Char(groups=_K8S_GROUP)
+    rollback_snapshot = fields.Char(groups=_K8S_GROUP)
+    message = fields.Text(groups=_K8S_GROUP)
+    cluster_id = fields.Many2one(groups=_K8S_GROUP)
+    # Operator-strategy knobs -- internal replication detail.
+    filestore_method = fields.Selection(groups=_K8S_GROUP)
+    skip_filestore = fields.Boolean(groups=_K8S_GROUP)
+    neutralize = fields.Boolean(groups=_K8S_GROUP)
+
+    def _notify_instance_terminal(self, outcome, message=None):
+        """Best-effort completion/failure note to the TARGET instance chatter."""
+        for record in self:
+            instance = record.target_instance_id.sudo()
+            if not instance:
+                continue
+            verb = "completed" if outcome == "completed" else "failed"
+            body = "Staging refresh %s %s." % (record.name, verb)
+            if message:
+                body += " %s" % message
+            try:
+                instance.message_post(
+                    body=body,
+                    message_type="comment",
+                    subtype_xmlid="mail.mt_note",
+                )
+            except Exception:  # noqa: BLE001 -- notification is best-effort
+                continue
+
+    def mark_completed(self, completion_time=None, message=None, status=None):
+        res = super().mark_completed(
+            completion_time=completion_time, message=message, status=status
+        )
+        self._notify_instance_terminal("completed", message)
+        return res
+
+    def mark_failed(self, message=None, completion_time=None, status=None):
+        res = super().mark_failed(
+            message=message, completion_time=completion_time, status=status
+        )
+        self._notify_instance_terminal("failed", message)
+        return res

--- a/odoo_herd_portal/models/k8s_odoo_staging_refresh.py
+++ b/odoo_herd_portal/models/k8s_odoo_staging_refresh.py
@@ -24,6 +24,9 @@ PORTAL_VISIBLE_REFRESH_FIELDS = frozenset(
         "completion_time",
         "target_instance_id",
         "source_instance_id",
+        # The portal user who triggered the job; notified directly on terminal
+        # state.
+        "portal_initiator_id",
     }
 )
 
@@ -48,20 +51,27 @@ class K8sOdooStagingRefresh(models.Model):
     filestore_method = fields.Selection(groups=_K8S_GROUP)
     skip_filestore = fields.Boolean(groups=_K8S_GROUP)
     neutralize = fields.Boolean(groups=_K8S_GROUP)
+    # The portal user (partner) who triggered the job. Set by the portal
+    # controller at create time; unset for herd-/operator-driven jobs.
+    portal_initiator_id = fields.Many2one("res.partner")
 
     def _notify_instance_terminal(self, outcome):
         """Best-effort: STATUS-ONLY completion/failure comment to the client.
 
-        Addressed directly to the TARGET instance's ``allowed_partner_ids`` via
-        the client-visible ``mail.mt_comment`` subtype (per-message recipients,
-        NO standing follower subscription). The raw operator ``message`` blob is
-        never included. Wrapped so a failure never blocks the state write.
+        The direct recipient (``partner_ids``) is the recorded
+        ``portal_initiator_id`` -- ONLY that partner, never the whole
+        ``allowed_partner_ids`` set. Posting with the ``mail.mt_comment`` subtype
+        additionally reaches the TARGET instance's EXISTING followers (intended).
+        If no initiator was recorded, followers are notified but no direct
+        ``partner_ids`` recipient is set. NO standing follower subscription is
+        added; the raw operator ``message`` blob is never included. Wrapped so a
+        failure never blocks the state write.
         """
         for record in self:
             instance = record.target_instance_id.sudo()
             if not instance:
                 continue
-            partner_ids = instance.allowed_partner_ids.ids
+            initiator = record.sudo().portal_initiator_id
             if outcome == "completed":
                 body = "Staging refresh completed."
             else:
@@ -69,7 +79,7 @@ class K8sOdooStagingRefresh(models.Model):
             try:
                 instance.message_post(
                     body=body,
-                    partner_ids=partner_ids,
+                    partner_ids=initiator.ids,
                     message_type="comment",
                     subtype_xmlid="mail.mt_comment",
                 )

--- a/odoo_herd_portal/models/k8s_odoo_staging_refresh.py
+++ b/odoo_herd_portal/models/k8s_odoo_staging_refresh.py
@@ -49,21 +49,29 @@ class K8sOdooStagingRefresh(models.Model):
     skip_filestore = fields.Boolean(groups=_K8S_GROUP)
     neutralize = fields.Boolean(groups=_K8S_GROUP)
 
-    def _notify_instance_terminal(self, outcome, message=None):
-        """Best-effort completion/failure note to the TARGET instance chatter."""
+    def _notify_instance_terminal(self, outcome):
+        """Best-effort: STATUS-ONLY completion/failure comment to the client.
+
+        Addressed directly to the TARGET instance's ``allowed_partner_ids`` via
+        the client-visible ``mail.mt_comment`` subtype (per-message recipients,
+        NO standing follower subscription). The raw operator ``message`` blob is
+        never included. Wrapped so a failure never blocks the state write.
+        """
         for record in self:
             instance = record.target_instance_id.sudo()
             if not instance:
                 continue
-            verb = "completed" if outcome == "completed" else "failed"
-            body = "Staging refresh %s %s." % (record.name, verb)
-            if message:
-                body += " %s" % message
+            partner_ids = instance.allowed_partner_ids.ids
+            if outcome == "completed":
+                body = "Staging refresh completed."
+            else:
+                body = "Staging refresh failed — Bemade has been notified."
             try:
                 instance.message_post(
                     body=body,
+                    partner_ids=partner_ids,
                     message_type="comment",
-                    subtype_xmlid="mail.mt_note",
+                    subtype_xmlid="mail.mt_comment",
                 )
             except Exception:  # noqa: BLE001 -- notification is best-effort
                 continue
@@ -72,12 +80,12 @@ class K8sOdooStagingRefresh(models.Model):
         res = super().mark_completed(
             completion_time=completion_time, message=message, status=status
         )
-        self._notify_instance_terminal("completed", message)
+        self._notify_instance_terminal("completed")
         return res
 
     def mark_failed(self, message=None, completion_time=None, status=None):
         res = super().mark_failed(
             message=message, completion_time=completion_time, status=status
         )
-        self._notify_instance_terminal("failed", message)
+        self._notify_instance_terminal("failed")
         return res

--- a/odoo_herd_portal/models/k8s_odoo_staging_refresh.py
+++ b/odoo_herd_portal/models/k8s_odoo_staging_refresh.py
@@ -1,4 +1,4 @@
-# Part of Odoo Herd Portal. See LICENSE file for full copyright and licensing details.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 """Feature E -- field secrecy + notification for k8s.odoo.staging.refresh.
 
 Deny-by-default whitelist, mirroring the upgrade model. Only the fields in

--- a/odoo_herd_portal/models/k8s_odoo_upgrade.py
+++ b/odoo_herd_portal/models/k8s_odoo_upgrade.py
@@ -1,4 +1,4 @@
-# Part of Odoo Herd Portal. See LICENSE file for full copyright and licensing details.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 """Feature E -- field-level secrecy + client notification for k8s.odoo.upgrade.
 
 Mirrors Feature A/D's secrecy model: a deny-by-default *whitelist*. Only the

--- a/odoo_herd_portal/models/k8s_odoo_upgrade.py
+++ b/odoo_herd_portal/models/k8s_odoo_upgrade.py
@@ -1,0 +1,95 @@
+# Part of Odoo Herd Portal. See LICENSE file for full copyright and licensing details.
+"""Feature E -- field-level secrecy + client notification for k8s.odoo.upgrade.
+
+Mirrors Feature A/D's secrecy model: a deny-by-default *whitelist*. Only the
+fields in ``PORTAL_VISIBLE_UPGRADE_FIELDS`` are readable by portal users; every
+other field -- the webhook token, the k8s job name/uid, the operator message
+blob, the cluster reference and the raw module lists -- is redefined here with
+``groups="odoo_herd.group_k8s_user"`` so a portal user cannot read it even via
+the ORM. New fields added to the base model later default to hidden until added
+to the whitelist; the drift-guard test enforces this.
+
+It also wires the client-facing completion/failure notification: when the
+operator webhook drives ``mark_completed`` / ``mark_failed`` (the real terminal
+state transition), a best-effort message is posted to the *instance's* chatter
+so the instance followers (incl. the allowed partners subscribed when the
+action was initiated) are notified.
+"""
+from odoo import fields, models
+
+# Single source of truth for the portal-visible upgrade field whitelist. Kept
+# in the model so the drift-guard test imports the exact same set the code
+# enforces. instance_id is included for record-rule scoping.
+PORTAL_VISIBLE_UPGRADE_FIELDS = frozenset(
+    {
+        "id",
+        "name",
+        "display_name",
+        "state",
+        "scheduled_time",
+        "start_time",
+        "completion_time",
+        "instance_id",
+    }
+)
+
+# Group whose members (internal K8s users) keep full field access.
+_K8S_GROUP = "odoo_herd.group_k8s_user"
+
+
+class K8sOdooUpgrade(models.Model):
+    _inherit = "k8s.odoo.upgrade"
+
+    # --- Field-level secrecy: WHITELIST (deny-by-default) -------------------
+    # Webhook token -- shared secret with the operator.
+    webhook_token = fields.Char(groups=_K8S_GROUP)
+    # Kubernetes job identifiers.
+    job_name = fields.Char(groups=_K8S_GROUP)
+    job_uid = fields.Char(groups=_K8S_GROUP)
+    # Operator-side message blob (may carry internal paths / errors).
+    message = fields.Text(groups=_K8S_GROUP)
+    # Cluster traversal -- hidden so portal can't reach cluster credentials.
+    cluster_id = fields.Many2one(groups=_K8S_GROUP)
+    # Raw module lists -- internal upgrade detail, not portal-relevant.
+    modules = fields.Text(groups=_K8S_GROUP)
+    modules_install = fields.Text(groups=_K8S_GROUP)
+
+    def _notify_instance_terminal(self, outcome, message=None):
+        """Best-effort: post a completion/failure note to the instance chatter.
+
+        Fires only on the real terminal-state transition (the operator webhook
+        drives ``mark_completed`` / ``mark_failed`` in prod). The instance is
+        a ``mail.thread``; its followers (incl. the allowed partners subscribed
+        when the action was initiated) receive the message. Wrapped so a
+        notification failure never blocks the state write.
+        """
+        for record in self:
+            instance = record.instance_id.sudo()
+            if not instance:
+                continue
+            try:
+                instance.message_post(
+                    body=record._terminal_notification_body(outcome, message),
+                    message_type="comment",
+                    subtype_xmlid="mail.mt_note",
+                )
+            except Exception:  # noqa: BLE001 -- notification is best-effort
+                continue
+
+    def _terminal_notification_body(self, outcome, message):
+        self.ensure_one()
+        verb = "completed" if outcome == "completed" else "failed"
+        body = "Module upgrade %s %s." % (self.name, verb)
+        if message:
+            body += " %s" % message
+        return body
+
+    def mark_completed(self, completion_time=None, message=None):
+        res = super().mark_completed(completion_time=completion_time, message=message)
+        self._notify_instance_terminal("completed", message)
+        return res
+
+    def mark_failed(self, message=None, completion_time=None):
+        res = super().mark_failed(message=message, completion_time=completion_time)
+        self._notify_instance_terminal("failed", message)
+        return res

--- a/odoo_herd_portal/models/k8s_odoo_upgrade.py
+++ b/odoo_herd_portal/models/k8s_odoo_upgrade.py
@@ -11,9 +11,11 @@ to the whitelist; the drift-guard test enforces this.
 
 It also wires the client-facing completion/failure notification: when the
 operator webhook drives ``mark_completed`` / ``mark_failed`` (the real terminal
-state transition), a best-effort message is posted to the *instance's* chatter
-so the instance followers (incl. the allowed partners subscribed when the
-action was initiated) are notified.
+state transition), a status-only message is posted to the *instance's* chatter
+addressed directly to the instance's ``allowed_partner_ids`` via a
+client-visible ``mail.mt_comment`` subtype. Recipients are set per-message
+(``partner_ids=``); there is NO standing follower subscription, so no future
+internal team comment leaks to the client.
 """
 from odoo import fields, models
 
@@ -54,42 +56,45 @@ class K8sOdooUpgrade(models.Model):
     modules = fields.Text(groups=_K8S_GROUP)
     modules_install = fields.Text(groups=_K8S_GROUP)
 
-    def _notify_instance_terminal(self, outcome, message=None):
-        """Best-effort: post a completion/failure note to the instance chatter.
+    def _notify_instance_terminal(self, outcome):
+        """Best-effort: post a STATUS-ONLY completion/failure comment.
 
         Fires only on the real terminal-state transition (the operator webhook
-        drives ``mark_completed`` / ``mark_failed`` in prod). The instance is
-        a ``mail.thread``; its followers (incl. the allowed partners subscribed
-        when the action was initiated) receive the message. Wrapped so a
-        notification failure never blocks the state write.
+        drives ``mark_completed`` / ``mark_failed`` in prod). The message is
+        addressed directly to the instance's ``allowed_partner_ids`` via the
+        client-visible ``mail.mt_comment`` subtype, so it reaches the client
+        (portal chatter + share-partner email) WITHOUT any standing follower
+        subscription. The raw operator ``message`` blob is never included.
+        Wrapped so a notification failure never blocks the state write.
         """
         for record in self:
             instance = record.instance_id.sudo()
             if not instance:
                 continue
+            partner_ids = instance.allowed_partner_ids.ids
             try:
                 instance.message_post(
-                    body=record._terminal_notification_body(outcome, message),
+                    body=record._terminal_notification_body(outcome),
+                    partner_ids=partner_ids,
                     message_type="comment",
-                    subtype_xmlid="mail.mt_note",
+                    subtype_xmlid="mail.mt_comment",
                 )
             except Exception:  # noqa: BLE001 -- notification is best-effort
                 continue
 
-    def _terminal_notification_body(self, outcome, message):
+    def _terminal_notification_body(self, outcome):
+        """Status-only client-facing body. NEVER includes the operator blob."""
         self.ensure_one()
-        verb = "completed" if outcome == "completed" else "failed"
-        body = "Module upgrade %s %s." % (self.name, verb)
-        if message:
-            body += " %s" % message
-        return body
+        if outcome == "completed":
+            return "Module upgrade completed."
+        return "Module upgrade failed — Bemade has been notified."
 
     def mark_completed(self, completion_time=None, message=None):
         res = super().mark_completed(completion_time=completion_time, message=message)
-        self._notify_instance_terminal("completed", message)
+        self._notify_instance_terminal("completed")
         return res
 
     def mark_failed(self, message=None, completion_time=None):
         res = super().mark_failed(message=message, completion_time=completion_time)
-        self._notify_instance_terminal("failed", message)
+        self._notify_instance_terminal("failed")
         return res

--- a/odoo_herd_portal/models/k8s_odoo_upgrade.py
+++ b/odoo_herd_portal/models/k8s_odoo_upgrade.py
@@ -12,10 +12,15 @@ to the whitelist; the drift-guard test enforces this.
 It also wires the client-facing completion/failure notification: when the
 operator webhook drives ``mark_completed`` / ``mark_failed`` (the real terminal
 state transition), a status-only message is posted to the *instance's* chatter
-addressed directly to the instance's ``allowed_partner_ids`` via a
-client-visible ``mail.mt_comment`` subtype. Recipients are set per-message
-(``partner_ids=``); there is NO standing follower subscription, so no future
-internal team comment leaks to the client.
+via a client-visible ``mail.mt_comment`` subtype. The direct recipient
+(``partner_ids``) is the recorded ``portal_initiator_id`` -- the portal user who
+triggered the job -- and ONLY that partner, never the whole
+``allowed_partner_ids`` set (no blast). Posting with the ``mt_comment`` subtype
+additionally reaches the instance's EXISTING followers; that is intended and
+sufficient. A herd-/operator-driven job has no ``portal_initiator_id``, in which
+case followers are notified but no direct ``partner_ids`` recipient is set.
+There is NO standing follower subscription added here, so no future internal
+team comment leaks to the client.
 """
 from odoo import fields, models
 
@@ -32,6 +37,9 @@ PORTAL_VISIBLE_UPGRADE_FIELDS = frozenset(
         "start_time",
         "completion_time",
         "instance_id",
+        # The portal user who triggered the job; readable so the portal can
+        # show who initiated it. Notified directly on terminal state.
+        "portal_initiator_id",
     }
 )
 
@@ -55,27 +63,32 @@ class K8sOdooUpgrade(models.Model):
     # Raw module lists -- internal upgrade detail, not portal-relevant.
     modules = fields.Text(groups=_K8S_GROUP)
     modules_install = fields.Text(groups=_K8S_GROUP)
+    # The portal user (partner) who triggered the job. Set by the portal
+    # controller at create time; unset for herd-/operator-driven jobs.
+    portal_initiator_id = fields.Many2one("res.partner")
 
     def _notify_instance_terminal(self, outcome):
         """Best-effort: post a STATUS-ONLY completion/failure comment.
 
         Fires only on the real terminal-state transition (the operator webhook
-        drives ``mark_completed`` / ``mark_failed`` in prod). The message is
-        addressed directly to the instance's ``allowed_partner_ids`` via the
-        client-visible ``mail.mt_comment`` subtype, so it reaches the client
-        (portal chatter + share-partner email) WITHOUT any standing follower
-        subscription. The raw operator ``message`` blob is never included.
-        Wrapped so a notification failure never blocks the state write.
+        drives ``mark_completed`` / ``mark_failed`` in prod). The direct
+        recipient (``partner_ids``) is the recorded ``portal_initiator_id`` --
+        ONLY that partner, never the whole ``allowed_partner_ids`` set. Posting
+        with the ``mail.mt_comment`` subtype additionally reaches the instance's
+        EXISTING followers (intended). If no initiator was recorded, followers
+        are notified but no direct ``partner_ids`` recipient is set. NO standing
+        follower subscription is added; the raw operator ``message`` blob is
+        never included. Wrapped so a failure never blocks the state write.
         """
         for record in self:
             instance = record.instance_id.sudo()
             if not instance:
                 continue
-            partner_ids = instance.allowed_partner_ids.ids
+            initiator = record.sudo().portal_initiator_id
             try:
                 instance.message_post(
                     body=record._terminal_notification_body(outcome),
-                    partner_ids=partner_ids,
+                    partner_ids=initiator.ids,
                     message_type="comment",
                     subtype_xmlid="mail.mt_comment",
                 )

--- a/odoo_herd_portal/security/ir.model.access.csv
+++ b/odoo_herd_portal/security/ir.model.access.csv
@@ -1,3 +1,5 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_k8s_odoo_instance_portal,k8s.odoo.instance portal read-only,odoo_herd.model_k8s_odoo_instance,base.group_portal,1,0,0,0
 access_k8s_odoo_backup_portal,k8s.odoo.backup portal read-only,odoo_herd.model_k8s_odoo_backup,base.group_portal,1,0,0,0
+access_k8s_odoo_upgrade_portal,k8s.odoo.upgrade portal read-only,odoo_herd.model_k8s_odoo_upgrade,base.group_portal,1,0,0,0
+access_k8s_odoo_staging_refresh_portal,k8s.odoo.staging.refresh portal read-only,odoo_herd.model_k8s_odoo_staging_refresh,base.group_portal,1,0,0,0

--- a/odoo_herd_portal/security/ir.model.access.csv
+++ b/odoo_herd_portal/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_k8s_odoo_instance_portal,k8s.odoo.instance portal read-only,odoo_herd.model_k8s_odoo_instance,base.group_portal,1,0,0,0

--- a/odoo_herd_portal/security/ir.model.access.csv
+++ b/odoo_herd_portal/security/ir.model.access.csv
@@ -1,2 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_k8s_odoo_instance_portal,k8s.odoo.instance portal read-only,odoo_herd.model_k8s_odoo_instance,base.group_portal,1,0,0,0
+access_k8s_odoo_backup_portal,k8s.odoo.backup portal read-only,odoo_herd.model_k8s_odoo_backup,base.group_portal,1,0,0,0

--- a/odoo_herd_portal/security/k8s_portal_security.xml
+++ b/odoo_herd_portal/security/k8s_portal_security.xml
@@ -44,4 +44,46 @@
         <field name="perm_create" eval="False"/>
         <field name="perm_unlink" eval="False"/>
     </record>
+
+    <!--
+        Portal record rule (read-only) for k8s.odoo.upgrade (Feature E).
+
+        Scoped to base.group_portal ONLY: a portal user may read an upgrade job
+        only when its instance is one their commercial partner owns (same
+        ownership traversal as the instance/backup rules). The privileged
+        upgrade action runs under sudo() in the controller AFTER an explicit
+        ownership check in the user's own context; this rule is purely the
+        read/visibility barrier (so a client can watch their own upgrade's
+        state without seeing anyone else's).
+    -->
+    <record id="rule_k8s_upgrade_portal" model="ir.rule">
+        <field name="name">K8s Upgrade: Portal Owner Access</field>
+        <field name="model_id" ref="odoo_herd.model_k8s_odoo_upgrade"/>
+        <field name="domain_force">[('instance_id.allowed_partner_ids.commercial_partner_id', 'in', [user.partner_id.commercial_partner_id.id])]</field>
+        <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+    </record>
+
+    <!--
+        Portal record rule (read-only) for k8s.odoo.staging.refresh (Feature E).
+
+        Scoped to base.group_portal ONLY: a portal user may read a refresh job
+        only when its TARGET instance is one their commercial partner owns. The
+        privileged staging-refresh action runs under sudo() in the controller
+        AFTER an explicit ownership check (target AND source) in the user's own
+        context; this rule is purely the read/visibility barrier.
+    -->
+    <record id="rule_k8s_staging_refresh_portal" model="ir.rule">
+        <field name="name">K8s Staging Refresh: Portal Owner Access</field>
+        <field name="model_id" ref="odoo_herd.model_k8s_odoo_staging_refresh"/>
+        <field name="domain_force">[('target_instance_id.allowed_partner_ids.commercial_partner_id', 'in', [user.partner_id.commercial_partner_id.id])]</field>
+        <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+    </record>
 </odoo>

--- a/odoo_herd_portal/security/k8s_portal_security.xml
+++ b/odoo_herd_portal/security/k8s_portal_security.xml
@@ -4,19 +4,18 @@
         Portal record rule (read-only) for k8s.odoo.instance.
 
         Scoped to base.group_portal ONLY (not global), so it restricts portal
-        users to instances whose allowed_partner_ids include the user's
-        commercial partner, while leaving the existing group_k8s_user /
-        group_k8s_manager rules (which see everything) untouched.
+        users to instances whose allowed_partner_ids include the user's OWN
+        partner, while leaving the existing group_k8s_user / group_k8s_manager
+        rules (which see everything) untouched.
 
-        The domain matches on commercial_partner_id of the stored allowed
-        partner, so it works whether the stored partner is a company or a
-        contact (defense in depth: writes normalise to commercial partners,
-        but a hand-set contact would still match here).
+        Access is granted person by person: the domain matches the portal
+        user's own partner directly (no commercial-partner traversal), so a
+        colleague at the same company is NOT granted access unless added.
     -->
     <record id="rule_k8s_instance_portal" model="ir.rule">
         <field name="name">K8s Instance: Portal Owner Access</field>
         <field name="model_id" ref="odoo_herd.model_k8s_odoo_instance"/>
-        <field name="domain_force">[('allowed_partner_ids.commercial_partner_id', 'in', [user.partner_id.commercial_partner_id.id])]</field>
+        <field name="domain_force">[('allowed_partner_ids', 'in', [user.partner_id.id])]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
         <field name="perm_read" eval="True"/>
         <field name="perm_write" eval="False"/>
@@ -28,8 +27,8 @@
         Portal record rule (read-only) for k8s.odoo.backup.
 
         Scoped to base.group_portal ONLY: a portal user may read a backup only
-        when its instance is one their commercial partner owns (same ownership
-        traversal as the instance rule). The privileged client actions
+        when its instance lists the user's own partner (same person-by-person
+        ownership as the instance rule). The privileged client actions
         (backup-now, restore, download) are NOT granted by this rule: they run
         under sudo() in the controller AFTER an explicit ownership check in the
         user's own context, so this rule is purely the read/visibility barrier.
@@ -37,7 +36,7 @@
     <record id="rule_k8s_backup_portal" model="ir.rule">
         <field name="name">K8s Backup: Portal Owner Access</field>
         <field name="model_id" ref="odoo_herd.model_k8s_odoo_backup"/>
-        <field name="domain_force">[('instance_id.allowed_partner_ids.commercial_partner_id', 'in', [user.partner_id.commercial_partner_id.id])]</field>
+        <field name="domain_force">[('instance_id.allowed_partner_ids', 'in', [user.partner_id.id])]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
         <field name="perm_read" eval="True"/>
         <field name="perm_write" eval="False"/>
@@ -49,8 +48,8 @@
         Portal record rule (read-only) for k8s.odoo.upgrade (Feature E).
 
         Scoped to base.group_portal ONLY: a portal user may read an upgrade job
-        only when its instance is one their commercial partner owns (same
-        ownership traversal as the instance/backup rules). The privileged
+        only when its instance lists the user's own partner (same
+        person-by-person ownership as the instance/backup rules). The privileged
         upgrade action runs under sudo() in the controller AFTER an explicit
         ownership check in the user's own context; this rule is purely the
         read/visibility barrier (so a client can watch their own upgrade's
@@ -59,7 +58,7 @@
     <record id="rule_k8s_upgrade_portal" model="ir.rule">
         <field name="name">K8s Upgrade: Portal Owner Access</field>
         <field name="model_id" ref="odoo_herd.model_k8s_odoo_upgrade"/>
-        <field name="domain_force">[('instance_id.allowed_partner_ids.commercial_partner_id', 'in', [user.partner_id.commercial_partner_id.id])]</field>
+        <field name="domain_force">[('instance_id.allowed_partner_ids', 'in', [user.partner_id.id])]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
         <field name="perm_read" eval="True"/>
         <field name="perm_write" eval="False"/>
@@ -71,7 +70,7 @@
         Portal record rule (read-only) for k8s.odoo.staging.refresh (Feature E).
 
         Scoped to base.group_portal ONLY: a portal user may read a refresh job
-        only when its TARGET instance is one their commercial partner owns. The
+        only when its TARGET instance lists the user's own partner. The
         privileged staging-refresh action runs under sudo() in the controller
         AFTER an explicit ownership check (target AND source) in the user's own
         context; this rule is purely the read/visibility barrier.
@@ -79,7 +78,7 @@
     <record id="rule_k8s_staging_refresh_portal" model="ir.rule">
         <field name="name">K8s Staging Refresh: Portal Owner Access</field>
         <field name="model_id" ref="odoo_herd.model_k8s_odoo_staging_refresh"/>
-        <field name="domain_force">[('target_instance_id.allowed_partner_ids.commercial_partner_id', 'in', [user.partner_id.commercial_partner_id.id])]</field>
+        <field name="domain_force">[('target_instance_id.allowed_partner_ids', 'in', [user.partner_id.id])]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
         <field name="perm_read" eval="True"/>
         <field name="perm_write" eval="False"/>

--- a/odoo_herd_portal/security/k8s_portal_security.xml
+++ b/odoo_herd_portal/security/k8s_portal_security.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!--
+        Portal record rule (read-only) for k8s.odoo.instance.
+
+        Scoped to base.group_portal ONLY (not global), so it restricts portal
+        users to instances whose allowed_partner_ids include the user's
+        commercial partner, while leaving the existing group_k8s_user /
+        group_k8s_manager rules (which see everything) untouched.
+
+        The domain matches on commercial_partner_id of the stored allowed
+        partner, so it works whether the stored partner is a company or a
+        contact (defense in depth: writes normalise to commercial partners,
+        but a hand-set contact would still match here).
+    -->
+    <record id="rule_k8s_instance_portal" model="ir.rule">
+        <field name="name">K8s Instance: Portal Owner Access</field>
+        <field name="model_id" ref="odoo_herd.model_k8s_odoo_instance"/>
+        <field name="domain_force">[('allowed_partner_ids.commercial_partner_id', 'in', [user.partner_id.commercial_partner_id.id])]</field>
+        <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+    </record>
+</odoo>

--- a/odoo_herd_portal/security/k8s_portal_security.xml
+++ b/odoo_herd_portal/security/k8s_portal_security.xml
@@ -23,4 +23,25 @@
         <field name="perm_create" eval="False"/>
         <field name="perm_unlink" eval="False"/>
     </record>
+
+    <!--
+        Portal record rule (read-only) for k8s.odoo.backup.
+
+        Scoped to base.group_portal ONLY: a portal user may read a backup only
+        when its instance is one their commercial partner owns (same ownership
+        traversal as the instance rule). The privileged client actions
+        (backup-now, restore, download) are NOT granted by this rule: they run
+        under sudo() in the controller AFTER an explicit ownership check in the
+        user's own context, so this rule is purely the read/visibility barrier.
+    -->
+    <record id="rule_k8s_backup_portal" model="ir.rule">
+        <field name="name">K8s Backup: Portal Owner Access</field>
+        <field name="model_id" ref="odoo_herd.model_k8s_odoo_backup"/>
+        <field name="domain_force">[('instance_id.allowed_partner_ids.commercial_partner_id', 'in', [user.partner_id.commercial_partner_id.id])]</field>
+        <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+    </record>
 </odoo>

--- a/odoo_herd_portal/static/src/js/log_viewer.js
+++ b/odoo_herd_portal/static/src/js/log_viewer.js
@@ -1,0 +1,73 @@
+/* Part of Odoo Herd Portal. See LICENSE file for full copyright and licensing details. */
+/**
+ * Feature C -- live log viewer handoff.
+ *
+ * Hands the short-lived signed scope token (minted server-side, embedded in
+ * the ``data-log-scope`` attribute) to the sidecar iframe via ``postMessage``
+ * -- NOT via the iframe ``src`` / query string, so the token is never logged
+ * by proxies. (The attribute is named ``data-log-scope`` rather than
+ * ``...token`` because Odoo's website layer strips ``*token*`` attributes.)
+ *
+ * The target origin is derived from the configured sidecar URL
+ * (``data-log-viewer-url``) so the token is posted to the sidecar's origin
+ * ONLY -- never broadcast with ``"*"``. The sidecar verifies the token's HMAC
+ * signature and expiry, then trusts only its ``ns`` + ``sel`` claims.
+ */
+(function () {
+    "use strict";
+
+    function targetOriginFrom(url) {
+        try {
+            return new URL(url).origin;
+        } catch (e) {
+            return null;
+        }
+    }
+
+    function handoff(container) {
+        var token = container.getAttribute("data-log-scope");
+        var viewerUrl = container.getAttribute("data-log-viewer-url");
+        var iframe = container.querySelector("iframe.o_herd_log_iframe");
+        if (!token || !viewerUrl || !iframe) {
+            return;
+        }
+        var targetOrigin = targetOriginFrom(viewerUrl);
+        if (!targetOrigin) {
+            return;
+        }
+
+        var post = function () {
+            if (iframe.contentWindow) {
+                iframe.contentWindow.postMessage(
+                    { type: "herd-log-token", token: token },
+                    targetOrigin
+                );
+            }
+        };
+
+        // The iframe may load before or after this script runs; post on load,
+        // and also re-post if the sidecar asks for the token after it boots.
+        iframe.addEventListener("load", post);
+        window.addEventListener("message", function (event) {
+            if (
+                event.origin === targetOrigin &&
+                event.data &&
+                event.data.type === "herd-log-token-request"
+            ) {
+                post();
+            }
+        });
+    }
+
+    function init() {
+        document
+            .querySelectorAll(".o_herd_log_viewer")
+            .forEach(handoff);
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", init);
+    } else {
+        init();
+    }
+})();

--- a/odoo_herd_portal/static/src/js/log_viewer.js
+++ b/odoo_herd_portal/static/src/js/log_viewer.js
@@ -1,4 +1,4 @@
-/* Part of Odoo Herd Portal. See LICENSE file for full copyright and licensing details. */
+/* License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). */
 /**
  * Feature C -- live log viewer handoff.
  *

--- a/odoo_herd_portal/tests/__init__.py
+++ b/odoo_herd_portal/tests/__init__.py
@@ -1,3 +1,4 @@
 # Part of Odoo Herd Portal. See LICENSE file for full copyright and licensing details.
 from . import test_access_ownership
 from . import test_portal_overview
+from . import test_backups

--- a/odoo_herd_portal/tests/__init__.py
+++ b/odoo_herd_portal/tests/__init__.py
@@ -1,2 +1,2 @@
 # Part of Odoo Herd Portal. See LICENSE file for full copyright and licensing details.
-from . import models
+from . import test_access_ownership

--- a/odoo_herd_portal/tests/__init__.py
+++ b/odoo_herd_portal/tests/__init__.py
@@ -1,4 +1,4 @@
-# Part of Odoo Herd Portal. See LICENSE file for full copyright and licensing details.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 from . import test_access_ownership
 from . import test_portal_overview
 from . import test_backups

--- a/odoo_herd_portal/tests/__init__.py
+++ b/odoo_herd_portal/tests/__init__.py
@@ -1,2 +1,3 @@
 # Part of Odoo Herd Portal. See LICENSE file for full copyright and licensing details.
 from . import test_access_ownership
+from . import test_portal_overview

--- a/odoo_herd_portal/tests/__init__.py
+++ b/odoo_herd_portal/tests/__init__.py
@@ -3,3 +3,4 @@ from . import test_access_ownership
 from . import test_portal_overview
 from . import test_backups
 from . import test_lifecycle
+from . import test_log_viewer

--- a/odoo_herd_portal/tests/__init__.py
+++ b/odoo_herd_portal/tests/__init__.py
@@ -2,3 +2,4 @@
 from . import test_access_ownership
 from . import test_portal_overview
 from . import test_backups
+from . import test_lifecycle

--- a/odoo_herd_portal/tests/__init__.py
+++ b/odoo_herd_portal/tests/__init__.py
@@ -4,3 +4,4 @@ from . import test_portal_overview
 from . import test_backups
 from . import test_lifecycle
 from . import test_log_viewer
+from . import test_backend_view

--- a/odoo_herd_portal/tests/test_access_ownership.py
+++ b/odoo_herd_portal/tests/test_access_ownership.py
@@ -1,4 +1,4 @@
-# Part of Odoo Herd Portal. See LICENSE file for full copyright and licensing details.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 """Feature A -- access & ownership (keystone) acceptance tests.
 
 Acceptance criteria under test:

--- a/odoo_herd_portal/tests/test_access_ownership.py
+++ b/odoo_herd_portal/tests/test_access_ownership.py
@@ -22,6 +22,41 @@ from odoo.exceptions import AccessError
 from odoo.tests.common import TransactionCase, tagged
 from odoo.tools.misc import mute_logger
 
+from odoo.addons.odoo_herd_portal.models.k8s_odoo_instance import (
+    PORTAL_VISIBLE_FIELDS,
+)
+
+# Framework / audit fields that are readable by any user by design and are not
+# instance/cluster secrets. They are intentionally NOT in PORTAL_VISIBLE_FIELDS
+# (the client UI doesn't surface them) but the drift-guard must not demand
+# AccessError on them: they're framework plumbing, not Feature A's secrecy
+# concern. The mail.thread chatter fields carry only message/follower metadata
+# and are already core-gated to base.group_user; gating them with the k8s group
+# would break the chatter widget for non-k8s internal users.
+_FRAMEWORK_READABLE = frozenset(
+    {
+        "create_date",
+        "write_date",
+        "create_uid",
+        "write_uid",
+        "__last_update",
+        # mail.thread / chatter metadata (core, group_user-gated)
+        "message_is_follower",
+        "message_follower_ids",
+        "message_partner_ids",
+        "message_ids",
+        "has_message",
+        "message_needaction",
+        "message_needaction_counter",
+        "message_has_error",
+        "message_has_error_counter",
+        "message_has_sms_error",
+        "message_attachment_count",
+        "website_message_ids",
+        "rating_ids",
+    }
+)
+
 
 @tagged("post_install", "-at_install", "odoo_herd_portal")
 class TestAccessOwnership(TransactionCase):
@@ -170,3 +205,85 @@ class TestAccessOwnership(TransactionCase):
         visible = self.env["k8s.odoo.instance"].with_user(k8s_user).search([])
         self.assertIn(self.instance_x, visible)
         self.assertIn(self.instance_y, visible)
+
+    # ------------------------------------------------------------------
+    # Whitelist hardening (review fix): secrecy holes closed
+    # ------------------------------------------------------------------
+    def test_known_secret_fields_unreadable_by_portal(self):
+        """The specific leaks the review proved are now AccessError."""
+        inst = self.instance_x.with_user(self.user_x)
+        for field_name in (
+            "config_options",
+            "cluster_id",
+            "image_pull_secret",
+            "database_cluster",
+        ):
+            with self.subTest(field=field_name):
+                with self.assertRaises(
+                    AccessError,
+                    msg="Field %s must be unreadable by portal users"
+                    % field_name,
+                ), mute_logger("odoo.models"):
+                    inst.read([field_name])
+
+    def test_cluster_kubeconfig_traversal_blocked(self):
+        """cluster_id.kubeconfig must not leak via related-field traversal."""
+        inst = self.instance_x.with_user(self.user_x)
+        # Reaching cluster_id is itself blocked; reading kubeconfig off the
+        # cluster is blocked too. Either raising AccessError satisfies the
+        # defense-in-depth requirement.
+        with self.assertRaises(AccessError), mute_logger("odoo.models"):
+            inst.cluster_id.kubeconfig
+
+    def test_cluster_secret_fields_unreadable_by_portal(self):
+        """Cluster credentials/secrets are AccessError for portal users."""
+        cluster = self.cluster.with_user(self.user_x)
+        for field_name in ("kubeconfig", "instance_webhook_token", "api_endpoint"):
+            with self.subTest(field=field_name):
+                with self.assertRaises(AccessError), mute_logger("odoo.models"):
+                    cluster.read([field_name])
+
+    def test_whitelisted_fields_readable_by_portal(self):
+        """Every whitelisted field must remain readable by a portal user."""
+        inst = self.instance_x.with_user(self.user_x)
+        model_fields = self.env["k8s.odoo.instance"]._fields
+        readable = sorted(PORTAL_VISIBLE_FIELDS & set(model_fields))
+        # Sanity: the whitelist names real fields.
+        self.assertEqual(
+            set(readable),
+            PORTAL_VISIBLE_FIELDS,
+            "PORTAL_VISIBLE_FIELDS references fields absent from the model.",
+        )
+        # A single read of all whitelisted fields must succeed.
+        values = inst.read(readable)
+        self.assertTrue(values, "Portal user must be able to read whitelisted fields.")
+
+    def test_drift_guard_non_whitelisted_fields_hidden(self):
+        """Deny-by-default: any field NOT whitelisted is hidden from portal.
+
+        This is the key protection against blocklist fragility -- a field added
+        to the base model later defaults to hidden (AccessError on read) unless
+        it is deliberately added to PORTAL_VISIBLE_FIELDS.
+        """
+        Instance = self.env["k8s.odoo.instance"]
+        inst = self.instance_x.with_user(self.user_x)
+        leaked = []
+        for field_name in Instance._fields:
+            if field_name in PORTAL_VISIBLE_FIELDS:
+                continue
+            if field_name in _FRAMEWORK_READABLE:
+                continue
+            with self.subTest(field=field_name):
+                try:
+                    with mute_logger("odoo.models"):
+                        inst.read([field_name])
+                except AccessError:
+                    continue
+                # Reading did not raise -> the field is exposed to portal.
+                leaked.append(field_name)
+        self.assertEqual(
+            leaked,
+            [],
+            "These non-whitelisted fields are readable by a portal user and "
+            "must be hidden (add groups= or extend the whitelist): %s" % leaked,
+        )

--- a/odoo_herd_portal/tests/test_access_ownership.py
+++ b/odoo_herd_portal/tests/test_access_ownership.py
@@ -1,0 +1,172 @@
+# Part of Odoo Herd Portal. See LICENSE file for full copyright and licensing details.
+"""Feature A -- access & ownership (keystone) acceptance tests.
+
+Acceptance criteria under test:
+
+* A portal user sees ONLY the ``k8s.odoo.instance`` records their company is
+  allowed (record rule scoped to ``base.group_portal`` matching the user's
+  ``commercial_partner_id``).
+* A portal user of company X cannot see company Y's instances (cross-tenant
+  isolation at the ORM layer).
+* Normalisation: ``allowed_partner_ids`` is normalised to commercial partners
+  on write, so a *contact* of an allowed company still matches the rule.
+* A portal user with no allowed instances gets an empty, NON-erroring result
+  (an empty recordset, not an AccessError).
+* Sensitive fields (``spec``, ``status``) are unreadable by portal users even
+  via the ORM (defense in depth via ``groups=`` on the field).
+* Internal K8s users keep seeing every instance (the existing global-ish
+  ``group_k8s_user`` rule is not broken by the new portal rule).
+"""
+
+from odoo.exceptions import AccessError
+from odoo.tests.common import TransactionCase, tagged
+from odoo.tools.misc import mute_logger
+
+
+@tagged("post_install", "-at_install", "odoo_herd_portal")
+class TestAccessOwnership(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        Partner = cls.env["res.partner"]
+        Users = cls.env["res.users"]
+        portal_group = cls.env.ref("base.group_portal")
+
+        # Two client companies, each with a child contact.
+        cls.company_x = Partner.create({"name": "Company X", "is_company": True})
+        cls.contact_x = Partner.create(
+            {"name": "Alice X", "parent_id": cls.company_x.id}
+        )
+        cls.company_y = Partner.create({"name": "Company Y", "is_company": True})
+        cls.contact_y = Partner.create(
+            {"name": "Bob Y", "parent_id": cls.company_y.id}
+        )
+
+        # Portal users tied to each contact (a contact of the company, not the
+        # company record itself -- this exercises commercial-partner matching).
+        cls.user_x = Users.create(
+            {
+                "name": "Portal User X",
+                "login": "portal_user_x",
+                "email": "portal_x@example.com",
+                "partner_id": cls.contact_x.id,
+                "group_ids": [(6, 0, [portal_group.id])],
+            }
+        )
+        cls.user_y = Users.create(
+            {
+                "name": "Portal User Y",
+                "login": "portal_user_y",
+                "email": "portal_y@example.com",
+                "partner_id": cls.contact_y.id,
+                "group_ids": [(6, 0, [portal_group.id])],
+            }
+        )
+        # A portal user whose company owns nothing.
+        cls.company_z = Partner.create({"name": "Company Z", "is_company": True})
+        cls.user_z = Users.create(
+            {
+                "name": "Portal User Z",
+                "login": "portal_user_z",
+                "email": "portal_z@example.com",
+                "partner_id": cls.company_z.id,
+                "group_ids": [(6, 0, [portal_group.id])],
+            }
+        )
+
+        # Inactive cluster so the k8s-hitting computes short-circuit.
+        cls.cluster = cls.env["k8s.cluster"].create(
+            {
+                "name": "Test Cluster",
+                "api_endpoint": "https://example.invalid:6443",
+                "kubeconfig": "apiVersion: v1\nkind: Config\n",
+                "default_namespace": "default",
+                "active": False,
+            }
+        )
+        Instance = cls.env["k8s.odoo.instance"]
+        # Instance owned by company X -- allowed via the *contact*, to prove
+        # normalisation up to the commercial partner.
+        cls.instance_x = Instance.create(
+            {
+                "name": "inst-x",
+                "namespace": "x",
+                "cluster_id": cls.cluster.id,
+                "environment": "production",
+                "allowed_partner_ids": [(6, 0, [cls.contact_x.id])],
+            }
+        )
+        # Instance owned by company Y -- allowed via the company record itself.
+        cls.instance_y = Instance.create(
+            {
+                "name": "inst-y",
+                "namespace": "y",
+                "cluster_id": cls.cluster.id,
+                "environment": "production",
+                "allowed_partner_ids": [(6, 0, [cls.company_y.id])],
+            }
+        )
+
+    def test_normalisation_to_commercial_partner(self):
+        """Writing a contact stores its commercial (company) partner."""
+        self.assertIn(
+            self.company_x,
+            self.instance_x.allowed_partner_ids,
+            "Contact must be normalised to its commercial partner on write.",
+        )
+        self.assertNotIn(
+            self.contact_x,
+            self.instance_x.allowed_partner_ids,
+            "The raw contact must not remain in allowed_partner_ids.",
+        )
+
+    def test_portal_user_sees_only_own_instances(self):
+        """Portal user X sees their company's instance and nothing else."""
+        visible = self.env["k8s.odoo.instance"].with_user(self.user_x).search([])
+        self.assertEqual(visible, self.instance_x)
+
+    def test_portal_user_cannot_see_other_company(self):
+        """Company X's portal user cannot read company Y's instance."""
+        visible = self.env["k8s.odoo.instance"].with_user(self.user_x).search([])
+        self.assertNotIn(self.instance_y, visible)
+        with self.assertRaises(AccessError), mute_logger("odoo.addons.base.models.ir_rule"):
+            self.instance_y.with_user(self.user_x).read(["name"])
+
+    def test_contact_of_allowed_company_matches(self):
+        """A contact (not the company) of an allowed company still matches."""
+        # user_x's partner is contact_x, a child of company_x; instance_x is
+        # owned by company_x -> must be visible.
+        visible = self.env["k8s.odoo.instance"].with_user(self.user_x).search([])
+        self.assertIn(self.instance_x, visible)
+
+    def test_no_instances_empty_non_erroring(self):
+        """A portal user whose company owns nothing gets an empty recordset."""
+        visible = self.env["k8s.odoo.instance"].with_user(self.user_z).search([])
+        self.assertFalse(visible, "Expected an empty, non-erroring result.")
+
+    def test_sensitive_fields_hidden_from_portal(self):
+        """Portal users cannot read sensitive fields even via the ORM."""
+        inst = self.instance_x.with_user(self.user_x)
+        for field_name in ("spec", "status"):
+            with self.subTest(field=field_name):
+                with self.assertRaises(
+                    AccessError,
+                    msg="Field %s must be unreadable by portal users" % field_name,
+                ), mute_logger("odoo.models"):
+                    inst.read([field_name])
+
+    def test_internal_k8s_user_sees_everything(self):
+        """The existing internal K8s user rule still sees all instances."""
+        k8s_user = self.env["res.users"].create(
+            {
+                "name": "Internal K8s",
+                "login": "internal_k8s",
+                "email": "k8s@example.com",
+                "group_ids": [
+                    (6, 0, [self.env.ref("odoo_herd.group_k8s_user").id])
+                ],
+            }
+        )
+        visible = self.env["k8s.odoo.instance"].with_user(k8s_user).search([])
+        self.assertIn(self.instance_x, visible)
+        self.assertIn(self.instance_y, visible)

--- a/odoo_herd_portal/tests/test_access_ownership.py
+++ b/odoo_herd_portal/tests/test_access_ownership.py
@@ -3,15 +3,18 @@
 
 Acceptance criteria under test:
 
-* A portal user sees ONLY the ``k8s.odoo.instance`` records their company is
-  allowed (record rule scoped to ``base.group_portal`` matching the user's
-  ``commercial_partner_id``).
+* A portal user sees ONLY the ``k8s.odoo.instance`` records whose
+  ``allowed_partner_ids`` include the user's OWN partner (record rule scoped to
+  ``base.group_portal``). Access is granted person-by-person, NOT by company.
 * A portal user of company X cannot see company Y's instances (cross-tenant
   isolation at the ORM layer).
-* Normalisation: ``allowed_partner_ids`` is normalised to commercial partners
-  on write, so a *contact* of an allowed company still matches the rule.
+* Per-person scoping: a *different* contact of the same company does NOT get
+  access unless explicitly added to ``allowed_partner_ids``; the stored
+  partner is used verbatim (no commercial-partner normalisation).
 * A portal user with no allowed instances gets an empty, NON-erroring result
   (an empty recordset, not an AccessError).
+* A portal user's ``search_count([])`` works (regression: the portal order
+  substitution must NOT leak into the COUNT query, which Postgres rejects).
 * Sensitive fields (``spec``, ``status``) are unreadable by portal users even
   via the ORM (defense in depth via ``groups=`` on the field).
 * Internal K8s users keep seeing every instance (the existing global-ish
@@ -78,7 +81,8 @@ class TestAccessOwnership(TransactionCase):
         )
 
         # Portal users tied to each contact (a contact of the company, not the
-        # company record itself -- this exercises commercial-partner matching).
+        # company record itself -- per-person access keys off the user's OWN
+        # partner, so the contact must be the one listed in allowed_partner_ids).
         cls.user_x = Users.create(
             {
                 "name": "Portal User X",
@@ -119,9 +123,24 @@ class TestAccessOwnership(TransactionCase):
                 "active": False,
             }
         )
+        # A second contact under company X, NOT granted access -- proves
+        # per-person scoping (a colleague at the same company does not inherit
+        # access just because the company has a granted contact).
+        cls.contact_x2 = Partner.create(
+            {"name": "Carol X", "parent_id": cls.company_x.id}
+        )
+        cls.user_x2 = Users.create(
+            {
+                "name": "Portal User X2",
+                "login": "portal_user_x2",
+                "email": "portal_x2@example.com",
+                "partner_id": cls.contact_x2.id,
+                "group_ids": [(6, 0, [portal_group.id])],
+            }
+        )
+
         Instance = cls.env["k8s.odoo.instance"]
-        # Instance owned by company X -- allowed via the *contact*, to prove
-        # normalisation up to the commercial partner.
+        # Instance granted to the *specific contact* contact_x (person-by-person).
         cls.instance_x = Instance.create(
             {
                 "name": "inst-x",
@@ -131,28 +150,28 @@ class TestAccessOwnership(TransactionCase):
                 "allowed_partner_ids": [(6, 0, [cls.contact_x.id])],
             }
         )
-        # Instance owned by company Y -- allowed via the company record itself.
+        # Instance granted to the specific contact contact_y.
         cls.instance_y = Instance.create(
             {
                 "name": "inst-y",
                 "namespace": "y",
                 "cluster_id": cls.cluster.id,
                 "environment": "production",
-                "allowed_partner_ids": [(6, 0, [cls.company_y.id])],
+                "allowed_partner_ids": [(6, 0, [cls.contact_y.id])],
             }
         )
 
-    def test_normalisation_to_commercial_partner(self):
-        """Writing a contact stores its commercial (company) partner."""
+    def test_allowed_partner_stored_verbatim(self):
+        """The exact partner selected is stored -- no commercial normalisation."""
         self.assertIn(
-            self.company_x,
-            self.instance_x.allowed_partner_ids,
-            "Contact must be normalised to its commercial partner on write.",
-        )
-        self.assertNotIn(
             self.contact_x,
             self.instance_x.allowed_partner_ids,
-            "The raw contact must not remain in allowed_partner_ids.",
+            "The selected contact must be stored verbatim.",
+        )
+        self.assertNotIn(
+            self.company_x,
+            self.instance_x.allowed_partner_ids,
+            "Per-person access must NOT promote the contact to its company.",
         )
 
     def test_portal_user_sees_only_own_instances(self):
@@ -167,12 +186,46 @@ class TestAccessOwnership(TransactionCase):
         with self.assertRaises(AccessError), mute_logger("odoo.addons.base.models.ir_rule"):
             self.instance_y.with_user(self.user_x).read(["name"])
 
-    def test_contact_of_allowed_company_matches(self):
-        """A contact (not the company) of an allowed company still matches."""
-        # user_x's partner is contact_x, a child of company_x; instance_x is
-        # owned by company_x -> must be visible.
+    def test_granted_contact_matches(self):
+        """The specific contact granted access sees the instance."""
+        # user_x's partner is contact_x, which is in instance_x.allowed_partner_ids.
         visible = self.env["k8s.odoo.instance"].with_user(self.user_x).search([])
         self.assertIn(self.instance_x, visible)
+
+    def test_other_contact_same_company_no_access(self):
+        """Per-person scoping: an unlisted colleague of the same company sees nothing.
+
+        contact_x2 is a child of company_x (same company as contact_x, who IS
+        granted instance_x), but contact_x2 is NOT in allowed_partner_ids, so the
+        company affiliation alone must NOT grant access.
+        """
+        visible = (
+            self.env["k8s.odoo.instance"].with_user(self.user_x2).search([])
+        )
+        self.assertFalse(
+            visible,
+            "A colleague not explicitly granted must see no instances.",
+        )
+        with self.assertRaises(AccessError), mute_logger(
+            "odoo.addons.base.models.ir_rule"
+        ):
+            self.instance_x.with_user(self.user_x2).read(["name"])
+
+    def test_portal_search_count_no_order_crash(self):
+        """Regression: portal search_count([]) must not emit ORDER BY.
+
+        The portal order substitution (name instead of the hidden
+        cluster_id/namespace default order) must NEVER reach a COUNT query --
+        Postgres rejects ``SELECT COUNT(*) ... ORDER BY name`` with
+        'column ... must appear in the GROUP BY clause'. This is the exact path
+        the /my home-card counter RPC hits.
+        """
+        Instance = self.env["k8s.odoo.instance"].with_user(self.user_x)
+        # Must not raise; user_x is granted exactly one instance.
+        self.assertEqual(Instance.search_count([]), 1)
+        # And a plain list fetch must still work (ordered by name, the
+        # portal-safe field -- never by the hidden cluster_id/namespace).
+        self.assertEqual(Instance.search([]), self.instance_x)
 
     def test_no_instances_empty_non_erroring(self):
         """A portal user whose company owns nothing gets an empty recordset."""

--- a/odoo_herd_portal/tests/test_backend_view.py
+++ b/odoo_herd_portal/tests/test_backend_view.py
@@ -1,0 +1,93 @@
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+"""Backend admin-view smoke test for the Portal Access page.
+
+Acceptance criteria under test:
+
+* The inherited k8s.odoo.instance form (with the new "Portal Access" page
+  exposing ``allowed_partner_ids``) BUILDS for an internal k8s manager user --
+  i.e. the inherit xpath resolves and the field name is valid (a broken
+  inherit or a typo'd field name fails at Form-build time here).
+* A manager can set ``allowed_partner_ids`` through the form, save, and the
+  exact partner selected persists on the record (stored verbatim -- access is
+  granted person by person, no commercial-partner normalisation).
+
+This guards the click-to-assign path the view exists to provide; the portal
+record-rule behaviour itself is covered by test_access_ownership.
+"""
+
+from odoo.tests import Form, TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install", "odoo_herd_portal")
+class TestBackendView(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        Partner = cls.env["res.partner"]
+        Users = cls.env["res.users"]
+        manager_group = cls.env.ref("odoo_herd.group_k8s_manager")
+        internal_group = cls.env.ref("base.group_user")
+
+        cls.client_company = Partner.create(
+            {"name": "View Test Co", "is_company": True}
+        )
+
+        # Internal k8s manager (has WRITE on the instance via the odoo_herd
+        # manager record rule) -- the staff member who assigns portal access.
+        # base.group_user makes them a real internal employee, as k8s staff
+        # always are (needed to read res.partner for the m2m_tags widget).
+        cls.manager = Users.create(
+            {
+                "name": "K8s Manager",
+                "login": "herd_view_manager",
+                "email": "herd_view_manager@example.com",
+                "group_ids": [(6, 0, [internal_group.id, manager_group.id])],
+            }
+        )
+
+        # Inactive cluster so k8s-hitting computes short-circuit (no live
+        # cluster needed) -- mirrors the other feature tests.
+        cls.cluster = cls.env["k8s.cluster"].create(
+            {
+                "name": "View Test Cluster",
+                "api_endpoint": "https://example.invalid:6443",
+                "kubeconfig": "apiVersion: v1\nkind: Config\n",
+                "default_namespace": "default",
+                "active": False,
+            }
+        )
+
+        cls.instance = cls.env["k8s.odoo.instance"].create(
+            {
+                "name": "view-test-instance",
+                "namespace": "view-test",
+                "cluster_id": cls.cluster.id,
+                "environment": "production",
+                "phase": "Running",
+            }
+        )
+
+    def test_form_builds_with_portal_access_field(self):
+        """The inherited form builds for a manager and exposes the field."""
+        form = Form(
+            self.instance.with_user(self.manager),
+            view="odoo_herd_portal.view_k8s_odoo_instance_form_portal",
+        )
+        # Field is present in the built form (KeyError if the inherit/xpath
+        # failed or the field name is wrong).
+        self.assertIn("allowed_partner_ids", form._view["fields"])
+
+    def test_manager_assigns_allowed_partner_via_form(self):
+        """A manager sets allowed_partner_ids through the form and it persists."""
+        form = Form(
+            self.instance.with_user(self.manager),
+            view="odoo_herd_portal.view_k8s_odoo_instance_form_portal",
+        )
+        form.allowed_partner_ids.add(self.client_company)
+        form.save()
+
+        self.assertIn(
+            self.client_company,
+            self.instance.allowed_partner_ids,
+            "The assigned partner must persist on the instance after save.",
+        )

--- a/odoo_herd_portal/tests/test_backups.py
+++ b/odoo_herd_portal/tests/test_backups.py
@@ -1,4 +1,4 @@
-# Part of Odoo Herd Portal. See LICENSE file for full copyright and licensing details.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 """Feature D -- backups self-service acceptance tests.
 
 Acceptance criteria under test:

--- a/odoo_herd_portal/tests/test_backups.py
+++ b/odoo_herd_portal/tests/test_backups.py
@@ -1,0 +1,458 @@
+# Part of Odoo Herd Portal. See LICENSE file for full copyright and licensing details.
+"""Feature D -- backups self-service acceptance tests.
+
+Acceptance criteria under test:
+
+* (a) A portal user sees ONLY the backups of an instance their company owns;
+  another company's backups are invisible at the ORM layer (record rule scoped
+  to ``base.group_portal`` via ``instance_id.allowed_partner_ids``).
+* (b) Sensitive backup fields (``webhook_token``, ``download_url``, ``job_name``,
+  ``backup_job_name``, S3/cluster internals) raise AccessError for a portal
+  user even via the ORM (deny-by-default field whitelist). A drift-guard
+  ensures any field NOT whitelisted stays hidden.
+* (c) "Backup now" creates a new pending ``k8s.odoo.backup`` for an OWNED
+  instance (the k8s CR creation is stubbed -- no live cluster), and is REFUSED
+  (no record created, redirect/403) for a NON-owned instance (IDOR).
+* (d) Restore is ALLOWED (creates a ``k8s.odoo.restore``) when the target
+  instance is staging + owned; REFUSED when the target is production (never
+  exposed in the portal); and REFUSED for a NON-owned backup (IDOR).
+* (e) The download endpoint checks ownership: a non-owned backup id yields a
+  redirect/403 and NO presigned URL is leaked; S3 credentials are never read in
+  the portal user's context.
+* (f) Every client-initiated action (backup-now, restore) posts an audit
+  message to the instance's chatter recording who/what/when.
+
+These mix HttpCase (end-to-end controller + record rule + CSRF) and
+TransactionCase (ORM-level field secrecy / drift-guard). The actual Kubernetes
+calls are stubbed by patching the record models' CR-creation hooks and the
+presign method, mirroring how ``odoo_herd``'s own tests avoid a live cluster.
+"""
+
+from unittest.mock import patch
+
+from odoo import http
+from odoo.exceptions import AccessError
+from odoo.tests import HttpCase, TransactionCase, tagged
+from odoo.tools.misc import mute_logger
+
+from odoo.addons.odoo_herd_portal.models.k8s_odoo_backup import (
+    PORTAL_VISIBLE_BACKUP_FIELDS,
+)
+
+# CR-creation hooks that hit the live cluster; stubbed in every test that
+# creates a backup or restore record so no Kubernetes API call is made.
+_BACKUP_CR = (
+    "odoo.addons.odoo_herd.models.k8s_backup.K8sOdooBackup._create_backup_job_cr"
+)
+_RESTORE_CR = (
+    "odoo.addons.odoo_herd.models.k8s_restore.K8sOdooRestore._create_restore_job_cr"
+)
+_PRESIGN = (
+    "odoo.addons.odoo_herd.models.k8s_backup.K8sOdooBackup._generate_presigned_url"
+)
+
+# Framework / audit fields readable by any user by design -- excluded from the
+# drift-guard (same rationale as Feature A's instance drift-guard).
+_FRAMEWORK_READABLE = frozenset(
+    {
+        "create_date",
+        "write_date",
+        "create_uid",
+        "write_uid",
+        "__last_update",
+    }
+)
+
+
+def _common_fixtures(cls):
+    """Build the two-company / two-instance / backups fixture set."""
+    Partner = cls.env["res.partner"]
+    Users = cls.env["res.users"]
+    portal_group = cls.env.ref("base.group_portal")
+
+    cls.company_a = Partner.create({"name": "Backup Co A", "is_company": True})
+    cls.company_b = Partner.create({"name": "Backup Co B", "is_company": True})
+
+    cls.user_a = Users.create(
+        {
+            "name": "Backup User A",
+            "login": "backup_user_a",
+            "password": "backup_user_a",
+            "email": "backup_a@example.com",
+            "partner_id": cls.company_a.id,
+            "group_ids": [(6, 0, [portal_group.id])],
+        }
+    )
+    cls.user_b = Users.create(
+        {
+            "name": "Backup User B",
+            "login": "backup_user_b",
+            "password": "backup_user_b",
+            "email": "backup_b@example.com",
+            "partner_id": cls.company_b.id,
+            "group_ids": [(6, 0, [portal_group.id])],
+        }
+    )
+
+    # S3 config so the backup wizard's pre-flight check passes; the real S3
+    # call never happens because the CR-creation hooks are stubbed.
+    cls.s3_config = cls.env["k8s.s3.config"].create(
+        {
+            "name": "Test S3",
+            "endpoint": "https://minio.invalid",
+            "bucket": "backups",
+            "credentials_secret_name": "s3-creds",
+        }
+    )
+    # Inactive cluster -- never reached because CR hooks are stubbed, but kept
+    # consistent with the rest of the module's fixtures.
+    cls.cluster = cls.env["k8s.cluster"].create(
+        {
+            "name": "Backup Test Cluster",
+            "api_endpoint": "https://example.invalid:6443",
+            "kubeconfig": "apiVersion: v1\nkind: Config\n",
+            "default_namespace": "default",
+            "active": False,
+            "backup_s3_config_id": cls.s3_config.id,
+        }
+    )
+
+    Instance = cls.env["k8s.odoo.instance"]
+    # Company A: a production + a staging instance.
+    cls.inst_a_prod = Instance.create(
+        {
+            "name": "co-a-prod",
+            "namespace": "co-a",
+            "cluster_id": cls.cluster.id,
+            "environment": "production",
+            "allowed_partner_ids": [(6, 0, [cls.company_a.id])],
+        }
+    )
+    cls.inst_a_staging = Instance.create(
+        {
+            "name": "co-a-staging",
+            "namespace": "co-a",
+            "cluster_id": cls.cluster.id,
+            "environment": "staging",
+            "allowed_partner_ids": [(6, 0, [cls.company_a.id])],
+        }
+    )
+    # Company B: a production instance, never visible to A.
+    cls.inst_b_prod = Instance.create(
+        {
+            "name": "co-b-prod",
+            "namespace": "co-b",
+            "cluster_id": cls.cluster.id,
+            "environment": "production",
+            "allowed_partner_ids": [(6, 0, [cls.company_b.id])],
+        }
+    )
+
+    Backup = cls.env["k8s.odoo.backup"]
+    with patch(_BACKUP_CR):
+        # A completed backup for A's production instance (downloadable).
+        cls.backup_a_prod = Backup.create(
+            {
+                "instance_id": cls.inst_a_prod.id,
+                "format": "zip",
+                "state": "completed",
+                "object_key": "co-a-prod/20260101-000000.zip",
+                "bucket": "backups",
+                "endpoint": "https://minio.invalid",
+                "webhook_token": "SECRET-TOKEN-A",
+                "download_url": "https://leak.invalid/presigned-A",
+                "size_bytes": 12345,
+            }
+        )
+        # A completed backup for A's staging instance (restore target).
+        cls.backup_a_staging = Backup.create(
+            {
+                "instance_id": cls.inst_a_staging.id,
+                "format": "zip",
+                "state": "completed",
+                "object_key": "co-a-staging/20260101-000000.zip",
+                "bucket": "backups",
+                "endpoint": "https://minio.invalid",
+            }
+        )
+        # A completed backup for B's production instance -- never visible to A.
+        cls.backup_b_prod = Backup.create(
+            {
+                "instance_id": cls.inst_b_prod.id,
+                "format": "zip",
+                "state": "completed",
+                "object_key": "co-b-prod/20260101-000000.zip",
+                "bucket": "backups",
+                "endpoint": "https://minio.invalid",
+                "webhook_token": "SECRET-TOKEN-B",
+            }
+        )
+
+
+@tagged("post_install", "-at_install", "odoo_herd_portal")
+class TestBackupSecrecy(TransactionCase):
+    """ORM-level field secrecy + isolation + drift-guard (b, a)."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        _common_fixtures(cls)
+
+    # -------------------------------------------------------------- (a)
+    def test_portal_user_sees_only_own_backups(self):
+        """Portal user A sees A's backups; B's backup is invisible."""
+        visible = self.env["k8s.odoo.backup"].with_user(self.user_a).search([])
+        self.assertIn(self.backup_a_prod, visible)
+        self.assertIn(self.backup_a_staging, visible)
+        self.assertNotIn(self.backup_b_prod, visible)
+
+    def test_portal_user_cannot_read_other_company_backup(self):
+        """Reading B's backup as A raises AccessError (record rule)."""
+        with self.assertRaises(AccessError), mute_logger(
+            "odoo.addons.base.models.ir_rule"
+        ):
+            self.backup_b_prod.with_user(self.user_a).read(["name"])
+
+    # -------------------------------------------------------------- (b)
+    def test_sensitive_backup_fields_hidden(self):
+        """Known secret fields raise AccessError for a portal user."""
+        rec = self.backup_a_prod.with_user(self.user_a)
+        for field_name in (
+            "webhook_token",
+            "download_url",
+            "job_name",
+            "backup_job_name",
+            "object_key",
+            "bucket",
+            "endpoint",
+            "cluster_id",
+            "s3_config_id",
+        ):
+            with self.subTest(field=field_name):
+                with self.assertRaises(AccessError), mute_logger("odoo.models"):
+                    rec.read([field_name])
+
+    def test_whitelisted_backup_fields_readable(self):
+        """Every whitelisted backup field stays readable by a portal user."""
+        rec = self.backup_a_prod.with_user(self.user_a)
+        model_fields = self.env["k8s.odoo.backup"]._fields
+        readable = sorted(PORTAL_VISIBLE_BACKUP_FIELDS & set(model_fields))
+        self.assertEqual(
+            set(readable),
+            PORTAL_VISIBLE_BACKUP_FIELDS,
+            "PORTAL_VISIBLE_BACKUP_FIELDS references fields absent from model.",
+        )
+        values = rec.read(readable)
+        self.assertTrue(values)
+
+    def test_drift_guard_non_whitelisted_backup_fields_hidden(self):
+        """Deny-by-default: any non-whitelisted backup field is hidden."""
+        Backup = self.env["k8s.odoo.backup"]
+        rec = self.backup_a_prod.with_user(self.user_a)
+        leaked = []
+        for field_name in Backup._fields:
+            if field_name in PORTAL_VISIBLE_BACKUP_FIELDS:
+                continue
+            if field_name in _FRAMEWORK_READABLE:
+                continue
+            with self.subTest(field=field_name):
+                try:
+                    with mute_logger("odoo.models"):
+                        rec.read([field_name])
+                except AccessError:
+                    continue
+                leaked.append(field_name)
+        self.assertEqual(
+            leaked,
+            [],
+            "Non-whitelisted backup fields readable by a portal user "
+            "(add groups= or extend the whitelist): %s" % leaked,
+        )
+
+
+@tagged("post_install", "-at_install", "odoo_herd_portal")
+class TestBackupSelfService(HttpCase):
+    """End-to-end portal controller: list/download/backup-now/restore (c-f)."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        _common_fixtures(cls)
+
+    def _csrf_token(self):
+        """Mint a CSRF token valid for the authenticated session."""
+        return http.Request.csrf_token(self)
+
+    # -------------------------------------------------------------- (a) list
+    def test_backups_list_shows_own_not_other(self):
+        """List page for A's prod instance shows its backup, not B's."""
+        self.authenticate("backup_user_a", "backup_user_a")
+        resp = self.url_open(
+            "/my/instances/%d/backups" % self.inst_a_prod.id
+        )
+        self.assertEqual(resp.status_code, 200)
+        body = resp.text
+        self.assertIn(self.backup_a_prod.name, body)
+        # B's backup name must never appear.
+        self.assertNotIn(self.backup_b_prod.name, body)
+        # No secret leaks into the page.
+        self.assertNotIn("SECRET-TOKEN-A", body)
+        self.assertNotIn("presigned-A", body)
+
+    def test_backups_list_non_owned_instance_redirects(self):
+        """List page for a non-owned instance redirects, leaks nothing."""
+        self.authenticate("backup_user_a", "backup_user_a")
+        resp = self.url_open(
+            "/my/instances/%d/backups" % self.inst_b_prod.id,
+            allow_redirects=False,
+        )
+        self.assertIn(resp.status_code, (301, 302, 303, 404))
+        self.assertNotIn(self.backup_b_prod.name, resp.text)
+
+    # -------------------------------------------------------------- (c) backup-now
+    def test_backup_now_owned_creates_record(self):
+        """POST backup-now on an owned instance creates a pending backup."""
+        self.authenticate("backup_user_a", "backup_user_a")
+        Backup = self.env["k8s.odoo.backup"]
+        before = Backup.search_count([("instance_id", "=", self.inst_a_prod.id)])
+        with patch(_BACKUP_CR) as cr:
+            resp = self.url_open(
+                "/my/instances/%d/backup" % self.inst_a_prod.id,
+                data={"csrf_token": self._csrf_token(), "format": "zip"},
+            )
+        self.assertEqual(resp.status_code, 200)
+        after = Backup.search_count([("instance_id", "=", self.inst_a_prod.id)])
+        self.assertEqual(after, before + 1, "A new backup must be created.")
+        # The k8s CR hook was invoked (under sudo) -- not skipped.
+        self.assertTrue(cr.called)
+        new = Backup.search(
+            [("instance_id", "=", self.inst_a_prod.id)],
+            order="create_date desc",
+            limit=1,
+        )
+        self.assertEqual(new.state, "pending")
+
+    def test_backup_now_non_owned_refused(self):
+        """POST backup-now on a non-owned instance creates nothing (IDOR)."""
+        self.authenticate("backup_user_a", "backup_user_a")
+        Backup = self.env["k8s.odoo.backup"]
+        before = Backup.search_count([("instance_id", "=", self.inst_b_prod.id)])
+        with patch(_BACKUP_CR) as cr:
+            resp = self.url_open(
+                "/my/instances/%d/backup" % self.inst_b_prod.id,
+                data={"csrf_token": self._csrf_token(), "format": "zip"},
+                allow_redirects=False,
+            )
+        self.assertIn(resp.status_code, (301, 302, 303, 403, 404))
+        after = Backup.search_count([("instance_id", "=", self.inst_b_prod.id)])
+        self.assertEqual(after, before, "No backup may be created for a foreign instance.")
+        self.assertFalse(cr.called, "The k8s CR hook must not run for an IDOR attempt.")
+
+    # -------------------------------------------------------------- (f) audit
+    def test_backup_now_posts_audit_message(self):
+        """Backup-now posts an audit chatter message on the instance."""
+        self.authenticate("backup_user_a", "backup_user_a")
+        before = len(self.inst_a_prod.message_ids)
+        with patch(_BACKUP_CR):
+            self.url_open(
+                "/my/instances/%d/backup" % self.inst_a_prod.id,
+                data={"csrf_token": self._csrf_token(), "format": "zip"},
+            )
+        self.inst_a_prod.invalidate_recordset()
+        messages = self.inst_a_prod.message_ids
+        self.assertGreater(len(messages), before, "An audit message must be posted.")
+        latest = messages[0]
+        self.assertIn("ackup", latest.body or "")
+        self.assertEqual(latest.author_id, self.user_a.partner_id)
+
+    # -------------------------------------------------------------- (d) restore
+    def test_restore_staging_owned_creates_restore(self):
+        """Restore to an owned staging instance creates a k8s.odoo.restore."""
+        self.authenticate("backup_user_a", "backup_user_a")
+        Restore = self.env["k8s.odoo.restore"]
+        before = Restore.search_count([])
+        with patch(_RESTORE_CR) as cr:
+            resp = self.url_open(
+                "/my/instances/backup/%d/restore" % self.backup_a_staging.id,
+                data={"csrf_token": self._csrf_token()},
+            )
+        self.assertEqual(resp.status_code, 200)
+        after = Restore.search_count([])
+        self.assertEqual(after, before + 1)
+        self.assertTrue(cr.called)
+        new = Restore.search([], order="create_date desc", limit=1)
+        self.assertEqual(new.target_instance_id, self.inst_a_staging)
+
+    def test_restore_production_refused(self):
+        """Restore targeting a production instance is refused (never exposed)."""
+        self.authenticate("backup_user_a", "backup_user_a")
+        Restore = self.env["k8s.odoo.restore"]
+        before = Restore.search_count([])
+        with patch(_RESTORE_CR) as cr:
+            resp = self.url_open(
+                "/my/instances/backup/%d/restore" % self.backup_a_prod.id,
+                data={"csrf_token": self._csrf_token()},
+                allow_redirects=False,
+            )
+        self.assertIn(resp.status_code, (301, 302, 303, 403, 404))
+        after = Restore.search_count([])
+        self.assertEqual(after, before, "Production restore must never create a record.")
+        self.assertFalse(cr.called)
+
+    def test_restore_non_owned_backup_refused(self):
+        """Restore from a non-owned backup is refused (IDOR)."""
+        self.authenticate("backup_user_a", "backup_user_a")
+        Restore = self.env["k8s.odoo.restore"]
+        before = Restore.search_count([])
+        with patch(_RESTORE_CR) as cr:
+            resp = self.url_open(
+                "/my/instances/backup/%d/restore" % self.backup_b_prod.id,
+                data={"csrf_token": self._csrf_token()},
+                allow_redirects=False,
+            )
+        self.assertIn(resp.status_code, (301, 302, 303, 403, 404))
+        after = Restore.search_count([])
+        self.assertEqual(after, before)
+        self.assertFalse(cr.called)
+
+    def test_restore_staging_posts_audit_message(self):
+        """Restore posts an audit chatter message on the target instance."""
+        self.authenticate("backup_user_a", "backup_user_a")
+        before = len(self.inst_a_staging.message_ids)
+        with patch(_RESTORE_CR):
+            self.url_open(
+                "/my/instances/backup/%d/restore" % self.backup_a_staging.id,
+                data={"csrf_token": self._csrf_token()},
+            )
+        self.inst_a_staging.invalidate_recordset()
+        messages = self.inst_a_staging.message_ids
+        self.assertGreater(len(messages), before)
+        self.assertEqual(messages[0].author_id, self.user_a.partner_id)
+
+    # -------------------------------------------------------------- (e) download
+    def test_download_owned_redirects_to_presigned(self):
+        """Download of an owned, completed backup redirects to the presign."""
+        self.authenticate("backup_user_a", "backup_user_a")
+        with patch(_PRESIGN, return_value="https://minio.invalid/presigned-OK") as p:
+            resp = self.url_open(
+                "/my/instances/backup/%d/download" % self.backup_a_prod.id,
+                allow_redirects=False,
+            )
+        self.assertIn(resp.status_code, (301, 302, 303))
+        self.assertEqual(
+            resp.headers.get("Location"),
+            "https://minio.invalid/presigned-OK",
+        )
+        self.assertTrue(p.called, "Presign must be generated under sudo.")
+
+    def test_download_non_owned_refused_no_presign(self):
+        """Download of a non-owned backup is refused; no presign generated."""
+        self.authenticate("backup_user_a", "backup_user_a")
+        with patch(_PRESIGN, return_value="https://leak.invalid/SHOULD-NOT") as p:
+            resp = self.url_open(
+                "/my/instances/backup/%d/download" % self.backup_b_prod.id,
+                allow_redirects=False,
+            )
+        self.assertIn(resp.status_code, (301, 302, 303, 403, 404))
+        self.assertNotIn("SHOULD-NOT", resp.text)
+        self.assertFalse(p.called, "No presign for a non-owned backup (IDOR).")

--- a/odoo_herd_portal/tests/test_lifecycle.py
+++ b/odoo_herd_portal/tests/test_lifecycle.py
@@ -301,34 +301,76 @@ class TestLifecycleNotification(TransactionCase):
         super().setUpClass()
         _common_fixtures(cls)
 
-    def test_upgrade_completion_notifies_instance(self):
-        """mark_completed on an upgrade posts a message to the instance."""
+    def _new_messages(self, instance, before_ids):
+        """Return messages posted on ``instance`` since the ``before_ids`` set."""
+        instance.invalidate_recordset()
+        return instance.message_ids.filtered(lambda m: m.id not in before_ids)
+
+    def _assert_client_comment(self, message, expected_partner, body_must_avoid=()):
+        """AC (f): the terminal message must reach the client via a client-visible
+        comment subtype, NOT an internal note, and must not leak internal detail.
+        """
+        self.assertTrue(message, "A terminal notification must be posted.")
+        self.assertEqual(
+            len(message),
+            1,
+            "Exactly one terminal client comment is expected, got %s." % len(message),
+        )
+        comment_subtype = self.env.ref("mail.mt_comment")
+        note_subtype = self.env.ref("mail.mt_note")
+        self.assertEqual(
+            message.subtype_id,
+            comment_subtype,
+            "Terminal client notification must use mail.mt_comment "
+            "(portal/share-visible), not an internal note.",
+        )
+        self.assertNotEqual(
+            message.subtype_id,
+            note_subtype,
+            "Terminal client notification must NOT be an internal mt_note.",
+        )
+        self.assertIn(
+            expected_partner,
+            message.partner_ids,
+            "The allowed client partner must be a recipient of the "
+            "terminal notification.",
+        )
+        for forbidden in body_must_avoid:
+            self.assertNotIn(
+                forbidden,
+                message.body or "",
+                "Client-facing body must be status-only; it leaked the raw "
+                "operator message %r." % forbidden,
+            )
+
+    def test_upgrade_completion_notifies_client_partner(self):
+        """mark_completed posts a client-visible comment to the allowed partner."""
         with patch(_UPGRADE_CR):
             upgrade = self.env["k8s.odoo.upgrade"].create(
                 {"instance_id": self.inst_a_prod.id, "modules": "base"}
             )
-        before = len(self.inst_a_prod.message_ids)
-        upgrade.mark_completed(message="done")
-        self.inst_a_prod.invalidate_recordset()
-        self.assertGreater(
-            len(self.inst_a_prod.message_ids),
-            before,
-            "A completion notification must be posted to the instance.",
+        before = set(self.inst_a_prod.message_ids.ids)
+        upgrade.mark_completed(message="INTERNAL: /var/lib/odoo trace")
+        new = self._new_messages(self.inst_a_prod, before)
+        self._assert_client_comment(
+            new, self.company_a, body_must_avoid=("INTERNAL: /var/lib/odoo trace",)
         )
 
-    def test_upgrade_failure_notifies_instance(self):
-        """mark_failed on an upgrade posts a message to the instance."""
+    def test_upgrade_failure_notifies_client_partner(self):
+        """mark_failed posts a client-visible comment to the allowed partner."""
         with patch(_UPGRADE_CR):
             upgrade = self.env["k8s.odoo.upgrade"].create(
                 {"instance_id": self.inst_a_prod.id, "modules": "base"}
             )
-        before = len(self.inst_a_prod.message_ids)
-        upgrade.mark_failed(message="boom")
-        self.inst_a_prod.invalidate_recordset()
-        self.assertGreater(len(self.inst_a_prod.message_ids), before)
+        before = set(self.inst_a_prod.message_ids.ids)
+        upgrade.mark_failed(message="INTERNAL: boom at /opt/odoo")
+        new = self._new_messages(self.inst_a_prod, before)
+        self._assert_client_comment(
+            new, self.company_a, body_must_avoid=("INTERNAL: boom at /opt/odoo",)
+        )
 
-    def test_refresh_completion_notifies_target_instance(self):
-        """mark_completed on a staging-refresh posts to the target instance."""
+    def test_refresh_completion_notifies_target_client_partner(self):
+        """mark_completed on a refresh comments the target's allowed partner."""
         with patch(_REFRESH_CR):
             refresh = self.env["k8s.odoo.staging.refresh"].create(
                 {
@@ -336,21 +378,42 @@ class TestLifecycleNotification(TransactionCase):
                     "source_instance_id": self.inst_a_prod.id,
                 }
             )
-        before = len(self.inst_a_staging.message_ids)
-        refresh.mark_completed(message="refreshed")
-        self.inst_a_staging.invalidate_recordset()
-        self.assertGreater(len(self.inst_a_staging.message_ids), before)
+        before = set(self.inst_a_staging.message_ids.ids)
+        refresh.mark_completed(message="INTERNAL: snapshot detail")
+        new = self._new_messages(self.inst_a_staging, before)
+        self._assert_client_comment(
+            new, self.company_a, body_must_avoid=("INTERNAL: snapshot detail",)
+        )
 
-    def test_backup_completion_notifies_instance(self):
-        """mark_completed on a backup posts to the instance (best-effort)."""
+    def test_backup_completion_notifies_client_partner(self):
+        """mark_completed on a backup comments the allowed partner."""
         with patch(_BACKUP_CR):
             backup = self.env["k8s.odoo.backup"].create(
                 {"instance_id": self.inst_a_prod.id, "format": "zip"}
             )
-        before = len(self.inst_a_prod.message_ids)
-        backup.mark_completed(message="backed up")
-        self.inst_a_prod.invalidate_recordset()
-        self.assertGreater(len(self.inst_a_prod.message_ids), before)
+        before = set(self.inst_a_prod.message_ids.ids)
+        backup.mark_completed(message="INTERNAL: object_key s3://x")
+        new = self._new_messages(self.inst_a_prod, before)
+        self._assert_client_comment(
+            new, self.company_a, body_must_avoid=("INTERNAL: object_key s3://x",)
+        )
+
+    def test_terminal_notification_excludes_non_allowed_partner(self):
+        """Negative: a non-allowed company's partner is NOT a recipient."""
+        with patch(_UPGRADE_CR):
+            upgrade = self.env["k8s.odoo.upgrade"].create(
+                {"instance_id": self.inst_a_prod.id, "modules": "base"}
+            )
+        before = set(self.inst_a_prod.message_ids.ids)
+        upgrade.mark_completed(message="done")
+        new = self._new_messages(self.inst_a_prod, before)
+        self.assertTrue(new, "A terminal notification must be posted.")
+        self.assertNotIn(
+            self.company_b,
+            new.partner_ids,
+            "A non-allowed company's partner must NOT receive the "
+            "terminal notification.",
+        )
 
 
 @tagged("post_install", "-at_install", "odoo_herd_portal")

--- a/odoo_herd_portal/tests/test_lifecycle.py
+++ b/odoo_herd_portal/tests/test_lifecycle.py
@@ -81,6 +81,17 @@ def _common_fixtures(cls):
     cls.company_a = Partner.create({"name": "Life Co A", "is_company": True})
     cls.company_b = Partner.create({"name": "Life Co B", "is_company": True})
 
+    # A portal *initiator* contact under company A, distinct from the company
+    # partner itself. Used to assert the terminal notification targets the
+    # acting initiator -- NOT every allowed_partner_ids member (the company).
+    cls.initiator_a = Partner.create(
+        {
+            "name": "Life Initiator A",
+            "email": "initiator_a@example.com",
+            "parent_id": cls.company_a.id,
+        }
+    )
+
     cls.user_a = Users.create(
         {
             "name": "Life User A",
@@ -306,9 +317,21 @@ class TestLifecycleNotification(TransactionCase):
         instance.invalidate_recordset()
         return instance.message_ids.filtered(lambda m: m.id not in before_ids)
 
-    def _assert_client_comment(self, message, expected_partner, body_must_avoid=()):
+    def _assert_client_comment(
+        self,
+        message,
+        initiator_partner,
+        body_must_avoid=(),
+        not_recipient=(),
+        followers=(),
+    ):
         """AC (f): the terminal message must reach the client via a client-visible
         comment subtype, NOT an internal note, and must not leak internal detail.
+
+        Targeting rule (Marc's decision): direct recipients are the recorded
+        ``portal_initiator_id`` only -- NOT every ``allowed_partner_ids`` member.
+        Existing followers are reached via the ``mail.mt_comment`` subtype, not
+        by being added to ``partner_ids``.
         """
         self.assertTrue(message, "A terminal notification must be posted.")
         self.assertEqual(
@@ -329,12 +352,26 @@ class TestLifecycleNotification(TransactionCase):
             note_subtype,
             "Terminal client notification must NOT be an internal mt_note.",
         )
-        self.assertIn(
-            expected_partner,
-            message.partner_ids,
-            "The allowed client partner must be a recipient of the "
-            "terminal notification.",
-        )
+        if initiator_partner is not None:
+            self.assertIn(
+                initiator_partner,
+                message.partner_ids,
+                "The recorded portal initiator must be a direct recipient of "
+                "the terminal notification.",
+            )
+        for partner in not_recipient:
+            self.assertNotIn(
+                partner,
+                message.partner_ids,
+                "A non-initiator allowed partner must NOT be a direct recipient "
+                "(no all-allowed-partners blast).",
+            )
+        for follower in followers:
+            self.assertIn(
+                follower,
+                message.notified_partner_ids,
+                "An existing follower must be notified by the mt_comment subtype.",
+            )
         for forbidden in body_must_avoid:
             self.assertNotIn(
                 forbidden,
@@ -343,66 +380,148 @@ class TestLifecycleNotification(TransactionCase):
                 "operator message %r." % forbidden,
             )
 
-    def test_upgrade_completion_notifies_client_partner(self):
-        """mark_completed posts a client-visible comment to the allowed partner."""
+    def test_upgrade_completion_notifies_initiator(self):
+        """mark_completed posts a client-visible comment to the initiator only."""
         with patch(_UPGRADE_CR):
             upgrade = self.env["k8s.odoo.upgrade"].create(
-                {"instance_id": self.inst_a_prod.id, "modules": "base"}
+                {
+                    "instance_id": self.inst_a_prod.id,
+                    "modules": "base",
+                    "portal_initiator_id": self.initiator_a.id,
+                }
             )
         before = set(self.inst_a_prod.message_ids.ids)
         upgrade.mark_completed(message="INTERNAL: /var/lib/odoo trace")
         new = self._new_messages(self.inst_a_prod, before)
         self._assert_client_comment(
-            new, self.company_a, body_must_avoid=("INTERNAL: /var/lib/odoo trace",)
+            new,
+            self.initiator_a,
+            body_must_avoid=("INTERNAL: /var/lib/odoo trace",),
+            # The bare allowed-partner (company) is NOT a follower and NOT the
+            # initiator, so it must not be a direct recipient.
+            not_recipient=(self.company_a,),
         )
 
-    def test_upgrade_failure_notifies_client_partner(self):
-        """mark_failed posts a client-visible comment to the allowed partner."""
+    def test_upgrade_failure_notifies_initiator(self):
+        """mark_failed posts a client-visible comment to the initiator only."""
         with patch(_UPGRADE_CR):
             upgrade = self.env["k8s.odoo.upgrade"].create(
-                {"instance_id": self.inst_a_prod.id, "modules": "base"}
+                {
+                    "instance_id": self.inst_a_prod.id,
+                    "modules": "base",
+                    "portal_initiator_id": self.initiator_a.id,
+                }
             )
         before = set(self.inst_a_prod.message_ids.ids)
         upgrade.mark_failed(message="INTERNAL: boom at /opt/odoo")
         new = self._new_messages(self.inst_a_prod, before)
         self._assert_client_comment(
-            new, self.company_a, body_must_avoid=("INTERNAL: boom at /opt/odoo",)
+            new,
+            self.initiator_a,
+            body_must_avoid=("INTERNAL: boom at /opt/odoo",),
+            not_recipient=(self.company_a,),
         )
 
-    def test_refresh_completion_notifies_target_client_partner(self):
-        """mark_completed on a refresh comments the target's allowed partner."""
+    def test_refresh_completion_notifies_initiator(self):
+        """mark_completed on a refresh comments the recorded initiator only."""
         with patch(_REFRESH_CR):
             refresh = self.env["k8s.odoo.staging.refresh"].create(
                 {
                     "target_instance_id": self.inst_a_staging.id,
                     "source_instance_id": self.inst_a_prod.id,
+                    "portal_initiator_id": self.initiator_a.id,
                 }
             )
         before = set(self.inst_a_staging.message_ids.ids)
         refresh.mark_completed(message="INTERNAL: snapshot detail")
         new = self._new_messages(self.inst_a_staging, before)
         self._assert_client_comment(
-            new, self.company_a, body_must_avoid=("INTERNAL: snapshot detail",)
+            new,
+            self.initiator_a,
+            body_must_avoid=("INTERNAL: snapshot detail",),
+            not_recipient=(self.company_a,),
         )
 
-    def test_backup_completion_notifies_client_partner(self):
-        """mark_completed on a backup comments the allowed partner."""
+    def test_backup_completion_notifies_initiator(self):
+        """mark_completed on a backup comments the recorded initiator only."""
         with patch(_BACKUP_CR):
             backup = self.env["k8s.odoo.backup"].create(
-                {"instance_id": self.inst_a_prod.id, "format": "zip"}
+                {
+                    "instance_id": self.inst_a_prod.id,
+                    "format": "zip",
+                    "portal_initiator_id": self.initiator_a.id,
+                }
             )
         before = set(self.inst_a_prod.message_ids.ids)
         backup.mark_completed(message="INTERNAL: object_key s3://x")
         new = self._new_messages(self.inst_a_prod, before)
         self._assert_client_comment(
-            new, self.company_a, body_must_avoid=("INTERNAL: object_key s3://x",)
+            new,
+            self.initiator_a,
+            body_must_avoid=("INTERNAL: object_key s3://x",),
+            not_recipient=(self.company_a,),
+        )
+
+    def test_terminal_notification_notifies_followers(self):
+        """An existing follower is notified via the mt_comment subtype."""
+        # Subscribe a follower partner BEFORE the terminal transition.
+        follower = self.env["res.partner"].create(
+            {"name": "Life Follower", "email": "follower@example.com"}
+        )
+        self.inst_a_prod.message_subscribe(partner_ids=follower.ids)
+        with patch(_UPGRADE_CR):
+            upgrade = self.env["k8s.odoo.upgrade"].create(
+                {
+                    "instance_id": self.inst_a_prod.id,
+                    "modules": "base",
+                    "portal_initiator_id": self.initiator_a.id,
+                }
+            )
+        before = set(self.inst_a_prod.message_ids.ids)
+        upgrade.mark_completed(message="done")
+        new = self._new_messages(self.inst_a_prod, before)
+        self._assert_client_comment(
+            new,
+            self.initiator_a,
+            followers=(follower,),
+            not_recipient=(self.company_a,),
+        )
+
+    def test_terminal_notification_without_initiator_notifies_followers_only(self):
+        """Herd/operator-driven op (no initiator): followers only, no direct partner."""
+        follower = self.env["res.partner"].create(
+            {"name": "Life Follower 2", "email": "follower2@example.com"}
+        )
+        self.inst_a_prod.message_subscribe(partner_ids=follower.ids)
+        with patch(_UPGRADE_CR):
+            upgrade = self.env["k8s.odoo.upgrade"].create(
+                {"instance_id": self.inst_a_prod.id, "modules": "base"}
+            )
+        before = set(self.inst_a_prod.message_ids.ids)
+        upgrade.mark_completed(message="done")
+        new = self._new_messages(self.inst_a_prod, before)
+        # No initiator => no direct partner_ids recipient at all.
+        self._assert_client_comment(
+            new,
+            None,
+            followers=(follower,),
+            not_recipient=(self.company_a,),
+        )
+        self.assertFalse(
+            new.partner_ids,
+            "With no portal initiator there must be no direct partner_ids "
+            "recipient (followers are reached via the subtype).",
         )
 
     def test_terminal_notification_excludes_non_allowed_partner(self):
         """Negative: a non-allowed company's partner is NOT a recipient."""
         with patch(_UPGRADE_CR):
             upgrade = self.env["k8s.odoo.upgrade"].create(
-                {"instance_id": self.inst_a_prod.id, "modules": "base"}
+                {
+                    "instance_id": self.inst_a_prod.id,
+                    "modules": "base",
+                    "portal_initiator_id": self.initiator_a.id,
+                }
             )
         before = set(self.inst_a_prod.message_ids.ids)
         upgrade.mark_completed(message="done")
@@ -413,6 +532,25 @@ class TestLifecycleNotification(TransactionCase):
             new.partner_ids,
             "A non-allowed company's partner must NOT receive the "
             "terminal notification.",
+        )
+
+    def test_terminal_notification_does_not_subscribe_initiator(self):
+        """No auto-subscription: the initiator is not added as a follower."""
+        with patch(_UPGRADE_CR):
+            upgrade = self.env["k8s.odoo.upgrade"].create(
+                {
+                    "instance_id": self.inst_a_prod.id,
+                    "modules": "base",
+                    "portal_initiator_id": self.initiator_a.id,
+                }
+            )
+        upgrade.mark_completed(message="done")
+        self.inst_a_prod.invalidate_recordset()
+        self.assertNotIn(
+            self.initiator_a,
+            self.inst_a_prod.message_partner_ids,
+            "The terminal notification must NOT subscribe the initiator as a "
+            "standing follower.",
         )
 
 

--- a/odoo_herd_portal/tests/test_lifecycle.py
+++ b/odoo_herd_portal/tests/test_lifecycle.py
@@ -1,4 +1,4 @@
-# Part of Odoo Herd Portal. See LICENSE file for full copyright and licensing details.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 """Feature E -- self-serve lifecycle acceptance tests (upgrade + staging-refresh).
 
 Acceptance criteria under test:

--- a/odoo_herd_portal/tests/test_lifecycle.py
+++ b/odoo_herd_portal/tests/test_lifecycle.py
@@ -1,0 +1,546 @@
+# Part of Odoo Herd Portal. See LICENSE file for full copyright and licensing details.
+"""Feature E -- self-serve lifecycle acceptance tests (upgrade + staging-refresh).
+
+Acceptance criteria under test:
+
+* (a) Upgrade on an OWNED instance creates a ``k8s.odoo.upgrade`` job AND a
+  PRECEDING ``k8s.odoo.backup`` (the auto-backup-before-upgrade guardrail). The
+  same POST on a NON-owned instance creates nothing -- no upgrade, no backup,
+  and the k8s CR hooks are never called (IDOR protection).
+* (b) Safe-target guardrail: a portal-supplied ``modules_install`` (or any
+  arbitrary module list in the request) NEVER reaches the upgrade job / k8s
+  call. The upgrade is the instance's STANDARD upgrade, derived server-side.
+* (c) Staging-refresh is ALLOWED when the target is a staging instance the user
+  owns whose ``production_instance_id`` they also own; it is REFUSED when the
+  target is production (the control is never exposed there); REFUSED for a
+  non-owned target (IDOR); and the created refresh is bound to the correct
+  source = the target's ``production_instance_id``.
+* (d) A sensitive field on ``k8s.odoo.upgrade`` / ``k8s.odoo.staging.refresh``
+  (webhook token, job names/uids, internal refs) raises AccessError for a
+  portal user even via the ORM (deny-by-default field whitelist). A drift-guard
+  ensures any field NOT whitelisted stays hidden, for BOTH models.
+* (e) Every client-initiated action (upgrade, staging-refresh) posts an audit
+  chatter message on the instance recording who/what/when.
+* (f) The client-completion/failure notification is created on a SIMULATED
+  terminal-state transition (the operator webhook drives ``mark_completed`` /
+  ``mark_failed`` in prod): a message is posted to the instance's chatter.
+
+These mix HttpCase (end-to-end controller + record rule + CSRF) and
+TransactionCase (ORM-level field secrecy / drift-guard / notification hook).
+The actual Kubernetes calls are stubbed by patching each job model's CR-creation
+hook, mirroring Feature D's tests and how ``odoo_herd``'s own tests avoid a live
+cluster.
+"""
+
+from unittest.mock import patch
+
+from odoo import http
+from odoo.exceptions import AccessError
+from odoo.tests import HttpCase, TransactionCase, tagged
+from odoo.tools.misc import mute_logger
+
+from odoo.addons.odoo_herd_portal.models.k8s_odoo_upgrade import (
+    PORTAL_VISIBLE_UPGRADE_FIELDS,
+)
+from odoo.addons.odoo_herd_portal.models.k8s_odoo_staging_refresh import (
+    PORTAL_VISIBLE_REFRESH_FIELDS,
+)
+
+# CR-creation hooks that hit the live cluster; stubbed in every test that
+# creates a job record so no Kubernetes API call is made.
+_BACKUP_CR = (
+    "odoo.addons.odoo_herd.models.k8s_backup.K8sOdooBackup._create_backup_job_cr"
+)
+_UPGRADE_CR = (
+    "odoo.addons.odoo_herd.models.k8s_upgrade.K8sOdooUpgrade._trigger_upgrade"
+)
+_REFRESH_CR = (
+    "odoo.addons.odoo_herd.models.k8s_staging_refresh"
+    ".K8sOdooStagingRefresh._create_refresh_job_cr"
+)
+
+# Framework / audit fields readable by any user by design -- excluded from the
+# drift-guard (same rationale as Feature A/D drift-guards).
+_FRAMEWORK_READABLE = frozenset(
+    {
+        "create_date",
+        "write_date",
+        "create_uid",
+        "write_uid",
+        "__last_update",
+    }
+)
+
+
+def _common_fixtures(cls):
+    """Build the two-company / instances fixture set for lifecycle tests."""
+    Partner = cls.env["res.partner"]
+    Users = cls.env["res.users"]
+    portal_group = cls.env.ref("base.group_portal")
+
+    cls.company_a = Partner.create({"name": "Life Co A", "is_company": True})
+    cls.company_b = Partner.create({"name": "Life Co B", "is_company": True})
+
+    cls.user_a = Users.create(
+        {
+            "name": "Life User A",
+            "login": "life_user_a",
+            "password": "life_user_a",
+            "email": "life_a@example.com",
+            "partner_id": cls.company_a.id,
+            "group_ids": [(6, 0, [portal_group.id])],
+        }
+    )
+    cls.user_b = Users.create(
+        {
+            "name": "Life User B",
+            "login": "life_user_b",
+            "password": "life_user_b",
+            "email": "life_b@example.com",
+            "partner_id": cls.company_b.id,
+            "group_ids": [(6, 0, [portal_group.id])],
+        }
+    )
+
+    cls.s3_config = cls.env["k8s.s3.config"].create(
+        {
+            "name": "Life Test S3",
+            "endpoint": "https://minio.invalid",
+            "bucket": "backups",
+            "credentials_secret_name": "s3-creds",
+        }
+    )
+    # Active cluster: the upgrade/refresh wizard pre-flight checks
+    # ``cluster_id.active``; CR hooks are stubbed so no real call is made.
+    cls.cluster = cls.env["k8s.cluster"].create(
+        {
+            "name": "Life Test Cluster",
+            "api_endpoint": "https://example.invalid:6443",
+            "kubeconfig": "apiVersion: v1\nkind: Config\n",
+            "default_namespace": "default",
+            "active": True,
+            "backup_s3_config_id": cls.s3_config.id,
+        }
+    )
+
+    Instance = cls.env["k8s.odoo.instance"]
+    # Company A: production + staging (staging sourced from prod).
+    cls.inst_a_prod = Instance.create(
+        {
+            "name": "lifeco-a-prod",
+            "namespace": "lifeco-a",
+            "cluster_id": cls.cluster.id,
+            "environment": "production",
+            "allowed_partner_ids": [(6, 0, [cls.company_a.id])],
+        }
+    )
+    cls.inst_a_staging = Instance.create(
+        {
+            "name": "lifeco-a-staging",
+            "namespace": "lifeco-a",
+            "cluster_id": cls.cluster.id,
+            "environment": "staging",
+            "production_instance_id": cls.inst_a_prod.id,
+            "allowed_partner_ids": [(6, 0, [cls.company_a.id])],
+        }
+    )
+    # Company B: a production instance, never visible to A.
+    cls.inst_b_prod = Instance.create(
+        {
+            "name": "lifeco-b-prod",
+            "namespace": "lifeco-b",
+            "cluster_id": cls.cluster.id,
+            "environment": "production",
+            "allowed_partner_ids": [(6, 0, [cls.company_b.id])],
+        }
+    )
+    cls.inst_b_staging = Instance.create(
+        {
+            "name": "lifeco-b-staging",
+            "namespace": "lifeco-b",
+            "cluster_id": cls.cluster.id,
+            "environment": "staging",
+            "production_instance_id": cls.inst_b_prod.id,
+            "allowed_partner_ids": [(6, 0, [cls.company_b.id])],
+        }
+    )
+
+
+@tagged("post_install", "-at_install", "odoo_herd_portal")
+class TestLifecycleSecrecy(TransactionCase):
+    """ORM-level field secrecy + drift-guard for both job models (d)."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        _common_fixtures(cls)
+        # One upgrade + one refresh job to read fields off, created with the
+        # CR hooks stubbed so no cluster call is made.
+        with patch(_UPGRADE_CR):
+            cls.upgrade = cls.env["k8s.odoo.upgrade"].create(
+                {
+                    "instance_id": cls.inst_a_prod.id,
+                    "modules": "base",
+                }
+            )
+        with patch(_REFRESH_CR):
+            cls.refresh = cls.env["k8s.odoo.staging.refresh"].create(
+                {
+                    "target_instance_id": cls.inst_a_staging.id,
+                    "source_instance_id": cls.inst_a_prod.id,
+                }
+            )
+
+    # -------------------------------------------------------------- (d) upgrade
+    def test_sensitive_upgrade_fields_hidden(self):
+        """Known secret upgrade fields raise AccessError for a portal user."""
+        rec = self.upgrade.with_user(self.user_a)
+        for field_name in ("webhook_token", "job_name", "job_uid", "message"):
+            with self.subTest(field=field_name):
+                with self.assertRaises(AccessError), mute_logger("odoo.models"):
+                    rec.read([field_name])
+
+    def test_whitelisted_upgrade_fields_readable(self):
+        """Every whitelisted upgrade field stays readable by a portal user."""
+        rec = self.upgrade.with_user(self.user_a)
+        model_fields = self.env["k8s.odoo.upgrade"]._fields
+        readable = sorted(PORTAL_VISIBLE_UPGRADE_FIELDS & set(model_fields))
+        self.assertEqual(
+            set(readable),
+            PORTAL_VISIBLE_UPGRADE_FIELDS,
+            "PORTAL_VISIBLE_UPGRADE_FIELDS references fields absent from model.",
+        )
+        self.assertTrue(rec.read(readable))
+
+    def test_drift_guard_non_whitelisted_upgrade_fields_hidden(self):
+        """Deny-by-default: any non-whitelisted upgrade field is hidden."""
+        Upgrade = self.env["k8s.odoo.upgrade"]
+        rec = self.upgrade.with_user(self.user_a)
+        leaked = []
+        for field_name in Upgrade._fields:
+            if field_name in PORTAL_VISIBLE_UPGRADE_FIELDS:
+                continue
+            if field_name in _FRAMEWORK_READABLE:
+                continue
+            with self.subTest(field=field_name):
+                try:
+                    with mute_logger("odoo.models"):
+                        rec.read([field_name])
+                except AccessError:
+                    continue
+                leaked.append(field_name)
+        self.assertEqual(
+            leaked,
+            [],
+            "Non-whitelisted upgrade fields readable by a portal user "
+            "(add groups= or extend the whitelist): %s" % leaked,
+        )
+
+    # -------------------------------------------------------------- (d) refresh
+    def test_sensitive_refresh_fields_hidden(self):
+        """Known secret staging-refresh fields raise AccessError."""
+        rec = self.refresh.with_user(self.user_a)
+        for field_name in (
+            "webhook_token",
+            "refresh_job_name",
+            "db_job_name",
+            "filestore_job_name",
+            "neutralize_job_name",
+            "temp_db_name",
+            "source_snapshot",
+            "rollback_snapshot",
+            "message",
+        ):
+            with self.subTest(field=field_name):
+                with self.assertRaises(AccessError), mute_logger("odoo.models"):
+                    rec.read([field_name])
+
+    def test_whitelisted_refresh_fields_readable(self):
+        """Every whitelisted refresh field stays readable by a portal user."""
+        rec = self.refresh.with_user(self.user_a)
+        model_fields = self.env["k8s.odoo.staging.refresh"]._fields
+        readable = sorted(PORTAL_VISIBLE_REFRESH_FIELDS & set(model_fields))
+        self.assertEqual(
+            set(readable),
+            PORTAL_VISIBLE_REFRESH_FIELDS,
+            "PORTAL_VISIBLE_REFRESH_FIELDS references fields absent from model.",
+        )
+        self.assertTrue(rec.read(readable))
+
+    def test_drift_guard_non_whitelisted_refresh_fields_hidden(self):
+        """Deny-by-default: any non-whitelisted refresh field is hidden."""
+        Refresh = self.env["k8s.odoo.staging.refresh"]
+        rec = self.refresh.with_user(self.user_a)
+        leaked = []
+        for field_name in Refresh._fields:
+            if field_name in PORTAL_VISIBLE_REFRESH_FIELDS:
+                continue
+            if field_name in _FRAMEWORK_READABLE:
+                continue
+            with self.subTest(field=field_name):
+                try:
+                    with mute_logger("odoo.models"):
+                        rec.read([field_name])
+                except AccessError:
+                    continue
+                leaked.append(field_name)
+        self.assertEqual(
+            leaked,
+            [],
+            "Non-whitelisted refresh fields readable by a portal user "
+            "(add groups= or extend the whitelist): %s" % leaked,
+        )
+
+
+@tagged("post_install", "-at_install", "odoo_herd_portal")
+class TestLifecycleNotification(TransactionCase):
+    """Client completion/failure notification on terminal-state transition (f)."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        _common_fixtures(cls)
+
+    def test_upgrade_completion_notifies_instance(self):
+        """mark_completed on an upgrade posts a message to the instance."""
+        with patch(_UPGRADE_CR):
+            upgrade = self.env["k8s.odoo.upgrade"].create(
+                {"instance_id": self.inst_a_prod.id, "modules": "base"}
+            )
+        before = len(self.inst_a_prod.message_ids)
+        upgrade.mark_completed(message="done")
+        self.inst_a_prod.invalidate_recordset()
+        self.assertGreater(
+            len(self.inst_a_prod.message_ids),
+            before,
+            "A completion notification must be posted to the instance.",
+        )
+
+    def test_upgrade_failure_notifies_instance(self):
+        """mark_failed on an upgrade posts a message to the instance."""
+        with patch(_UPGRADE_CR):
+            upgrade = self.env["k8s.odoo.upgrade"].create(
+                {"instance_id": self.inst_a_prod.id, "modules": "base"}
+            )
+        before = len(self.inst_a_prod.message_ids)
+        upgrade.mark_failed(message="boom")
+        self.inst_a_prod.invalidate_recordset()
+        self.assertGreater(len(self.inst_a_prod.message_ids), before)
+
+    def test_refresh_completion_notifies_target_instance(self):
+        """mark_completed on a staging-refresh posts to the target instance."""
+        with patch(_REFRESH_CR):
+            refresh = self.env["k8s.odoo.staging.refresh"].create(
+                {
+                    "target_instance_id": self.inst_a_staging.id,
+                    "source_instance_id": self.inst_a_prod.id,
+                }
+            )
+        before = len(self.inst_a_staging.message_ids)
+        refresh.mark_completed(message="refreshed")
+        self.inst_a_staging.invalidate_recordset()
+        self.assertGreater(len(self.inst_a_staging.message_ids), before)
+
+    def test_backup_completion_notifies_instance(self):
+        """mark_completed on a backup posts to the instance (best-effort)."""
+        with patch(_BACKUP_CR):
+            backup = self.env["k8s.odoo.backup"].create(
+                {"instance_id": self.inst_a_prod.id, "format": "zip"}
+            )
+        before = len(self.inst_a_prod.message_ids)
+        backup.mark_completed(message="backed up")
+        self.inst_a_prod.invalidate_recordset()
+        self.assertGreater(len(self.inst_a_prod.message_ids), before)
+
+
+@tagged("post_install", "-at_install", "odoo_herd_portal")
+class TestLifecycleSelfService(HttpCase):
+    """End-to-end controller: upgrade + staging-refresh (a, b, c, e)."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        _common_fixtures(cls)
+
+    def _csrf_token(self):
+        return http.Request.csrf_token(self)
+
+    # ============================================================= (a) upgrade
+    def test_upgrade_owned_creates_upgrade_and_backup(self):
+        """POST upgrade on an owned instance creates an upgrade + a backup."""
+        self.authenticate("life_user_a", "life_user_a")
+        Upgrade = self.env["k8s.odoo.upgrade"]
+        Backup = self.env["k8s.odoo.backup"]
+        up_before = Upgrade.search_count([("instance_id", "=", self.inst_a_prod.id)])
+        bk_before = Backup.search_count([("instance_id", "=", self.inst_a_prod.id)])
+        with patch(_UPGRADE_CR) as up_cr, patch(_BACKUP_CR) as bk_cr:
+            resp = self.url_open(
+                "/my/instances/%d/upgrade" % self.inst_a_prod.id,
+                data={"csrf_token": self._csrf_token()},
+            )
+        self.assertEqual(resp.status_code, 200)
+        up_after = Upgrade.search_count([("instance_id", "=", self.inst_a_prod.id)])
+        bk_after = Backup.search_count([("instance_id", "=", self.inst_a_prod.id)])
+        self.assertEqual(up_after, up_before + 1, "An upgrade job must be created.")
+        self.assertEqual(
+            bk_after, bk_before + 1, "An auto-backup must precede the upgrade."
+        )
+        self.assertTrue(up_cr.called, "Upgrade CR hook must run under sudo.")
+        self.assertTrue(bk_cr.called, "Backup CR hook must run under sudo.")
+        # Backup must be created BEFORE the upgrade (guardrail ordering).
+        # The two models have independent id sequences, so compare by
+        # create_date instead of id.
+        backup = Backup.search(
+            [("instance_id", "=", self.inst_a_prod.id)],
+            order="create_date desc, id desc",
+            limit=1,
+        )
+        upgrade = Upgrade.search(
+            [("instance_id", "=", self.inst_a_prod.id)],
+            order="create_date desc, id desc",
+            limit=1,
+        )
+        self.assertLessEqual(
+            backup.create_date,
+            upgrade.create_date,
+            "Backup must be created before (or at) the upgrade.",
+        )
+
+    def test_upgrade_non_owned_refused(self):
+        """POST upgrade on a non-owned instance creates nothing (IDOR)."""
+        self.authenticate("life_user_a", "life_user_a")
+        Upgrade = self.env["k8s.odoo.upgrade"]
+        Backup = self.env["k8s.odoo.backup"]
+        up_before = Upgrade.search_count([("instance_id", "=", self.inst_b_prod.id)])
+        bk_before = Backup.search_count([("instance_id", "=", self.inst_b_prod.id)])
+        with patch(_UPGRADE_CR) as up_cr, patch(_BACKUP_CR) as bk_cr:
+            resp = self.url_open(
+                "/my/instances/%d/upgrade" % self.inst_b_prod.id,
+                data={"csrf_token": self._csrf_token()},
+                allow_redirects=False,
+            )
+        self.assertIn(resp.status_code, (301, 302, 303, 403, 404))
+        up_after = Upgrade.search_count([("instance_id", "=", self.inst_b_prod.id)])
+        bk_after = Backup.search_count([("instance_id", "=", self.inst_b_prod.id)])
+        self.assertEqual(up_after, up_before, "No upgrade for a foreign instance.")
+        self.assertEqual(bk_after, bk_before, "No backup for a foreign instance.")
+        self.assertFalse(up_cr.called)
+        self.assertFalse(bk_cr.called)
+
+    # ============================================================= (b) safe-target
+    def test_upgrade_ignores_supplied_module_install_list(self):
+        """A portal-supplied modules_install never reaches the upgrade job."""
+        self.authenticate("life_user_a", "life_user_a")
+        Upgrade = self.env["k8s.odoo.upgrade"]
+        with patch(_UPGRADE_CR), patch(_BACKUP_CR):
+            self.url_open(
+                "/my/instances/%d/upgrade" % self.inst_a_prod.id,
+                data={
+                    "csrf_token": self._csrf_token(),
+                    # Attacker-controlled install-anything vector:
+                    "modules_install": "auth_signup,base_import_module",
+                    "modules": "account,sale",
+                },
+            )
+        upgrade = Upgrade.search(
+            [("instance_id", "=", self.inst_a_prod.id)],
+            order="create_date desc, id desc",
+            limit=1,
+        )
+        # Nothing the client sent may end up on the job.
+        self.assertFalse(
+            upgrade.modules_install,
+            "No portal-supplied install list may reach the upgrade job.",
+        )
+        for forbidden in ("auth_signup", "base_import_module"):
+            self.assertNotIn(forbidden, upgrade.modules or "")
+
+    # ============================================================= (c) refresh
+    def test_refresh_staging_owned_creates_refresh_bound_to_source(self):
+        """Refresh on an owned staging instance creates a refresh from prod."""
+        self.authenticate("life_user_a", "life_user_a")
+        Refresh = self.env["k8s.odoo.staging.refresh"]
+        before = Refresh.search_count([])
+        with patch(_REFRESH_CR) as cr:
+            resp = self.url_open(
+                "/my/instances/%d/refresh-staging" % self.inst_a_staging.id,
+                data={"csrf_token": self._csrf_token()},
+            )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(Refresh.search_count([]), before + 1)
+        self.assertTrue(cr.called)
+        new = Refresh.search([], order="create_date desc, id desc", limit=1)
+        self.assertEqual(new.target_instance_id, self.inst_a_staging)
+        self.assertEqual(
+            new.source_instance_id,
+            self.inst_a_prod,
+            "Source must be bound to the target's production_instance_id.",
+        )
+
+    def test_refresh_production_target_refused(self):
+        """Refresh targeting a production instance is refused (never exposed)."""
+        self.authenticate("life_user_a", "life_user_a")
+        Refresh = self.env["k8s.odoo.staging.refresh"]
+        before = Refresh.search_count([])
+        with patch(_REFRESH_CR) as cr:
+            resp = self.url_open(
+                "/my/instances/%d/refresh-staging" % self.inst_a_prod.id,
+                data={"csrf_token": self._csrf_token()},
+                allow_redirects=False,
+            )
+        self.assertIn(resp.status_code, (301, 302, 303, 403, 404))
+        self.assertEqual(
+            Refresh.search_count([]), before, "No refresh against a production target."
+        )
+        self.assertFalse(cr.called)
+
+    def test_refresh_non_owned_refused(self):
+        """Refresh on a non-owned staging instance is refused (IDOR)."""
+        self.authenticate("life_user_a", "life_user_a")
+        Refresh = self.env["k8s.odoo.staging.refresh"]
+        before = Refresh.search_count([])
+        with patch(_REFRESH_CR) as cr:
+            resp = self.url_open(
+                "/my/instances/%d/refresh-staging" % self.inst_b_staging.id,
+                data={"csrf_token": self._csrf_token()},
+                allow_redirects=False,
+            )
+        self.assertIn(resp.status_code, (301, 302, 303, 403, 404))
+        self.assertEqual(Refresh.search_count([]), before)
+        self.assertFalse(cr.called)
+
+    # ============================================================= (e) audit
+    def test_upgrade_posts_audit_message(self):
+        """Upgrade posts an audit chatter message on the instance."""
+        self.authenticate("life_user_a", "life_user_a")
+        before = len(self.inst_a_prod.message_ids)
+        with patch(_UPGRADE_CR), patch(_BACKUP_CR):
+            self.url_open(
+                "/my/instances/%d/upgrade" % self.inst_a_prod.id,
+                data={"csrf_token": self._csrf_token()},
+            )
+        self.inst_a_prod.invalidate_recordset()
+        messages = self.inst_a_prod.message_ids
+        self.assertGreater(len(messages), before)
+        bodies = " ".join(m.body or "" for m in messages)
+        self.assertIn("pgrade", bodies)
+        # Authored by the acting portal user (who/what/when).
+        self.assertTrue(
+            any(m.author_id == self.user_a.partner_id for m in messages)
+        )
+
+    def test_refresh_posts_audit_message(self):
+        """Staging-refresh posts an audit chatter message on the target."""
+        self.authenticate("life_user_a", "life_user_a")
+        before = len(self.inst_a_staging.message_ids)
+        with patch(_REFRESH_CR):
+            self.url_open(
+                "/my/instances/%d/refresh-staging" % self.inst_a_staging.id,
+                data={"csrf_token": self._csrf_token()},
+            )
+        self.inst_a_staging.invalidate_recordset()
+        messages = self.inst_a_staging.message_ids
+        self.assertGreater(len(messages), before)
+        self.assertTrue(
+            any(m.author_id == self.user_a.partner_id for m in messages)
+        )

--- a/odoo_herd_portal/tests/test_log_viewer.py
+++ b/odoo_herd_portal/tests/test_log_viewer.py
@@ -1,0 +1,308 @@
+# Part of Odoo Herd Portal. See LICENSE file for full copyright and licensing details.
+"""Feature C -- live log viewer (Odoo side) acceptance tests.
+
+The streaming sidecar is a SEPARATE service; these tests cover ONLY the Odoo
+side: the signed short-lived scope-token mint, the portal route, and the
+iframe/postMessage handoff page.
+
+Acceptance criteria under test:
+
+* (a) Token mint for an OWNED instance produces a token of the form
+  ``b64url(payload).b64url(hmac_sha256(secret, b64url_payload))``. Decoding the
+  payload yields the correct ``ns`` (instance namespace), ``sel``
+  (``bemade.org/instance=<name>``) and ``iid`` (instance id); ``exp`` is about
+  ``now + 120``; recomputing the HMAC with the stored secret matches the
+  signature.
+* (b) Tampering with the payload, or signing/verifying with a wrong secret,
+  makes verification FAIL.
+* (c) A token whose ``exp`` is in the past is rejected by the verify helper.
+* (d) IDOR: ``/my/instances/<id>/logs`` for a NON-owned instance redirects (or
+  404s) and mints NO token -- the response body contains no token and no
+  ``<iframe>``.
+* (e) The rendered logs page does NOT contain the signing secret nor the
+  namespace in clear text (outside the opaque signed token), and the token is
+  NOT present in the iframe ``src`` URL.
+* (f) The "recent logs only" notice is present on the page.
+
+The token mint helper is stdlib-only (hmac/hashlib/base64/json/time); no live
+cluster is touched, so nothing is stubbed.
+"""
+
+import base64
+import hashlib
+import hmac
+import json
+import time
+
+from odoo.tests import HttpCase, TransactionCase, tagged
+
+SECRET_PARAM = "odoo_herd_portal.log_token_secret"
+VIEWER_URL_PARAM = "odoo_herd_portal.log_viewer_url"
+
+
+def _b64url_decode(segment):
+    """Decode an unpadded urlsafe base64 string (mirrors the sidecar)."""
+    padding = "=" * (-len(segment) % 4)
+    return base64.urlsafe_b64decode(segment + padding)
+
+
+def _verify_token(token, secret, *, now=None):
+    """Standalone verifier mirroring what the SIDECAR must implement.
+
+    Returns the decoded payload dict on success; raises ``ValueError`` on a bad
+    structure, signature mismatch, or expiry. This is intentionally written
+    here (not imported from the module) so the test proves the wire format is
+    independently verifiable.
+    """
+    if now is None:
+        now = int(time.time())
+    try:
+        payload_b64, sig_b64 = token.split(".")
+    except ValueError as exc:
+        raise ValueError("malformed token") from exc
+    expected = hmac.new(
+        secret.encode("utf-8"),
+        payload_b64.encode("utf-8"),
+        hashlib.sha256,
+    ).digest()
+    got = _b64url_decode(sig_b64)
+    if not hmac.compare_digest(expected, got):
+        raise ValueError("bad signature")
+    payload = json.loads(_b64url_decode(payload_b64))
+    if int(payload.get("exp", 0)) < now:
+        raise ValueError("expired")
+    return payload
+
+
+def _common_fixtures(cls):
+    """Two companies, two portal users, one owned + one foreign instance."""
+    Partner = cls.env["res.partner"]
+    Users = cls.env["res.users"]
+    portal_group = cls.env.ref("base.group_portal")
+
+    cls.company_a = Partner.create({"name": "Logs Co A", "is_company": True})
+    cls.company_b = Partner.create({"name": "Logs Co B", "is_company": True})
+
+    cls.user_a = Users.create(
+        {
+            "name": "Logs User A",
+            "login": "logs_user_a",
+            "password": "logs_user_a",
+            "email": "logs_a@example.com",
+            "partner_id": cls.company_a.id,
+            "group_ids": [(6, 0, [portal_group.id])],
+        }
+    )
+
+    cls.cluster = cls.env["k8s.cluster"].create(
+        {
+            "name": "Logs Test Cluster",
+            "api_endpoint": "https://example.invalid:6443",
+            "kubeconfig": "apiVersion: v1\nkind: Config\n",
+            "default_namespace": "default",
+            "active": False,
+        }
+    )
+
+    Instance = cls.env["k8s.odoo.instance"]
+    # NB: the namespace is deliberately NOT a substring of the instance name,
+    # so the no-leak assertions can tell a namespace leak apart from the
+    # instance name (which is legitimately displayed on the page).
+    cls.inst_a = Instance.create(
+        {
+            "name": "alpha-prod",
+            "namespace": "nsclient-alpha",
+            "cluster_id": cls.cluster.id,
+            "environment": "production",
+            "allowed_partner_ids": [(6, 0, [cls.company_a.id])],
+        }
+    )
+    cls.inst_b = Instance.create(
+        {
+            "name": "bravo-prod",
+            "namespace": "nsclient-bravo",
+            "cluster_id": cls.cluster.id,
+            "environment": "production",
+            "allowed_partner_ids": [(6, 0, [cls.company_b.id])],
+        }
+    )
+
+    # Configure a sidecar URL so the page renders an iframe.
+    cls.env["ir.config_parameter"].sudo().set_param(
+        VIEWER_URL_PARAM, "https://logs.bemade.org"
+    )
+
+
+@tagged("post_install", "-at_install", "odoo_herd_portal")
+class TestLogTokenMint(TransactionCase):
+    """Token mint / verify / tamper / expiry (a, b, c)."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        _common_fixtures(cls)
+
+    def _secret(self):
+        return (
+            self.env["ir.config_parameter"].sudo().get_param(SECRET_PARAM)
+        )
+
+    # -------------------------------------------------------------- (a)
+    def test_mint_token_claims_and_signature(self):
+        """Mint for an owned instance: claims correct, signature verifies."""
+        Instance = self.env["k8s.odoo.instance"]
+        inst = Instance.with_user(self.user_a).browse(self.inst_a.id)
+        before = int(time.time())
+        token = inst._mint_log_token()
+        after = int(time.time())
+
+        secret = self._secret()
+        self.assertTrue(secret, "A secret must be generated on first use.")
+        self.assertNotIn(
+            secret, token, "The raw secret must never appear in the token."
+        )
+
+        payload = _verify_token(token, secret)
+        self.assertEqual(payload["ns"], "nsclient-alpha")
+        self.assertEqual(payload["sel"], "bemade.org/instance=alpha-prod")
+        self.assertEqual(payload["iid"], self.inst_a.id)
+        # exp ~ now + 120 (allow for the second the mint took).
+        self.assertGreaterEqual(payload["exp"], before + 120)
+        self.assertLessEqual(payload["exp"], after + 120)
+        self.assertGreaterEqual(payload["iat"], before)
+        self.assertLessEqual(payload["iat"], after)
+
+    def test_secret_is_persisted_and_stable(self):
+        """The generated secret is reused, not regenerated each mint."""
+        inst = self.env["k8s.odoo.instance"].with_user(self.user_a).browse(
+            self.inst_a.id
+        )
+        inst._mint_log_token()
+        first = self._secret()
+        inst._mint_log_token()
+        self.assertEqual(self._secret(), first)
+        self.assertGreaterEqual(len(first), 32, "Secret must be strong.")
+
+    # -------------------------------------------------------------- (b)
+    def test_tampered_payload_fails_verification(self):
+        """Altering the payload breaks the signature."""
+        inst = self.env["k8s.odoo.instance"].with_user(self.user_a).browse(
+            self.inst_a.id
+        )
+        token = inst._mint_log_token()
+        secret = self._secret()
+        payload_b64, sig_b64 = token.split(".")
+        tampered_payload = json.dumps(
+            {
+                "ns": "victim-namespace",
+                "sel": "bemade.org/instance=victim",
+                "exp": int(time.time()) + 120,
+                "iat": int(time.time()),
+                "iid": 999999,
+            }
+        ).encode("utf-8")
+        forged_b64 = (
+            base64.urlsafe_b64encode(tampered_payload)
+            .rstrip(b"=")
+            .decode("ascii")
+        )
+        forged_token = "%s.%s" % (forged_b64, sig_b64)
+        with self.assertRaises(ValueError):
+            _verify_token(forged_token, secret)
+
+    def test_wrong_secret_fails_verification(self):
+        """Verifying with the wrong secret fails."""
+        inst = self.env["k8s.odoo.instance"].with_user(self.user_a).browse(
+            self.inst_a.id
+        )
+        token = inst._mint_log_token()
+        with self.assertRaises(ValueError):
+            _verify_token(token, "not-the-real-secret")
+
+    # -------------------------------------------------------------- (c)
+    def test_expired_token_rejected(self):
+        """A token with exp in the past is rejected."""
+        inst = self.env["k8s.odoo.instance"].with_user(self.user_a).browse(
+            self.inst_a.id
+        )
+        token = inst._mint_log_token()
+        secret = self._secret()
+        # It verifies now ...
+        self.assertTrue(_verify_token(token, secret))
+        # ... but not when "now" is 200s in the future (past its 120s window).
+        with self.assertRaises(ValueError):
+            _verify_token(token, secret, now=int(time.time()) + 200)
+
+
+@tagged("post_install", "-at_install", "odoo_herd_portal")
+class TestLogViewerPage(HttpCase):
+    """Portal route: IDOR guard + no-leak rendering (d, e, f)."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        _common_fixtures(cls)
+
+    # -------------------------------------------------------------- (e, f)
+    def test_logs_page_owned_renders_iframe_no_leak(self):
+        """Owned instance: iframe present, token NOT in src, no secret/ns leak."""
+        self.authenticate("logs_user_a", "logs_user_a")
+        resp = self.url_open("/my/instances/%d/logs" % self.inst_a.id)
+        self.assertEqual(resp.status_code, 200)
+        body = resp.text
+
+        # (f) recent-only notice.
+        self.assertIn("recent", body.lower())
+
+        # iframe present, pointing at the configured sidecar base URL.
+        self.assertIn("<iframe", body)
+        self.assertIn("https://logs.bemade.org", body)
+
+        # (e) the signing secret never appears.
+        secret = (
+            self.env["ir.config_parameter"].sudo().get_param(SECRET_PARAM)
+        )
+        self.assertTrue(secret)
+        self.assertNotIn(secret, body)
+
+        # (e) the namespace never appears in clear text outside the token.
+        # Locate the token, strip it, then assert the namespace is absent.
+        self.assertIn("data-log-scope", body)
+        # The iframe src must NOT carry the token as a query param.
+        # Grab the iframe tag and check the token value is not inside it.
+        token = self._extract_token(body)
+        self.assertTrue(token, "A token must be embedded in the page.")
+        iframe_tag = body[body.index("<iframe"):]
+        iframe_tag = iframe_tag[: iframe_tag.index(">") + 1]
+        self.assertNotIn(token, iframe_tag, "Token must NOT be in the iframe src.")
+        self.assertNotIn("token=", iframe_tag.lower())
+
+        # Namespace must not appear in clear text. It is only legitimately
+        # present inside the signed (base64) token payload, so strip the token
+        # out before asserting.
+        body_without_token = body.replace(token, "")
+        self.assertNotIn("nsclient-alpha", body_without_token)
+
+    # -------------------------------------------------------------- (d) IDOR
+    def test_logs_page_non_owned_redirects_no_token(self):
+        """Non-owned instance: redirect/404, no token, no iframe."""
+        self.authenticate("logs_user_a", "logs_user_a")
+        resp = self.url_open(
+            "/my/instances/%d/logs" % self.inst_b.id,
+            allow_redirects=False,
+        )
+        self.assertIn(resp.status_code, (301, 302, 303, 404))
+        body = resp.text
+        self.assertNotIn("data-log-scope", body)
+        self.assertNotIn("<iframe", body)
+        self.assertNotIn("nsclient-bravo", body)
+
+    def _extract_token(self, body):
+        """Pull the token out of the data-log-scope attribute."""
+        marker = 'data-log-scope="'
+        idx = body.find(marker)
+        if idx == -1:
+            return ""
+        start = idx + len(marker)
+        end = body.find('"', start)
+        return body[start:end]

--- a/odoo_herd_portal/tests/test_log_viewer.py
+++ b/odoo_herd_portal/tests/test_log_viewer.py
@@ -1,4 +1,4 @@
-# Part of Odoo Herd Portal. See LICENSE file for full copyright and licensing details.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 """Feature C -- live log viewer (Odoo side) acceptance tests.
 
 The streaming sidecar is a SEPARATE service; these tests cover ONLY the Odoo

--- a/odoo_herd_portal/tests/test_portal_overview.py
+++ b/odoo_herd_portal/tests/test_portal_overview.py
@@ -1,0 +1,185 @@
+# Part of Odoo Herd Portal. See LICENSE file for full copyright and licensing details.
+"""Feature B -- instance overview acceptance tests.
+
+Acceptance criteria under test:
+
+* (a) A portal user can open ``/my/instances`` (HTTP 200) and sees their own
+  company's instances grouped into Production and Staging (driven by the
+  ``environment`` field).
+* (b) Cross-tenant isolation: company A's portal user must NOT see company B's
+  instance on the list (its name is absent from the rendered body).
+* (c) The detail page ``/my/instances/<id>`` for an OWNED instance renders the
+  phase, ready/available replicas, the ingress URL (as a link-out), the image,
+  and -- for a staging instance -- a link to its source production instance.
+* (d) The detail page for a NON-owned instance id does not leak the data: it
+  returns a 404 / redirect to the portal home, never the foreign record.
+* (e) ``/my`` (the portal home) shows the "Odoo Instances" card with the count
+  of the user's instances.
+
+These are HttpCase tests: they drive the real portal controller + QWeb
+templates over HTTP as an authenticated portal user, exercising the Feature A
+record rule end-to-end (no manual partner filtering in the controller).
+"""
+
+import json
+
+from odoo.tests import HttpCase, tagged
+
+
+@tagged("post_install", "-at_install", "odoo_herd_portal")
+class TestPortalOverview(HttpCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        Partner = cls.env["res.partner"]
+        Users = cls.env["res.users"]
+        portal_group = cls.env.ref("base.group_portal")
+
+        # Two client companies, each with a portal user.
+        cls.company_a = Partner.create({"name": "Company A", "is_company": True})
+        cls.company_b = Partner.create({"name": "Company B", "is_company": True})
+
+        cls.user_a = Users.create(
+            {
+                "name": "Portal User A",
+                "login": "portal_overview_a",
+                "password": "portal_overview_a",
+                "email": "portal_overview_a@example.com",
+                "partner_id": cls.company_a.id,
+                "group_ids": [(6, 0, [portal_group.id])],
+            }
+        )
+        cls.user_b = Users.create(
+            {
+                "name": "Portal User B",
+                "login": "portal_overview_b",
+                "password": "portal_overview_b",
+                "email": "portal_overview_b@example.com",
+                "partner_id": cls.company_b.id,
+                "group_ids": [(6, 0, [portal_group.id])],
+            }
+        )
+
+        # Inactive cluster so the k8s-hitting computes short-circuit (no live
+        # cluster needed) -- mirrors Feature A's pattern.
+        cls.cluster = cls.env["k8s.cluster"].create(
+            {
+                "name": "Test Cluster B",
+                "api_endpoint": "https://example.invalid:6443",
+                "kubeconfig": "apiVersion: v1\nkind: Config\n",
+                "default_namespace": "default",
+                "active": False,
+            }
+        )
+
+        Instance = cls.env["k8s.odoo.instance"]
+
+        def _status(url):
+            # ingress_url is a stored computed field derived from the status
+            # JSON (status.ingress.urls[0]); replicas come only from a live
+            # deployment, so with an inactive cluster they stay 0.
+            return json.dumps({"ingress": {"urls": [url]}})
+
+        # Company A production instance.
+        cls.inst_a_prod = Instance.create(
+            {
+                "name": "company-a-prod",
+                "namespace": "company-a",
+                "cluster_id": cls.cluster.id,
+                "environment": "production",
+                "image": "registry.example.com/odoo:19.0-a",
+                "phase": "Running",
+                "status": _status("https://a-prod.example.com"),
+                "allowed_partner_ids": [(6, 0, [cls.company_a.id])],
+            }
+        )
+        # Company A staging instance, linked to the prod source.
+        cls.inst_a_staging = Instance.create(
+            {
+                "name": "company-a-staging",
+                "namespace": "company-a",
+                "cluster_id": cls.cluster.id,
+                "environment": "staging",
+                "image": "registry.example.com/odoo:19.0-a-stg",
+                "phase": "Running",
+                "status": _status("https://a-staging.example.com"),
+                "production_instance_id": cls.inst_a_prod.id,
+                "allowed_partner_ids": [(6, 0, [cls.company_a.id])],
+            }
+        )
+        # Company B production instance -- must never be visible to user A.
+        cls.inst_b_prod = Instance.create(
+            {
+                "name": "company-b-secret-prod",
+                "namespace": "company-b",
+                "cluster_id": cls.cluster.id,
+                "environment": "production",
+                "image": "registry.example.com/odoo:19.0-b",
+                "phase": "Running",
+                "status": _status("https://b-prod.example.com"),
+                "allowed_partner_ids": [(6, 0, [cls.company_b.id])],
+            }
+        )
+
+    # ------------------------------------------------------------------ (a)
+    def test_instances_list_groups_production_and_staging(self):
+        """Portal user A sees their prod + staging instances grouped."""
+        self.authenticate("portal_overview_a", "portal_overview_a")
+        resp = self.url_open("/my/instances")
+        self.assertEqual(resp.status_code, 200)
+        body = resp.text
+        self.assertIn("company-a-prod", body)
+        self.assertIn("company-a-staging", body)
+        # Both grouping headers are present.
+        self.assertIn("Production", body)
+        self.assertIn("Staging", body)
+
+    # ------------------------------------------------------------------ (b)
+    def test_list_does_not_leak_other_company(self):
+        """Company B's instance name must be absent from A's list page."""
+        self.authenticate("portal_overview_a", "portal_overview_a")
+        resp = self.url_open("/my/instances")
+        self.assertEqual(resp.status_code, 200)
+        self.assertNotIn("company-b-secret-prod", resp.text)
+
+    # ------------------------------------------------------------------ (c)
+    def test_detail_page_renders_owned_instance(self):
+        """Detail page shows phase/replicas/ingress/image + staging->prod link."""
+        self.authenticate("portal_overview_a", "portal_overview_a")
+        resp = self.url_open("/my/instances/%d" % self.inst_a_staging.id)
+        self.assertEqual(resp.status_code, 200)
+        body = resp.text
+        # Phase.
+        self.assertIn("Running", body)
+        # Replicas row is rendered (counts are 0/0 with no live cluster).
+        self.assertIn("Ready / Available replicas", body)
+        # Ingress URL as a link-out.
+        self.assertIn("https://a-staging.example.com", body)
+        # Image.
+        self.assertIn("registry.example.com/odoo:19.0-a-stg", body)
+        # Staging -> production source link (by name and by detail URL).
+        self.assertIn("company-a-prod", body)
+        self.assertIn("/my/instances/%d" % self.inst_a_prod.id, body)
+
+    # ------------------------------------------------------------------ (d)
+    def test_detail_page_non_owned_does_not_leak(self):
+        """Detail page for a foreign instance returns 404/redirect, no data."""
+        self.authenticate("portal_overview_a", "portal_overview_a")
+        resp = self.url_open(
+            "/my/instances/%d" % self.inst_b_prod.id, allow_redirects=False
+        )
+        # Either a redirect away (to /my) or a 404 -- never a 200 with the data.
+        self.assertIn(resp.status_code, (301, 302, 303, 404))
+        self.assertNotIn("company-b-secret-prod", resp.text)
+        self.assertNotIn("https://b-prod.example.com", resp.text)
+
+    # ------------------------------------------------------------------ (e)
+    def test_portal_home_shows_instances_card(self):
+        """/my shows the Odoo Instances card with the user's instance count."""
+        self.authenticate("portal_overview_a", "portal_overview_a")
+        resp = self.url_open("/my")
+        self.assertEqual(resp.status_code, 200)
+        body = resp.text
+        self.assertIn("Odoo Instances", body)
+        # The link to the instances list is present on the home card.
+        self.assertIn("/my/instances", body)

--- a/odoo_herd_portal/tests/test_portal_overview.py
+++ b/odoo_herd_portal/tests/test_portal_overview.py
@@ -23,6 +23,7 @@ record rule end-to-end (no manual partner filtering in the controller).
 
 import json
 
+from odoo.exceptions import AccessError
 from odoo.tests import HttpCase, tagged
 
 
@@ -120,6 +121,24 @@ class TestPortalOverview(HttpCase):
                 "allowed_partner_ids": [(6, 0, [cls.company_b.id])],
             }
         )
+        # Company A staging instance whose source production instance is owned
+        # by company B (a cross-owner reference). User A owns the staging
+        # instance and may open its detail page, but must NOT learn the foreign
+        # production source's name. Mirrors a real "operator cloned from another
+        # tenant" data shape; here it stresses the sudo-render bypass.
+        cls.inst_a_staging_foreign_src = Instance.create(
+            {
+                "name": "company-a-staging-xsrc",
+                "namespace": "company-a",
+                "cluster_id": cls.cluster.id,
+                "environment": "staging",
+                "image": "registry.example.com/odoo:19.0-a-xsrc",
+                "phase": "Running",
+                "status": _status("https://a-staging-xsrc.example.com"),
+                "production_instance_id": cls.inst_b_prod.id,
+                "allowed_partner_ids": [(6, 0, [cls.company_a.id])],
+            }
+        )
 
     # ------------------------------------------------------------------ (a)
     def test_instances_list_groups_production_and_staging(self):
@@ -172,6 +191,46 @@ class TestPortalOverview(HttpCase):
         self.assertIn(resp.status_code, (301, 302, 303, 404))
         self.assertNotIn("company-b-secret-prod", resp.text)
         self.assertNotIn("https://b-prod.example.com", resp.text)
+
+    # ------------------------------------------------------- (f) regression
+    def test_detail_does_not_leak_non_owned_production_source_name(self):
+        """Staging detail whose prod source is owned by another company must
+        render 200 without that foreign instance's name (no sudo bypass).
+
+        The detail record is re-browsed as the portal user, so the Feature A
+        record rule applies to the related ``production_instance_id`` too: its
+        name is only shown when the user can actually read it.
+        """
+        self.authenticate("portal_overview_a", "portal_overview_a")
+        resp = self.url_open(
+            "/my/instances/%d" % self.inst_a_staging_foreign_src.id
+        )
+        # The staging instance is owned by A, so the page renders (no 500,
+        # no AccessError surfaced by reading the foreign related record).
+        self.assertEqual(resp.status_code, 200)
+        body = resp.text
+        # The owned staging instance is shown ...
+        self.assertIn("company-a-staging-xsrc", body)
+        # ... but the foreign production source's name must be absent.
+        self.assertNotIn("company-b-secret-prod", body)
+
+    def test_detail_record_is_user_context_not_sudo(self):
+        """The record handed to the template is browsed in the portal user's
+        context (not SUPERUSER): reading a group-restricted field on it raises
+        AccessError, so the field-level secrecy + record rule are reinstated on
+        the detail page (rather than relying on the template's field choice)."""
+        self.authenticate("portal_overview_a", "portal_overview_a")
+        # Re-browse as the portal user the same way the controller now does.
+        rec = (
+            self.env["k8s.odoo.instance"]
+            .with_user(self.user_a)
+            .browse(self.inst_a_staging.id)
+        )
+        # Whitelisted field reads fine ...
+        self.assertEqual(rec.name, "company-a-staging")
+        # ... but a group-restricted field is denied (proves non-sudo context).
+        with self.assertRaises(AccessError):
+            rec.namespace  # noqa: B018
 
     # ------------------------------------------------------------------ (e)
     def test_portal_home_shows_instances_card(self):

--- a/odoo_herd_portal/tests/test_portal_overview.py
+++ b/odoo_herd_portal/tests/test_portal_overview.py
@@ -1,4 +1,4 @@
-# Part of Odoo Herd Portal. See LICENSE file for full copyright and licensing details.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 """Feature B -- instance overview acceptance tests.
 
 Acceptance criteria under test:

--- a/odoo_herd_portal/views/k8s_odoo_instance_views.xml
+++ b/odoo_herd_portal/views/k8s_odoo_instance_views.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!--
+        Backend admin UI for assigning portal access (Feature A).
+
+        The allowed_partner_ids field exists on k8s.odoo.instance but had no
+        backend view, so staff could not assign portal access by clicking.
+        This inherits the odoo_herd instance form and adds a "Portal Access"
+        notebook page exposing the field.
+
+        The whole page is gated to odoo_herd.group_k8s_user so only internal
+        k8s staff see it; WRITE is already restricted to group_k8s_manager by
+        the odoo_herd model record rules (rule_k8s_instance_manager), so no
+        extra permission wiring is needed here. Portal users never reach this
+        backend form.
+    -->
+    <record id="view_k8s_odoo_instance_form_portal" model="ir.ui.view">
+        <field name="name">k8s.odoo.instance.form.portal.access</field>
+        <field name="model">k8s.odoo.instance</field>
+        <field name="inherit_id" ref="odoo_herd.view_k8s_odoo_instance_form"/>
+        <field name="arch" type="xml">
+            <!--
+                Silence "Access Rights Inconsistency" view warnings.
+
+                Feature A redefines many infra fields with
+                groups="odoo_herd.group_k8s_user", so portal users (who hold
+                model-read ACL on k8s.odoo.instance) cannot read them. The base
+                form has elements whose invisible/domain expressions reference
+                those now-restricted fields; the validator therefore flags an
+                inconsistency for base.group_portal. These elements are k8s
+                internal and portal users never open this backend form, so we
+                gate each flagged element to group_k8s_user. Internal k8s users
+                still see the full form unchanged; only the spurious
+                cross-group inconsistency goes away.
+            -->
+            <!-- domain references cluster_id + namespace (group_k8s_user-only). -->
+            <xpath expr="//field[@name='production_instance_id']" position="attributes">
+                <attribute name="groups">odoo_herd.group_k8s_user</attribute>
+            </xpath>
+            <!-- invisible references deployment_strategy_type (group_k8s_user-only).
+                 Anchored via the child label's stable `for` attribute, because
+                 view inheritance may not select a group by its `string`. -->
+            <xpath expr="//label[@for='rolling_update_max_unavailable']/.." position="attributes">
+                <attribute name="groups">odoo_herd.group_k8s_user</attribute>
+            </xpath>
+
+            <xpath expr="//notebook" position="inside">
+                <page string="Portal Access" name="portal_access"
+                      groups="odoo_herd.group_k8s_user">
+                    <group>
+                        <field name="allowed_partner_ids"
+                               widget="many2many_tags"
+                               options="{'no_create_edit': True}"/>
+                    </group>
+                    <div class="text-muted small mt-1">
+                        <i class="fa fa-info-circle"/> Each portal user listed
+                        here can see this instance in the customer portal
+                        (<code>/my/instances</code>). Access is granted person
+                        by person: add the specific people who should have
+                        access -- a colleague at the same company does not get
+                        access unless added here too.
+                    </div>
+                </page>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/odoo_herd_portal/views/portal_templates.xml
+++ b/odoo_herd_portal/views/portal_templates.xml
@@ -113,6 +113,29 @@
                 </div>
             </div>
 
+            <!-- Lifecycle action error banners (set via ?error= on redirect). -->
+            <t t-set="lc_error" t-value="request.params.get('error')"/>
+            <t t-if="lc_error == 'upgrade'">
+                <div class="alert alert-danger" role="alert">
+                    The upgrade could not be started. Please contact support.
+                </div>
+            </t>
+            <t t-if="lc_error == 'refresh'">
+                <div class="alert alert-danger" role="alert">
+                    The staging refresh could not be started. Please contact support.
+                </div>
+            </t>
+            <t t-if="lc_error == 'not_staging'">
+                <div class="alert alert-warning" role="alert">
+                    Staging refresh is only available for staging instances.
+                </div>
+            </t>
+            <t t-if="lc_error == 'no_source'">
+                <div class="alert alert-warning" role="alert">
+                    This staging instance has no production source you can refresh from.
+                </div>
+            </t>
+
             <div class="o_portal_my_doc row">
                 <div class="col-12 col-lg-8">
                     <table class="table table-sm">
@@ -167,7 +190,39 @@
                 </div>
             </div>
 
-            <div class="row">
+            <!-- Self-serve lifecycle actions (Feature E). Each POST is
+                 CSRF-protected and gated by a confirm-intent dialog. -->
+            <div class="row mt-3">
+                <div class="col-12">
+                    <h5>Lifecycle actions</h5>
+                    <!-- Upgrade: standard upgrade, auto-backup first. Available
+                         on any owned instance. -->
+                    <form t-attf-action="/my/instances/#{instance.id}/upgrade"
+                          method="post" class="d-inline"
+                          onsubmit="return confirm('Upgrade this instance now? A backup will be taken automatically first, then all installed modules will be upgraded. This may cause downtime.');">
+                        <input type="hidden" name="csrf_token"
+                               t-att-value="request.csrf_token()"/>
+                        <button type="submit" class="btn btn-warning">
+                            <i class="fa fa-arrow-up"/> Upgrade (with auto-backup)
+                        </button>
+                    </form>
+                    <!-- Staging refresh: ONLY rendered for staging instances
+                         that have a production source the user may read. The
+                         control is never shown on production. -->
+                    <form t-if="instance.environment == 'staging' and prod_source_name"
+                          t-attf-action="/my/instances/#{instance.id}/refresh-staging"
+                          method="post" class="d-inline"
+                          onsubmit="return confirm('Refresh this staging instance from production? The current staging database and filestore will be REPLACED with a fresh copy from the production source.');">
+                        <input type="hidden" name="csrf_token"
+                               t-att-value="request.csrf_token()"/>
+                        <button type="submit" class="btn btn-danger">
+                            <i class="fa fa-refresh"/> Refresh staging from production
+                        </button>
+                    </form>
+                </div>
+            </div>
+
+            <div class="row mt-3">
                 <div class="col-12">
                     <a t-attf-href="/my/instances/#{instance.id}/backups"
                        class="btn btn-primary">

--- a/odoo_herd_portal/views/portal_templates.xml
+++ b/odoo_herd_portal/views/portal_templates.xml
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- =============================================================== -->
+    <!-- /my home: "Odoo Instances" card + count                          -->
+    <!-- =============================================================== -->
+    <template id="portal_my_home_instances"
+              name="Portal My Home: Odoo Instances"
+              inherit_id="portal.portal_my_home"
+              priority="40">
+        <xpath expr="//div[hasclass('o_portal_docs')]" position="inside">
+            <div class="o_portal_category row g-2 mt-3" id="portal_herd_category">
+                <t t-call="portal.portal_docs_entry">
+                    <t t-set="icon" t-value="'/portal/static/src/img/portal-connection.svg'"/>
+                    <t t-set="title">Odoo Instances</t>
+                    <t t-set="text">View the status of the Odoo instances your company owns</t>
+                    <t t-set="url" t-value="'/my/instances'"/>
+                    <t t-set="placeholder_count" t-value="'instance_count'"/>
+                </t>
+            </div>
+        </xpath>
+    </template>
+
+    <!-- =============================================================== -->
+    <!-- /my/instances: list grouped into Production and Staging          -->
+    <!-- =============================================================== -->
+    <template id="portal_my_instances" name="My Odoo Instances">
+        <t t-call="portal.portal_layout">
+            <t t-set="breadcrumbs_searchbar" t-value="True"/>
+
+            <t t-call="portal.portal_searchbar">
+                <t t-set="title">Odoo Instances</t>
+            </t>
+
+            <t t-if="not production_instances and not staging_instances">
+                <div class="alert alert-info mt-3" role="alert">
+                    Your company does not own any Odoo instances yet.
+                </div>
+            </t>
+
+            <!-- Production -->
+            <t t-if="production_instances">
+                <h4 class="mt-4 mb-2">Production</h4>
+                <t t-call="odoo_herd_portal.portal_instances_table">
+                    <t t-set="instances" t-value="production_instances"/>
+                </t>
+            </t>
+
+            <!-- Staging -->
+            <t t-if="staging_instances">
+                <h4 class="mt-4 mb-2">Staging</h4>
+                <t t-call="odoo_herd_portal.portal_instances_table">
+                    <t t-set="instances" t-value="staging_instances"/>
+                </t>
+            </t>
+        </t>
+    </template>
+
+    <!-- Reusable table rendering a recordset of instances (whitelisted -->
+    <!-- fields only). -->
+    <template id="portal_instances_table" name="Odoo Instances Table">
+        <div class="table-responsive">
+            <table class="table table-sm table-striped o_portal_my_doc_table">
+                <thead>
+                    <tr>
+                        <th>Instance</th>
+                        <th>Status</th>
+                        <th>Replicas</th>
+                        <th>URL</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr t-foreach="instances" t-as="instance">
+                        <td>
+                            <a t-attf-href="/my/instances/#{instance.id}">
+                                <span t-esc="instance.name"/>
+                            </a>
+                        </td>
+                        <td>
+                            <span t-esc="instance.phase or '-'"/>
+                        </td>
+                        <td>
+                            <span t-esc="instance.ready_replicas"/>
+                            /
+                            <span t-esc="instance.available_replicas"/>
+                        </td>
+                        <td>
+                            <a t-if="instance.ingress_url"
+                               t-att-href="instance.ingress_url"
+                               target="_blank" rel="noreferrer noopener">
+                                <span t-esc="instance.ingress_url"/>
+                            </a>
+                            <span t-else="">-</span>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </template>
+
+    <!-- =============================================================== -->
+    <!-- /my/instances/<id>: detail page                                  -->
+    <!-- =============================================================== -->
+    <template id="portal_instance_detail" name="Odoo Instance Detail">
+        <t t-call="portal.portal_layout">
+            <t t-set="breadcrumbs_searchbar" t-value="True"/>
+
+            <div class="row mt-3">
+                <div class="col-12">
+                    <h3 class="mb-3">
+                        <span t-esc="instance.name"/>
+                    </h3>
+                </div>
+            </div>
+
+            <div class="o_portal_my_doc row">
+                <div class="col-12 col-lg-8">
+                    <table class="table table-sm">
+                        <tbody>
+                            <tr>
+                                <th class="w-25">Environment</th>
+                                <td>
+                                    <span t-esc="dict(instance._fields['environment']._description_selection(instance.env)).get(instance.environment, instance.environment)"/>
+                                </td>
+                            </tr>
+                            <tr>
+                                <th>Status</th>
+                                <td><span t-esc="instance.phase or '-'"/></td>
+                            </tr>
+                            <tr>
+                                <th>Ready / Available replicas</th>
+                                <td>
+                                    <span t-esc="instance.ready_replicas"/>
+                                    /
+                                    <span t-esc="instance.available_replicas"/>
+                                </td>
+                            </tr>
+                            <tr>
+                                <th>URL</th>
+                                <td>
+                                    <a t-if="instance.ingress_url"
+                                       t-att-href="instance.ingress_url"
+                                       target="_blank" rel="noreferrer noopener">
+                                        <span t-esc="instance.ingress_url"/>
+                                    </a>
+                                    <span t-else="">-</span>
+                                </td>
+                            </tr>
+                            <tr>
+                                <th>Image</th>
+                                <td><span t-esc="instance.image or '-'"/></td>
+                            </tr>
+                            <tr t-if="instance.environment == 'staging' and instance.production_instance_id">
+                                <th>Source production instance</th>
+                                <td>
+                                    <a t-attf-href="/my/instances/#{instance.production_instance_id.id}">
+                                        <span t-esc="instance.production_instance_id.name"/>
+                                    </a>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+
+            <div class="row">
+                <div class="col-12">
+                    <a href="/my/instances" class="btn btn-link">
+                        <i class="fa fa-arrow-left"/> Back to instances
+                    </a>
+                </div>
+            </div>
+        </t>
+    </template>
+
+</odoo>

--- a/odoo_herd_portal/views/portal_templates.xml
+++ b/odoo_herd_portal/views/portal_templates.xml
@@ -150,11 +150,15 @@
                                 <th>Image</th>
                                 <td><span t-esc="instance.image or '-'"/></td>
                             </tr>
-                            <tr t-if="instance.environment == 'staging' and instance.production_instance_id">
+                            <!-- Only shown when the user may actually read the
+                                 source instance; prod_source_name is computed
+                                 in the controller as the portal user, so a
+                                 non-owned source's name never leaks. -->
+                            <tr t-if="instance.environment == 'staging' and prod_source_name">
                                 <th>Source production instance</th>
                                 <td>
                                     <a t-attf-href="/my/instances/#{instance.production_instance_id.id}">
-                                        <span t-esc="instance.production_instance_id.name"/>
+                                        <span t-esc="prod_source_name"/>
                                     </a>
                                 </td>
                             </tr>

--- a/odoo_herd_portal/views/portal_templates.xml
+++ b/odoo_herd_portal/views/portal_templates.xml
@@ -228,6 +228,10 @@
                        class="btn btn-primary">
                         <i class="fa fa-database"/> Backups
                     </a>
+                    <a t-attf-href="/my/instances/#{instance.id}/logs"
+                       class="btn btn-primary">
+                        <i class="fa fa-file-text-o"/> Live logs
+                    </a>
                     <a href="/my/instances" class="btn btn-link">
                         <i class="fa fa-arrow-left"/> Back to instances
                     </a>
@@ -345,6 +349,67 @@
             </div>
 
             <div class="row">
+                <div class="col-12">
+                    <a t-attf-href="/my/instances/#{instance.id}"
+                       class="btn btn-link">
+                        <i class="fa fa-arrow-left"/> Back to instance
+                    </a>
+                </div>
+            </div>
+        </t>
+    </template>
+
+    <!-- =============================================================== -->
+    <!-- /my/instances/<id>/logs: live log viewer (iframe + postMessage)  -->
+    <!-- =============================================================== -->
+    <template id="portal_instance_logs" name="Odoo Instance Live Logs">
+        <t t-call="portal.portal_layout">
+            <t t-set="breadcrumbs_searchbar" t-value="True"/>
+
+            <div class="row mt-3">
+                <div class="col-12">
+                    <h3 class="mb-3">
+                        Live logs &#8212; <span t-esc="instance.name"/>
+                    </h3>
+                </div>
+            </div>
+
+            <!-- "Recent logs only" notice; history search is v2 (Loki). -->
+            <div class="alert alert-info" role="alert">
+                <i class="fa fa-info-circle"/>
+                You are viewing <strong>recent logs only</strong>. Live and
+                recently-buffered log lines are shown; searching beyond the
+                node's log retention window is not yet available.
+            </div>
+
+            <t t-if="not log_viewer_url">
+                <div class="alert alert-warning" role="alert">
+                    The live log viewer is not configured. Please contact
+                    support.
+                </div>
+            </t>
+            <t t-else="">
+                <!-- The signed scope token is handed to the iframe via
+                     postMessage by the static JS asset; it lives in a data
+                     attribute, NEVER in the iframe src/query string, so it is
+                     not logged by proxies. The iframe src is the sidecar base
+                     URL with no token.
+
+                     NB: the attribute is named ``data-log-scope`` (not
+                     ``...token``): Odoo's website layer strips any HTML
+                     attribute whose NAME contains "token" as a CSRF/secret-leak
+                     guard, which would silently blank the value. -->
+                <div class="o_herd_log_viewer"
+                     t-attf-data-log-scope="#{log_token}"
+                     t-att-data-log-viewer-url="log_viewer_url">
+                    <iframe class="o_herd_log_iframe"
+                            t-att-src="log_viewer_url"
+                            title="Live logs"
+                            style="width: 100%; height: 70vh; border: 1px solid #dee2e6; border-radius: .25rem;"/>
+                </div>
+            </t>
+
+            <div class="row mt-3">
                 <div class="col-12">
                     <a t-attf-href="/my/instances/#{instance.id}"
                        class="btn btn-link">

--- a/odoo_herd_portal/views/portal_templates.xml
+++ b/odoo_herd_portal/views/portal_templates.xml
@@ -169,8 +169,131 @@
 
             <div class="row">
                 <div class="col-12">
+                    <a t-attf-href="/my/instances/#{instance.id}/backups"
+                       class="btn btn-primary">
+                        <i class="fa fa-database"/> Backups
+                    </a>
                     <a href="/my/instances" class="btn btn-link">
                         <i class="fa fa-arrow-left"/> Back to instances
+                    </a>
+                </div>
+            </div>
+        </t>
+    </template>
+
+    <!-- =============================================================== -->
+    <!-- /my/instances/<id>/backups: list + self-service actions          -->
+    <!-- =============================================================== -->
+    <template id="portal_instance_backups" name="Odoo Instance Backups">
+        <t t-call="portal.portal_layout">
+            <t t-set="breadcrumbs_searchbar" t-value="True"/>
+
+            <div class="row mt-3">
+                <div class="col-12">
+                    <h3 class="mb-3">
+                        Backups &#8212; <span t-esc="instance.name"/>
+                    </h3>
+                </div>
+            </div>
+
+            <!-- Error banners (set via ?error= on redirect). -->
+            <t t-set="error" t-value="request.params.get('error')"/>
+            <t t-if="error == 'prod_restore'">
+                <div class="alert alert-danger" role="alert">
+                    Restore is only available for staging instances.
+                </div>
+            </t>
+            <t t-if="error == 'restore'">
+                <div class="alert alert-danger" role="alert">
+                    The restore could not be started. Please contact support.
+                </div>
+            </t>
+            <t t-if="error == 'backup'">
+                <div class="alert alert-danger" role="alert">
+                    The backup could not be started. Please contact support.
+                </div>
+            </t>
+            <t t-if="error == 'download'">
+                <div class="alert alert-danger" role="alert">
+                    The download link could not be generated. Please try again.
+                </div>
+            </t>
+            <t t-if="error == 'not_ready'">
+                <div class="alert alert-warning" role="alert">
+                    That backup is not completed yet.
+                </div>
+            </t>
+
+            <!-- Backup now -->
+            <div class="row mb-3">
+                <div class="col-12">
+                    <form t-attf-action="/my/instances/#{instance.id}/backup"
+                          method="post" class="form-inline d-inline">
+                        <input type="hidden" name="csrf_token"
+                               t-att-value="request.csrf_token()"/>
+                        <input type="hidden" name="format" value="zip"/>
+                        <button type="submit" class="btn btn-primary">
+                            <i class="fa fa-plus"/> Backup now
+                        </button>
+                    </form>
+                </div>
+            </div>
+
+            <t t-if="not backups">
+                <div class="alert alert-info" role="alert">
+                    No backups for this instance yet.
+                </div>
+            </t>
+            <div t-if="backups" class="table-responsive">
+                <table class="table table-sm table-striped o_portal_my_doc_table">
+                    <thead>
+                        <tr>
+                            <th>Backup</th>
+                            <th>State</th>
+                            <th>Format</th>
+                            <th>Size</th>
+                            <th>Completed</th>
+                            <th/>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr t-foreach="backups" t-as="backup">
+                            <td><span t-esc="backup.name"/></td>
+                            <td><span t-esc="backup.state"/></td>
+                            <td><span t-esc="backup.format"/></td>
+                            <td><span t-esc="backup.size_bytes or 0"/></td>
+                            <td><span t-esc="backup.completion_time or '-'"/></td>
+                            <td>
+                                <a t-if="backup.state == 'completed'"
+                                   t-attf-href="/my/instances/backup/#{backup.id}/download"
+                                   class="btn btn-sm btn-secondary">
+                                    <i class="fa fa-download"/> Download
+                                </a>
+                                <!-- Restore is rendered ONLY for staging
+                                     targets; production restore is never
+                                     exposed in the portal. -->
+                                <form t-if="backup.state == 'completed' and instance.environment == 'staging'"
+                                      t-attf-action="/my/instances/backup/#{backup.id}/restore"
+                                      method="post" class="d-inline"
+                                      onsubmit="return confirm('Restore this backup onto the staging instance? The current staging database will be replaced.');">
+                                    <input type="hidden" name="csrf_token"
+                                           t-att-value="request.csrf_token()"/>
+                                    <button type="submit"
+                                            class="btn btn-sm btn-warning">
+                                        <i class="fa fa-undo"/> Restore
+                                    </button>
+                                </form>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+
+            <div class="row">
+                <div class="col-12">
+                    <a t-attf-href="/my/instances/#{instance.id}"
+                       class="btn btn-link">
+                        <i class="fa fa-arrow-left"/> Back to instance
                     </a>
                 </div>
             </div>


### PR DESCRIPTION
## `odoo_herd_portal` — client self-service portal (v1 epic)

Autonomous overnight build of the new `odoo_herd_portal` module: a client-facing portal layer over `odoo_herd` letting hosting customers observe and (within guardrails) act on the instances their company owns. Built feature-by-feature through a design→code(TDD)→test→**adversarial review** pipeline; each feature was review-gated and reworked where the reviewer found holes (see below).

**Epic:** Bemade Odoo Addons task **#3832**. Full spec: `odoo_herd_portal/docs/SPEC.md`.

### Features (all TDD, full suite green — 82 tests, 0 failed)
| | Feature | Tasks |
|---|---|---|
| **A** | Access & ownership — `allowed_partner_ids` (M2M) + portal record rule + read-only ACL + **deny-by-default field whitelist** (43 instance + 9 cluster fields gated) | #3833 |
| **B** | Instance overview — `/my/instances` grouped Production/Staging, detail page | #3834 |
| **C** | Live log viewer (Odoo side) — short-lived HMAC scope-token mint + iframe/`postMessage` handoff | #3835 |
| **D** | Backups self-service — list/download (S3 presign)/backup-now + **staging-only** restore | #3837 |
| **E** | Self-serve lifecycle — upgrade (auto-backup-first, safe-target) + staging-refresh + audit + initiator/follower notify | #3838 |

### Security model (this is a client-facing portal)
Per-instance isolation is enforced in-code: a `base.group_portal` record rule scopes records to the user's `commercial_partner_id`, and a **deny-by-default field whitelist** (`groups=`) hides every non-benign field. The recurring hazard — **sudo recordsets bypass both field `groups=` and record rules** — is handled by: rendering portal pages as the *portal user* (never sudo), and gating every privileged action with an ownership check *as the user* (`_filtered_access`) **before** any `sudo()`. Drift-guard tests assert any future un-gated field fails closed.

**Adversarial review caught and we fixed, before this PR:**
- **A:** original 3-field blocklist left `config_options` (raw `odoo.conf` incl. `admin_passwd`), `image_pull_secret`, and **`cluster_id.kubeconfig`** (cluster master credential, via related traversal) readable by any portal user → inverted to a whitelist + severed the cluster traversal two ways + drift-guard.
- **B:** detail page rendered a **sudo** record (bypassing secrecy) and leaked a non-owned `production_instance_id.name` → render as user + `_filtered_access` guard.
- **E:** completion notice was an internal `mt_note` (never reached the client) **and** permanently subscribed clients as followers (would email them every future internal comment) → status-only `mt_comment`, no standing subscription, then scoped to the initiator + followers (below).

### Resolved decisions / deploy notes
1. **Client notifications (Feature E) — decided & implemented (`68feaf3`):** terminal upgrade/refresh/backup notify **the initiator + the instance's existing followers** — *not* a blast to all `allowed_partner_ids`. Herd-/operator-driven ops with no portal initiator notify followers only. Nobody is auto-subscribed as a follower.
2. **Deploy step (not a decision):** set config params `odoo_herd_portal.log_viewer_url` (sidecar URL) and `odoo_herd_portal.log_token_secret` (auto-generated on first use; share it with the sidecar via a k8s Secret) before the log viewer functions end-to-end.
3. **Presigned download URLs:** kept at **1h** (accepted).
4. **Restore staging-guard:** controller-only is **accepted** as defense-in-depth — the record rule + ACL are the real boundary (a bad actor would need authenticated access, already exposed via RPC).

### Log-stream sidecar — design + scaffold ONLY (not shipped)
`docs/SIDECAR.md` (in this PR) has the full design + token-verification contract. A non-functional Go scaffold lives **locally** at `~/src/odoo-herd-log-sidecar/` (no repo created, not pushed): the **token verifier is real and unit-tested** (contract-exact); the kube pod-discovery/multiplex is stubbed (informer TODO); the react-logviewer SPA is design-only. **Fail-closed: unverified against the cluster — needs human review, a real repo, and cluster validation.** Task **#3836**.

### Testing / UAT
- `cd ~/src/bemade-site-herd-portal && odoo-dev test odoo_herd_portal` → 82 tests, 0 failed.
- Tests stub the k8s/S3 calls (no live cluster), matching `odoo_herd`'s own test approach.
- UAT not coverable headless: the log-viewer `postMessage` handoff to a live sidecar; the operator-webhook-driven terminal notifications; actual S3 presign download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
