### PR TITLE
[3155] crm_account_management: all-OU revenue-weighted avg GP% comparison figure

### DIFF
--- a/crm_account_management/models/organizational_unit.py
+++ b/crm_account_management/models/organizational_unit.py
@@ -231,6 +231,15 @@ class OrganizationalUnit(models.Model):
         string="Avg Gross Profit %",
         compute="_compute_gross_profit_metrics",
     )
+    all_ou_avg_gross_profit_percentage = fields.Float(
+        string="Avg GP % (all OUs)",
+        compute="_compute_all_ou_gross_profit_metrics",
+        help="Revenue-weighted average gross-profit margin across ALL "
+        "organizational units' YTD posted customer invoices "
+        "(sum(revenue - cost) / sum(revenue)). The same comparison figure "
+        "appears on every OU, to benchmark this account's own Avg Gross "
+        "Profit %.",
+    )
     won_quotations_prior_count = fields.Integer(
         string="Bookings Prior (Count)",
         compute="_compute_quotation_metrics",
@@ -288,16 +297,7 @@ class OrganizationalUnit(models.Model):
                 record.avg_gross_profit_percentage = 0.0
                 continue
 
-            start_ytd, end_ytd = record._get_ytd_dates()
-            invoices = self.env["account.move"].search(
-                [
-                    ("partner_id", "in", partners.ids),
-                    ("move_type", "=", "out_invoice"),
-                    ("state", "=", "posted"),
-                    ("invoice_date", ">=", start_ytd),
-                    ("invoice_date", "<=", end_ytd),
-                ]
-            )
+            invoices = record._get_ytd_gross_profit_invoices(partners)
 
             if not invoices:
                 record.avg_gross_profit_percentage = 0.0
@@ -305,36 +305,118 @@ class OrganizationalUnit(models.Model):
 
             invoice_margins = []
             for inv in invoices:
-                product_lines = inv.invoice_line_ids.filtered("product_id")
-                # Revenue (price_subtotal) is denominated in the invoice currency
-                # while cost (standard_price) is already in company currency.
-                # Convert the revenue to company currency at the invoice date
-                # before differencing so foreign-currency-billed invoices don't
-                # manufacture a fake margin equal to the FX rate.  ``_convert``
-                # short-circuits to identity when source and target currencies
-                # match (single-currency invoices are unaffected); cost is left
-                # as-is since it is company-currency already.
-                company = inv.company_id or self.env.company
-                company_currency = company.currency_id
-                conv_date = inv.invoice_date or inv.date or fields.Date.context_today(inv)
-                invoice_currency = inv.currency_id or company_currency
-                total_revenue = invoice_currency._convert(
-                    sum(product_lines.mapped("price_subtotal")),
-                    company_currency,
-                    company,
-                    conv_date,
-                )
+                total_revenue, total_cost = self._invoice_revenue_cost(inv)
                 if not total_revenue:
                     continue
-                total_cost = sum(
-                    line.quantity * (line.product_id.standard_price or 0.0)
-                    for line in product_lines
-                )
                 invoice_margins.append((total_revenue - total_cost) / total_revenue)
 
             record.avg_gross_profit_percentage = (
                 sum(invoice_margins) / len(invoice_margins) if invoice_margins else 0.0
             )
+
+    def _get_ytd_gross_profit_invoices(self, partners):
+        """Return the posted YTD customer invoices for ``partners``.
+
+        Shared search domain used by both the per-OU
+        ``avg_gross_profit_percentage`` compute and the all-OU comparison
+        figure, so the two metrics stay consistent.
+        """
+        self.ensure_one()
+        if not partners:
+            return self.env["account.move"]
+        start_ytd, end_ytd = self._get_ytd_dates()
+        return self.env["account.move"].search(
+            [
+                ("partner_id", "in", partners.ids),
+                ("move_type", "=", "out_invoice"),
+                ("state", "=", "posted"),
+                ("invoice_date", ">=", start_ytd),
+                ("invoice_date", "<=", end_ytd),
+            ]
+        )
+
+    def _invoice_revenue_cost(self, inv):
+        """Return ``(revenue, cost)`` for a single customer invoice, both in
+        company currency.
+
+        Revenue (``price_subtotal``) is denominated in the invoice currency
+        while cost (``standard_price``) is already in company currency.
+        Convert the revenue to company currency at the invoice date before
+        differencing so foreign-currency-billed invoices don't manufacture a
+        fake margin equal to the FX rate.  ``_convert`` short-circuits to
+        identity when source and target currencies match (single-currency
+        invoices are unaffected); cost is left as-is since it is
+        company-currency already.
+
+        This is the single source of the revenue/cost derivation reused by
+        both ``avg_gross_profit_percentage`` (per-OU, unweighted mean of
+        per-invoice margins) and ``all_ou_avg_gross_profit_percentage``
+        (revenue-weighted across all OUs).
+        """
+        product_lines = inv.invoice_line_ids.filtered("product_id")
+        company = inv.company_id or self.env.company
+        company_currency = company.currency_id
+        conv_date = inv.invoice_date or inv.date or fields.Date.context_today(inv)
+        invoice_currency = inv.currency_id or company_currency
+        total_revenue = invoice_currency._convert(
+            sum(product_lines.mapped("price_subtotal")),
+            company_currency,
+            company,
+            conv_date,
+        )
+        total_cost = sum(
+            line.quantity * (line.product_id.standard_price or 0.0)
+            for line in product_lines
+        )
+        return total_revenue, total_cost
+
+    @api.depends(
+        "owner_id",
+        "member_ids",
+        "child_ids",
+        "fiscal_year_start_date",
+        "owner_id.invoice_ids.state",
+        "owner_id.invoice_ids.amount_total",
+        "owner_id.invoice_ids.invoice_date",
+        "owner_id.invoice_ids.move_type",
+        "owner_id.invoice_ids.currency_id",
+    )
+    def _compute_all_ou_gross_profit_metrics(self):
+        """Revenue-weighted all-OU average gross-profit %.
+
+        A single rolled-up figure -- ``sum(revenue - cost) / sum(revenue)``
+        across every OU's YTD posted customer invoices -- so the SAME value
+        lands on every OU record.  Provides a benchmark to compare an
+        individual OU's ``avg_gross_profit_percentage`` against.  Reuses the
+        same invoice domain and per-invoice revenue/cost derivation as the
+        per-OU compute (``_get_ytd_gross_profit_invoices`` /
+        ``_invoice_revenue_cost``) so the two metrics stay consistent.
+        """
+        all_value = self._get_all_ou_avg_gross_profit_percentage()
+        for record in self:
+            record.all_ou_avg_gross_profit_percentage = all_value
+
+    @api.model
+    def _get_all_ou_avg_gross_profit_percentage(self):
+        """Compute the revenue-weighted GP% across ALL OUs' YTD invoices."""
+        total_revenue = 0.0
+        total_cost = 0.0
+        # Collect every OU's YTD invoices once (de-duplicated -- a partner that
+        # belongs to several OUs, e.g. via parent/child hierarchies, must not
+        # have its invoices counted twice in the rolled-up figure).
+        all_invoices = self.env["account.move"]
+        for ou in self.search([]):
+            partners = ou._get_all_partners()
+            if not partners:
+                continue
+            all_invoices |= ou._get_ytd_gross_profit_invoices(partners)
+        for inv in all_invoices:
+            revenue, cost = self._invoice_revenue_cost(inv)
+            total_revenue += revenue
+            total_cost += cost
+        if not total_revenue:
+            return 0.0
+        return (total_revenue - total_cost) / total_revenue
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/crm_account_management/tests/__init__.py
+++ b/crm_account_management/tests/__init__.py
@@ -13,4 +13,5 @@ from . import test_us20_top_products
 from . import test_us21_address_region
 from . import test_us2x_ytd_basis
 from . import test_us2y_gross_profit_fx
+from . import test_us2z_all_ou_gross_profit
 

--- a/crm_account_management/tests/test_us2z_all_ou_gross_profit.py
+++ b/crm_account_management/tests/test_us2z_all_ou_gross_profit.py
@@ -1,0 +1,155 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0).
+# Author: Bemade Inc. (Marc Durepos <marc@bemade.org>)
+"""
+US-2Z: All-OU revenue-weighted average gross-profit % comparison figure.
+
+Acceptance criteria
+-------------------
+1. ``all_ou_avg_gross_profit_percentage`` is the revenue-weighted average GP%
+   across ALL organizational units' YTD posted customer invoices:
+   ``sum(revenue - cost) / sum(revenue)``. It reuses the same invoice domain
+   and per-invoice revenue/cost derivation as the per-OU
+   ``avg_gross_profit_percentage`` compute, so the two metrics stay
+   consistent.
+2. The figure is a single rolled-up number: the SAME value on every OU record.
+3. It is revenue-weighted, not a plain mean of per-OU percentages -- so with
+   OUs of differing revenue it differs from the simple average of their
+   individual GP percentages.
+4. Divide-by-zero is guarded: with no qualifying revenue the field is 0.0.
+"""
+from datetime import date
+
+from odoo.tests import tagged
+
+from odoo.addons.crm_account_management.tests.common import OUTestCommon
+
+
+@tagged("post_install", "-at_install")
+class TestUS2ZAllOUGrossProfit(OUTestCommon):
+    """Revenue-weighted all-OU GP% comparison figure."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner_model = cls.env["res.partner"]
+        cls.ou_model = cls.env["organizational.unit"]
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _make_company(self, name):
+        """Create a company partner; its OU is auto-created by res.partner."""
+        partner = self.partner_model.create({"name": name, "is_company": True})
+        ou = self.ou_model.search([("owner_id", "=", partner.id)], limit=1)
+        self.assertTrue(ou, "Company partner should auto-create an OU.")
+        return partner, ou
+
+    def _make_product(self, standard_price):
+        return self.env["product.product"].create(
+            {
+                "name": "All-OU GP Product",
+                "list_price": standard_price * 2,
+                "standard_price": standard_price,  # company currency
+            }
+        )
+
+    def _make_posted_invoice(self, partner, product, qty, price_unit):
+        invoice = self.env["account.move"].create(
+            {
+                "partner_id": partner.id,
+                "move_type": "out_invoice",
+                "invoice_date": date.today(),
+                "invoice_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": product.id,
+                            "quantity": qty,
+                            "price_unit": price_unit,
+                            "tax_ids": False,
+                        },
+                    )
+                ],
+            }
+        )
+        invoice.action_post()
+        return invoice
+
+    # ------------------------------------------------------------------
+    # Test 1: revenue-weighted formula, identical across OUs, weighting matters
+    # ------------------------------------------------------------------
+
+    def test_all_ou_revenue_weighted_gp(self):
+        """
+        Two OUs with known YTD invoices (single currency).
+
+        OU A: 1 unit @ 100, cost 60  -> revenue 100, cost 60
+              per-OU GP% = (100 - 60) / 100 = 0.40
+        OU B: 3 units @ 100, cost 50 -> revenue 300, cost 150
+              per-OU GP% = (300 - 150) / 300 = 0.50
+
+        Revenue-weighted all-OU GP%:
+            sum(revenue - cost) / sum(revenue)
+          = ((100 - 60) + (300 - 150)) / (100 + 300)
+          = (40 + 150) / 400 = 190 / 400 = 0.475
+
+        A plain mean of the two per-OU percentages would be
+        (0.40 + 0.50) / 2 = 0.45 -- so 0.475 proves the figure is
+        revenue-weighted, not a simple average.
+        """
+        partner_a, ou_a = self._make_company("All-OU GP Partner A")
+        partner_b, ou_b = self._make_company("All-OU GP Partner B")
+
+        product_a = self._make_product(standard_price=60.0)
+        product_b = self._make_product(standard_price=50.0)
+
+        self._make_posted_invoice(partner_a, product_a, qty=1, price_unit=100.0)
+        self._make_posted_invoice(partner_b, product_b, qty=3, price_unit=100.0)
+
+        (ou_a | ou_b).invalidate_recordset()
+
+        # AC-1: per-OU metrics are the expected unweighted margins.
+        self.assertAlmostEqual(ou_a.avg_gross_profit_percentage, 0.40, places=4)
+        self.assertAlmostEqual(ou_b.avg_gross_profit_percentage, 0.50, places=4)
+
+        # AC-1 + AC-3: the all-OU figure is the revenue-weighted value 0.475,
+        # distinct from the simple mean 0.45.
+        self.assertAlmostEqual(
+            ou_a.all_ou_avg_gross_profit_percentage,
+            0.475,
+            places=4,
+            msg=(
+                "All-OU GP% must be revenue-weighted: "
+                "(40 + 150) / (100 + 300) = 0.475, not the plain mean 0.45."
+            ),
+        )
+        self.assertNotAlmostEqual(
+            ou_a.all_ou_avg_gross_profit_percentage,
+            0.45,
+            places=4,
+            msg="Revenue-weighted figure must differ from the plain mean.",
+        )
+
+        # AC-2: the SAME rolled-up value lands on every OU record.
+        self.assertAlmostEqual(
+            ou_a.all_ou_avg_gross_profit_percentage,
+            ou_b.all_ou_avg_gross_profit_percentage,
+            places=6,
+            msg="All-OU GP% must be identical across OU records.",
+        )
+
+    # ------------------------------------------------------------------
+    # Test 2: divide-by-zero guard
+    # ------------------------------------------------------------------
+
+    def test_all_ou_gp_zero_revenue_guarded(self):
+        """An OU with no qualifying YTD revenue yields 0.0, not an error."""
+        _partner, ou = self._make_company("All-OU GP Empty Partner")
+        ou.invalidate_recordset()
+        self.assertEqual(
+            ou.all_ou_avg_gross_profit_percentage,
+            0.0,
+            "With no qualifying revenue the all-OU GP% must be 0.0.",
+        )

--- a/crm_account_management/views/organizational_unit_views.xml
+++ b/crm_account_management/views/organizational_unit_views.xml
@@ -160,6 +160,7 @@
                             </div>
                             <field name="open_orders_to_invoice_amount" widget="monetary" string="Remaining to Invoice"/>
                             <field name="avg_gross_profit_percentage" widget="percentage" string="Avg Gross Profit %"/>
+                            <field name="all_ou_avg_gross_profit_percentage" widget="percentage" string="Avg GP % (all OUs)"/>
                             <field name="last_sale_order_date" string="Last Sales Order"/>
                         </group>
                         <group>


### PR DESCRIPTION
## Task #3155 — all-OU average profit % comparison figure

Adds a new computed field `all_ou_avg_gross_profit_percentage` on `organizational.unit`: the **revenue-weighted** average gross-profit margin across **all** OUs' YTD posted customer invoices — `sum(revenue − cost) / sum(revenue)` — so a user viewing one OU can benchmark its own Avg Gross Profit % against the all-OU average. Same rolled-up value on every OU record.

### Changes
- **Refactor (behavior-preserving):** extracted `_get_ytd_gross_profit_invoices(partners)` (shared YTD posted-out_invoice domain) and `_invoice_revenue_cost(inv)` (FX-converted revenue + standard-price cost) from the per-OU compute; the per-OU `avg_gross_profit_percentage` result is unchanged. The FX-correctness fix stays in #3748.
- **New compute** `_compute_all_ou_gross_profit_metrics`: aggregates revenue/cost across all OUs (invoice recordset union → a partner shared across parent/child OUs is counted once), revenue-weighted, divide-by-zero guarded.
- **Form view:** new field in the Dashboard group beside the per-OU figure, `widget="percentage"`, labelled "Avg GP % (all OUs)".
- **Tests:** `test_us2z_all_ou_gross_profit.py` — builds 2 OUs (rev-weighted 0.475 ≠ plain-mean 0.45), asserts identity across records + a zero-revenue→0.0 guard.

Full crm_account_management suite green (117 tests, 0 failed/error).

### Decision trail
Per Marc (2026-06-18): revenue-weighted aggregate, shown on the individual OU form as a comparison figure (not a list column, not a separate tile).

Downstream: Pneumac `.repos/bemade-addons` submodule bump follows on merge (will be consolidated with the open CRM bump if still pending).