### PR TITLE
[3474] sale_purchase_late_notification: configurable re-notification cadence

### DIFF
--- a/sale_purchase_late_notification/__manifest__.py
+++ b/sale_purchase_late_notification/__manifest__.py
@@ -1,11 +1,15 @@
 {
     "name": "Sale & Purchase Late Order Notifications",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.1.0",
     "category": "Sales/Purchases",
     "summary": "Get notifications for late sale and purchase orders",
     "description": """
         This module adds functionality to notify users about late sale and purchase orders.
-        It creates activities for orders that are more than 5 days late.
+        It creates activities (To-Dos) for orders that are past their configured late
+        threshold, and re-creates them on a configurable cadence: once a reminder is
+        marked Done, a new one is scheduled after a configurable cooldown if the order
+        is still late, so a persistently-late order keeps reminding the user instead of
+        firing only once.
     """,
     "author": "Bemade",
     "website": "https://www.bemade.org",

--- a/sale_purchase_late_notification/models/base_late_notification.py
+++ b/sale_purchase_late_notification/models/base_late_notification.py
@@ -18,6 +18,9 @@ class BaseLateNotificationMixin(models.AbstractModel):
     _late_activity_note = ""
     _late_activity_summary_default = "Vérifier commande en retard"
     _late_notification_days_default = 5
+    # Days to wait after a previous late-notification activity was marked Done
+    # before re-creating one while the order is still late.
+    _late_renotify_cooldown_days_default = 7
 
     late_notification_date = fields.Datetime(
         string="Late Notification Date",
@@ -84,6 +87,24 @@ class BaseLateNotificationMixin(models.AbstractModel):
             or self.env.user.id
         )
 
+    @api.model
+    def _get_renotify_cooldown_days(self):
+        """Number of days to wait after a prior late-notification activity was
+        marked Done before re-creating one while the order is still late.
+
+        Configurable per model via the
+        ``sale_purchase_late_notification.<prefix>_renotify_cooldown_days``
+        config parameter (exposed in the relevant app's settings). Falls back to
+        ``_late_renotify_cooldown_days_default``.
+        """
+        return int(
+            self._get_config_param(
+                "renotify_cooldown_days",
+                str(self._late_renotify_cooldown_days_default),
+            )
+            or self._late_renotify_cooldown_days_default
+        )
+
     @api.depends("partner_id.commercial_partner_id")
     def _compute_late_days_threshold(self):
         """Compute the number of days an order must be late before notification.
@@ -117,14 +138,18 @@ class BaseLateNotificationMixin(models.AbstractModel):
 
     @api.model
     def _get_late_orders_domain(self):
-        """Get the domain to find late orders that haven't been notified yet.
+        """Get the domain to find candidate late orders.
 
         Relies on the model's is_late field and its _search_is_late method to handle
         the actual late detection logic using stored/searchable fields.
+
+        NB: this no longer filters on ``late_notification_date = False``. Whether an
+        already-notified order is *re-notified* is decided per-order by
+        :meth:`_should_notify` (idempotent open-activity check + configurable
+        re-notification cooldown), which subsumes the old one-shot behaviour.
         """
         return [
             ("is_late", "=", True),
-            ("late_notification_date", "=", False),
         ]
 
     @api.model
@@ -145,9 +170,70 @@ class BaseLateNotificationMixin(models.AbstractModel):
         # Fallback: use domain search (less efficient)
         return self.search(self._get_late_orders_domain()).ids
 
+    def _get_open_late_activities(self):
+        """Return this order's currently-open late-notification activities.
+
+        ``activity_ids`` only exposes active (not-yet-done) activities, so a match
+        here means the user still has an open reminder for this order.
+        """
+        self.ensure_one()
+        activity_type = self._get_activity_type()
+        summary = self._get_late_activity_summary()
+        return cast("MailActivityMixin", self).activity_ids.filtered(
+            lambda act: act.activity_type_id == activity_type
+            and act.summary == summary
+        )
+
+    def _get_last_late_activity_done_date(self):
+        """Return when the most recent late-notification activity for this order
+        was marked Done, or ``False`` if none ever was.
+
+        When an activity is marked Done its record is unlinked (or archived), so we
+        cannot read it back directly. Instead we read the "activity done" message
+        that ``mail.activity._action_done`` posts on the record, identified by its
+        activity type and the ``mail.mt_activities`` subtype.
+        """
+        self.ensure_one()
+        activity_type = self._get_activity_type()
+        done_subtype = self.env.ref("mail.mt_activities", raise_if_not_found=False)
+        done_messages = cast("MailActivityMixin", self).message_ids.filtered(
+            lambda msg: msg.mail_activity_type_id == activity_type
+            and (not done_subtype or msg.subtype_id == done_subtype)
+        )
+        if not done_messages:
+            return False
+        return max(done_messages.mapped("date"))
+
+    def _should_notify(self):
+        """Decide whether to (re-)create a late activity for this order now.
+
+        - Skip if an open late activity already exists (idempotent — never stack).
+        - Notify if the order was never notified before.
+        - Otherwise re-notify only once the configured cooldown has elapsed since
+          the previous late activity was marked Done (subsumes the one-shot rule).
+        """
+        self.ensure_one()
+        if self._get_open_late_activities():
+            return False
+        if not self.late_notification_date:
+            return True
+        closed_on = self._get_last_late_activity_done_date()
+        if not closed_on:
+            # Previously notified but no done-message found (e.g. the activity is
+            # gone yet was not marked done via the standard flow). Fall back to the
+            # last notification timestamp so the cooldown still applies.
+            closed_on = self.late_notification_date
+        cooldown = timedelta(days=self._get_renotify_cooldown_days())
+        return fields.Datetime.now() - closed_on >= cooldown
+
     @api.model
     def create_late_activities(self):
-        """Create activities for late orders"""
+        """Create (or re-create) activities for late orders.
+
+        Re-creation respects a configurable cooldown after the previous activity
+        was marked Done, so a still-late order keeps reminding the user instead of
+        firing only once.
+        """
         late_orders = self._get_late_orders()
         if not late_orders:
             return
@@ -162,6 +248,8 @@ class BaseLateNotificationMixin(models.AbstractModel):
 
         for order in late_orders:
             if not order.is_past_threshold:
+                continue
+            if not order._should_notify():
                 continue
             cast("MailActivityMixin", order).activity_schedule(**activity_vals)
             order.late_notification_date = fields.Datetime.now()

--- a/sale_purchase_late_notification/models/res_config_settings.py
+++ b/sale_purchase_late_notification/models/res_config_settings.py
@@ -29,6 +29,13 @@ class ResConfigSettings(models.TransientModel):
         config_parameter="sale_purchase_late_notification.sale_default_user_id",
         help="Default user responsible for handling late sale orders",
     )
+    sale_late_renotify_cooldown_days = fields.Integer(
+        string="Re-notification Cooldown (Sales)",
+        default=7,
+        config_parameter="sale_purchase_late_notification.sale_renotify_cooldown_days",
+        help="Number of days to wait after a late sale order reminder is marked "
+        "Done before a new reminder is created while the order is still late",
+    )
 
     # Purchase order late notification settings
     purchase_late_notification_enabled = fields.Boolean(
@@ -54,4 +61,11 @@ class ResConfigSettings(models.TransientModel):
         string="Responsible User (Purchases)",
         config_parameter="sale_purchase_late_notification.purchase_default_user_id",
         help="Default user responsible for handling late purchase orders",
+    )
+    purchase_late_renotify_cooldown_days = fields.Integer(
+        string="Re-notification Cooldown (Purchases)",
+        default=7,
+        config_parameter="sale_purchase_late_notification.purchase_renotify_cooldown_days",
+        help="Number of days to wait after a late purchase order reminder is "
+        "marked Done before a new reminder is created while the order is still late",
     )

--- a/sale_purchase_late_notification/tests/__init__.py
+++ b/sale_purchase_late_notification/tests/__init__.py
@@ -1,1 +1,5 @@
-from . import test_late_notification, test_is_late_service_filter
+from . import (
+    test_late_notification,
+    test_is_late_service_filter,
+    test_renotify_cadence,
+)

--- a/sale_purchase_late_notification/tests/test_renotify_cadence.py
+++ b/sale_purchase_late_notification/tests/test_renotify_cadence.py
@@ -1,0 +1,245 @@
+"""Tests for the configurable re-notification cadence.
+
+Acceptance criteria covered:
+  1. A still-late order whose previous late-notification activity was marked Done
+     re-notifies once the configured cooldown has elapsed (the fix for the
+     one-shot bug).
+  2. Before the cooldown elapses, no new activity is created (cadence respected).
+  3. Idempotent: while a late activity is still open, the cron never stacks a
+     second one.
+  4. Both sale.order and purchase.order are covered (the mixin abstracts both).
+  5. The cooldown is a real, per-model configurable setting (config parameter).
+"""
+
+from datetime import timedelta
+
+from odoo import fields
+from odoo.tests import TransactionCase, tagged
+
+
+class _LateRenotifyCommon(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.product = cls.env["product.product"].create(
+            {"name": "Test Product", "type": "consu"}
+        )
+
+    def _mark_late_activity_done(self, order):
+        """Mark the order's open late-notification activity as Done.
+
+        Mirrors the user clicking "Done": the activity record is removed and an
+        "activity done" message is posted on the record (which is how the cron
+        later detects the closure timestamp).
+        """
+        activities = order._get_open_late_activities()
+        self.assertTrue(activities, "Expected an open late activity to mark Done")
+        activities.action_done()
+
+    def _backdate_closure(self, order, days):
+        """Move the most recent activity-done message back ``days`` days so the
+        cooldown logic sees the closure as having happened in the past."""
+        done_subtype = self.env.ref("mail.mt_activities")
+        activity_type = order._get_activity_type()
+        done_messages = order.message_ids.filtered(
+            lambda m: m.mail_activity_type_id == activity_type
+            and m.subtype_id == done_subtype
+        )
+        self.assertTrue(done_messages, "Expected an activity-done message")
+        done_messages.write({"date": fields.Datetime.now() - timedelta(days=days)})
+
+
+@tagged("post_install", "-at_install")
+class TestSaleRenotifyCadence(_LateRenotifyCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner = cls.env["res.partner"].create({"name": "Test Customer"})
+        cls.user = cls.env["res.users"].create(
+            {
+                "name": "Sale Renotify User",
+                "login": "test_renotify_sale_user",
+                "email": "renotify_sale@example.com",
+            }
+        )
+        ICP = cls.env["ir.config_parameter"].sudo()
+        ICP.set_param("sale_purchase_late_notification.sale_enabled", "True")
+        ICP.set_param("sale_purchase_late_notification.sale_late_days_threshold", "5")
+        ICP.set_param(
+            "sale_purchase_late_notification.sale_default_user_id", str(cls.user.id)
+        )
+        ICP.set_param(
+            "sale_purchase_late_notification.sale_renotify_cooldown_days", "7"
+        )
+
+    def _create_late_sale_order(self):
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "client_order_ref": "test",
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product.id,
+                            "product_uom_qty": 1,
+                            "price_unit": 100,
+                        },
+                    )
+                ],
+            }
+        )
+        order.with_context(skip_tax_warning=True).action_confirm()
+        order.order_line.expected_ship_date = fields.Date.today() - timedelta(days=6)
+        return order
+
+    def test_cooldown_is_configurable(self):
+        """The cooldown is read from the config parameter, not hard-coded."""
+        self.env["ir.config_parameter"].sudo().set_param(
+            "sale_purchase_late_notification.sale_renotify_cooldown_days", "13"
+        )
+        self.assertEqual(
+            self.env["sale.order"]._get_renotify_cooldown_days(),
+            13,
+            "Cooldown must come from the config parameter",
+        )
+
+    def test_renotifies_after_cooldown_post_done(self):
+        """Still-late order re-notifies once cooldown elapsed after prior Done."""
+        order = self._create_late_sale_order()
+
+        self.env["sale.order"]._cron_create_late_activities()
+        self.assertEqual(len(order.activity_ids), 1, "First activity should be created")
+
+        # User clears the reminder; order stays late.
+        self._mark_late_activity_done(order)
+        self.assertEqual(len(order.activity_ids), 0, "Activity cleared after Done")
+
+        # Closure happened 8 days ago > 7-day cooldown -> re-notify.
+        self._backdate_closure(order, days=8)
+        self.env["sale.order"]._cron_create_late_activities()
+        self.assertEqual(
+            len(order.activity_ids),
+            1,
+            "A renewed activity should be created after the cooldown",
+        )
+
+    def test_no_renotify_before_cooldown(self):
+        """No new activity while the cooldown since the prior Done has not elapsed."""
+        order = self._create_late_sale_order()
+        self.env["sale.order"]._cron_create_late_activities()
+        self._mark_late_activity_done(order)
+
+        # Closure only 2 days ago < 7-day cooldown -> no re-notify.
+        self._backdate_closure(order, days=2)
+        self.env["sale.order"]._cron_create_late_activities()
+        self.assertEqual(
+            len(order.activity_ids),
+            0,
+            "No renewed activity should be created before the cooldown elapses",
+        )
+
+    def test_idempotent_while_activity_open(self):
+        """Cron never stacks a second activity while one is still open."""
+        order = self._create_late_sale_order()
+        self.env["sale.order"]._cron_create_late_activities()
+        self.env["sale.order"]._cron_create_late_activities()
+        self.assertEqual(
+            len(order.activity_ids),
+            1,
+            "Only one open activity should exist while it is unresolved",
+        )
+
+
+@tagged("post_install", "-at_install")
+class TestPurchaseRenotifyCadence(_LateRenotifyCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner = cls.env["res.partner"].create({"name": "Test Vendor"})
+        cls.user = cls.env["res.users"].create(
+            {
+                "name": "Purchase Renotify User",
+                "login": "test_renotify_purchase_user",
+                "email": "renotify_purchase@example.com",
+            }
+        )
+        ICP = cls.env["ir.config_parameter"].sudo()
+        ICP.set_param("sale_purchase_late_notification.purchase_enabled", "True")
+        ICP.set_param(
+            "sale_purchase_late_notification.purchase_late_days_threshold", "5"
+        )
+        ICP.set_param(
+            "sale_purchase_late_notification.purchase_default_user_id", str(cls.user.id)
+        )
+        ICP.set_param(
+            "sale_purchase_late_notification.purchase_renotify_cooldown_days", "7"
+        )
+
+    def _create_late_purchase_order(self):
+        order = self.env["purchase.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product.id,
+                            "product_qty": 1,
+                            "price_unit": 100,
+                            "name": self.product.name,
+                            "date_planned": fields.Datetime.now()
+                            - timedelta(days=6),
+                        },
+                    )
+                ],
+            }
+        )
+        order.button_confirm()
+        return order
+
+    def test_renotifies_after_cooldown_post_done(self):
+        """Still-late PO re-notifies once cooldown elapsed after prior Done."""
+        order = self._create_late_purchase_order()
+
+        self.env["purchase.order"]._cron_create_late_activities()
+        self.assertEqual(len(order.activity_ids), 1, "First activity should be created")
+
+        self._mark_late_activity_done(order)
+        self.assertEqual(len(order.activity_ids), 0, "Activity cleared after Done")
+
+        self._backdate_closure(order, days=8)
+        self.env["purchase.order"]._cron_create_late_activities()
+        self.assertEqual(
+            len(order.activity_ids),
+            1,
+            "A renewed activity should be created after the cooldown",
+        )
+
+    def test_no_renotify_before_cooldown(self):
+        """No new PO activity while the cooldown since the prior Done has not elapsed."""
+        order = self._create_late_purchase_order()
+        self.env["purchase.order"]._cron_create_late_activities()
+        self._mark_late_activity_done(order)
+
+        self._backdate_closure(order, days=2)
+        self.env["purchase.order"]._cron_create_late_activities()
+        self.assertEqual(
+            len(order.activity_ids),
+            0,
+            "No renewed activity should be created before the cooldown elapses",
+        )
+
+    def test_idempotent_while_activity_open(self):
+        """Cron never stacks a second PO activity while one is still open."""
+        order = self._create_late_purchase_order()
+        self.env["purchase.order"]._cron_create_late_activities()
+        self.env["purchase.order"]._cron_create_late_activities()
+        self.assertEqual(
+            len(order.activity_ids),
+            1,
+            "Only one open activity should exist while it is unresolved",
+        )

--- a/sale_purchase_late_notification/views/res_config_settings_views.xml
+++ b/sale_purchase_late_notification/views/res_config_settings_views.xml
@@ -23,6 +23,10 @@
                                 <label for="sale_late_activity_user_id" class="col-3 o_light_label"/>
                                 <field name="sale_late_activity_user_id" class="col-3"/>
                             </div>
+                            <div class="row mt8">
+                                <label for="sale_late_renotify_cooldown_days" class="col-3 o_light_label"/>
+                                <field name="sale_late_renotify_cooldown_days" class="col-3"/>
+                            </div>
                         </div>
                     </setting>
                 </block>
@@ -52,6 +56,10 @@
                             <div class="row mt8">
                                 <label for="purchase_late_activity_user_id" class="col-3 o_light_label"/>
                                 <field name="purchase_late_activity_user_id" class="col-3"/>
+                            </div>
+                            <div class="row mt8">
+                                <label for="purchase_late_renotify_cooldown_days" class="col-3 o_light_label"/>
+                                <field name="purchase_late_renotify_cooldown_days" class="col-3"/>
                             </div>
                         </div>
                     </setting>


### PR DESCRIPTION
## Task 3474 (Pneumac, project 33) — upstream-first

The late SO/PO 'to-do' notification fired once and never re-fired after the user marked it Done, even when the order stayed late (Nicolas, S52600). Per Marc: the re-notification cadence must be **configurable**; the git module `sale_purchase_late_notification` is the source of truth and subsumes the instance ir.cron 131/132 + base.automation 7; the archived base.automation 11 was the SO side.

### Change
- Drop the one-shot `late_notification_date = False` filter from `_get_late_orders_domain` (the cause of fire-once).
- Per-order `_should_notify()`: skip if an open late activity exists (idempotent); notify if never notified; otherwise re-notify only once `now - <prior activity Done time> >= cooldown`. Done time read from the `mail.mt_activities` done-message (the `mail.activity` is unlinked on Done), with a sane fallback to `late_notification_date`.
- Configurable cadence: per-model `ir.config_parameter` `sale_purchase_late_notification.<sale|purchase>_renotify_cooldown_days` (default 7), surfaced in the Sales and Purchase settings. Covers **both** sale.order and purchase.order via the shared mixin.

### Tests
7 new tests (`tests/test_renotify_cadence.py`): re-notify after cooldown post-Done, no re-notify before cooldown, idempotent while open, cooldown configurable — for SO and PO. Green: `0 failed, 0 error(s) of 49 tests` (with `delivery_carrier_partner_account` co-installed, as the module's pre-existing SO tests require).

### Operational handoff (on deploy)
The module's own daily crons now own this behavior. On the Pneumac instance, retire ir.cron **131**/**132** and base.automation **7** (likely duplicate) so they don't double-fire; archived base.automation **11** (SO) stays archived — the module covers SO. These are instance config (not git).

Downstream: Pneumac client MR bumps `.repos/bemade-addons` after merge + enables/configures the module settings (responsible = Nicolas Drapeau, threshold, summary, cooldown).