### PR TITLE
[MIG] bemade_sale_price_rounding: sync to DurPro v19.0.2.0.0 (adds cost rounding)

### DIFF
--- a/bemade_sale_price_rounding/.gitignore
+++ b/bemade_sale_price_rounding/.gitignore
@@ -1,0 +1,2 @@
+bemade_sale_price_rounding
+__pycache__

--- a/bemade_sale_price_rounding/README.rst
+++ b/bemade_sale_price_rounding/README.rst
@@ -1,0 +1,80 @@
+==========================
+Bemade Sale Price Rounding
+==========================
+
+Rounds the unit price and cost (``purchase_price``) on sale order lines to the
+``Product Price`` decimal precision after pricelist computation, preventing
+extra trailing decimals from appearing on customer-facing and internal documents.
+
+Features
+--------
+
+**Unit price rounding (Bug 1 — since 18.0.1.0.0)**
+
+Since Odoo 18, price fields use a minimum display precision rather than a
+hard precision, meaning pricelist percentage/formula rules can produce unit
+prices with 4–6 decimal places.  This causes customer-facing documents to
+show inconsistent math (e.g. ``288.48 × 3 = 865.44`` displayed, but
+``price_subtotal`` computed from the raw ``288.480769``).  This module
+rounds ``price_unit`` (and ``technical_price_unit``) in the ORM cache
+*before* ``_compute_amount`` runs, ensuring the subtotal always equals the
+displayed unit price times the quantity.
+
+**Cost column rounding (Bug 2 — since 18.0.2.0.0)**
+
+``sale.order.line.purchase_price`` (declared by ``sale_margin`` with
+``min_display_digits``, which is display-only) stores the raw unrounded
+float in the database.  On confirmed SOs a downstream recompute from
+``sale_stock_margin`` happens to round the value via an average-cost
+calculation, so confirmed documents look fine.  On draft/sent quotes the
+stored value leaks 3–14 trailing decimals into PDF templates (e.g.
+``228.09285714285714`` from a UoM conversion of ``4789.95 / 21``).
+
+This module re-declares ``purchase_price`` with ``digits="Product Price"``
+and rounds the value in cache at compute time (``_compute_purchase_price``)
+and at direct write/create time, fixing the PDF cost column for all states
+without touching individual report templates.
+
+Configuration
+-------------
+
+No configuration required.  Install alongside ``sale_margin`` (required
+dependency).  Decimal precision is read from the ``Product Price`` precision
+setting (``Settings → Technical → Database Structure → Decimal Accuracy``).
+
+Usage
+-----
+
+- Install the module.
+- Create sale orders as usual.  ``price_unit`` and ``purchase_price`` on
+  every line will be rounded to ``Product Price`` precision at compute time,
+  on direct write, and on create.
+- No data migration for historical records is performed; only new writes
+  are rounded ("fix forward").
+
+Changelog
+---------
+
+18.0.2.0.0 (2026-05-11)
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+- **Bug 2 fix**: round ``purchase_price`` at compute/write/create time to
+  ``Product Price`` precision, eliminating trailing decimals in the PDF cost
+  column on quotes.
+- Add ``sale_margin`` as a hard dependency.
+- Add regression tests: ``test_price_subtotal_consistency.py`` (Bug 1) and
+  ``test_purchase_price_rounding.py`` (Bug 2).
+
+18.0.1.0.0 (2026-04-01)
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+- **Bug 1 fix**: round ``price_unit`` and ``technical_price_unit`` in cache
+  before ``_compute_amount`` runs, ensuring ``price_subtotal`` equals the
+  displayed (rounded) unit price times the quantity.
+
+Credits
+-------
+
+- **Author**: Bemade Inc., Marc Durepos <marc@bemade.org>
+- **Website**: https://www.bemade.org
+- **License**: LGPL-3

--- a/bemade_sale_price_rounding/__manifest__.py
+++ b/bemade_sale_price_rounding/__manifest__.py
@@ -1,22 +1,42 @@
 # -*- coding: utf-8 -*-
 {
     "name": "Bemade Sale Price Rounding",
-    "version": "19.0.1.0.0",
+    "version": "19.0.2.0.0",
     "category": "Sales",
-    "summary": "Round sale order line unit prices to currency precision after pricelist computation",
+    "summary": (
+        "Round sale order line unit prices and cost to Product Price precision "
+        "after pricelist computation"
+    ),
     "description": """
-Rounds the unit price on sale order lines to the active currency's precision
-after pricelist computation.
+Rounds the unit price and cost (purchase price) on sale order lines to the
+``Product Price`` decimal precision after pricelist computation, preventing
+extra trailing decimals from appearing on customer-facing and internal documents.
 
-Since Odoo 18 (January 2026), price fields use a minimum display precision
-rather than a hard precision, meaning pricelist percentage/formula rules can
-produce unit prices with 4–6 decimal places. This causes customer-facing
-documents to show inconsistent math (e.g. 1.11 × 3 = 3.34 instead of 3.33).
-This module restores rounding to the currency precision at computation time.
+**Bug 1 — Unit price total inconsistency (fixed since 18.0.1.0.0)**
+
+Since Odoo 18, price fields use a minimum display precision rather than a
+hard precision, meaning pricelist percentage/formula rules can produce unit
+prices with 4–6 decimal places.  This causes customer-facing documents to
+show inconsistent math (e.g. ``288.48 × 3 = 865.44`` displayed, but
+``price_subtotal`` computed from the raw ``288.480769``).  This module
+rounds ``price_unit`` (and ``technical_price_unit``) in the ORM cache
+*before* ``_compute_amount`` runs.
+
+**Bug 2 — PDF cost column shows extra decimals on quotes (fixed since 18.0.2.0.0)**
+
+``sale.order.line.purchase_price`` (declared by ``sale_margin`` with
+``min_display_digits``, which is display-only) stores the raw unrounded
+float in the database.  On confirmed SOs a downstream recompute from
+``sale_stock_margin`` happens to round the value via an average-cost
+calculation, so confirmed documents look fine.  On draft/sent quotes the
+stored value leaks 3–14 trailing decimals into PDF templates.  This module
+re-declares the field with ``digits="Product Price"`` and rounds the value
+in cache at compute time (``_compute_purchase_price``) and at direct
+write/create time.
     """,
-    "author": "Bemade Inc.",
+    "author": "Bemade Inc., Marc Durepos <marc@bemade.org>",
     "website": "https://www.bemade.org",
-    "depends": ["sale"],
+    "depends": ["sale", "sale_margin"],
     "auto_install": False,
     "installable": True,
     "license": "LGPL-3",

--- a/bemade_sale_price_rounding/models/sale_order_line.py
+++ b/bemade_sale_price_rounding/models/sale_order_line.py
@@ -1,12 +1,93 @@
 # -*- coding: utf-8 -*-
-from odoo import models
+from odoo import api, models, fields
+from odoo.tools import float_round
 
 
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
+    price_unit = fields.Float(digits="Product Price")
+    purchase_price = fields.Float(digits="Product Price")
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _round_to_price_precision(self, value, currency=None):
+        """Round *value* to the order currency's precision, or to the
+        ``Product Price`` decimal precision when no currency is available.
+
+        :param float value: the value to round.
+        :param res.currency currency: optional currency record.
+        :return float: rounded value.
+        """
+        if currency:
+            return currency.round(value)
+        dp = self.env["decimal.precision"].precision_get("Product Price")
+        return float_round(value, precision_digits=dp)
+
+    # ------------------------------------------------------------------
+    # Bug 1 — round price_unit in cache before _compute_amount runs
+    # ------------------------------------------------------------------
+
     def _reset_price_unit(self):
+        """Override: after super sets price_unit from pricelist computation,
+        round price_unit and technical_price_unit in cache so that
+        _compute_amount reads the rounded value.
+        """
         super()._reset_price_unit()
-        currency = self.currency_id or self.company_id.currency_id
-        self.price_unit = currency.round(self.price_unit)
-        self.technical_price_unit = self.price_unit
+        currency = (
+            self.currency_id
+            or self.order_id.currency_id
+            or self.company_id.currency_id
+            or self.env.company.currency_id
+        )
+        rounded = self._round_to_price_precision(self.price_unit, currency)
+        if rounded != self.price_unit:
+            self.update({
+                "price_unit": rounded,
+                "technical_price_unit": rounded,
+            })
+
+    # ------------------------------------------------------------------
+    # Bug 2 — round purchase_price in cache after every compute
+    # ------------------------------------------------------------------
+
+    def _compute_purchase_price(self):
+        """Override: after the full super() chain writes purchase_price,
+        round the in-cache value to Product Price precision so that PDF
+        templates and downstream consumers never see raw unrounded floats.
+        """
+        super()._compute_purchase_price()
+        for line in self:
+            if not line.purchase_price:
+                continue
+            currency = (
+                line.currency_id
+                or line.order_id.currency_id
+                or line.company_id.currency_id
+                or line.env.company.currency_id
+            )
+            rounded = line._round_to_price_precision(line.purchase_price, currency)
+            if rounded != line.purchase_price:
+                line.purchase_price = rounded
+
+    # ------------------------------------------------------------------
+    # Round at direct write / create (covers imports, API writes, etc.)
+    # ------------------------------------------------------------------
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        dp = self.env["decimal.precision"].precision_get("Product Price")
+        for vals in vals_list:
+            for fname in ("price_unit", "technical_price_unit", "purchase_price"):
+                if fname in vals and vals[fname] is not None:
+                    vals[fname] = float_round(vals[fname], precision_digits=dp)
+        return super().create(vals_list)
+
+    def write(self, vals):
+        dp = self.env["decimal.precision"].precision_get("Product Price")
+        for fname in ("price_unit", "technical_price_unit", "purchase_price"):
+            if fname in vals and vals[fname] is not None:
+                vals[fname] = float_round(vals[fname], precision_digits=dp)
+        return super().write(vals)

--- a/bemade_sale_price_rounding/tests/__init__.py
+++ b/bemade_sale_price_rounding/tests/__init__.py
@@ -1,2 +1,4 @@
 # -*- coding: utf-8 -*-
 from . import test_sale_price_rounding
+from . import test_price_subtotal_consistency
+from . import test_purchase_price_rounding

--- a/bemade_sale_price_rounding/tests/test_price_subtotal_consistency.py
+++ b/bemade_sale_price_rounding/tests/test_price_subtotal_consistency.py
@@ -1,0 +1,210 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for Bug 1 — price_subtotal uses unrounded price_unit.
+
+Acceptance criteria:
+
+A1. Given a sale.order.line whose pricelist computation produces an unrounded
+    raw price_unit (e.g. 288.480769), after the line is saved the persisted
+    price_unit is rounded to Product Price decimal precision AND price_subtotal
+    equals round(price_unit, dp) * product_uom_qty (modulo tax adjustments).
+    Tolerance: abs(price_subtotal - round(price_unit, 2) * qty) < 0.01.
+
+A2. A1 holds in state draft (fresh quote), and after action_confirm() (sale).
+    Re-triggering pricelist recomputation must not reintroduce the unrounded
+    value into price_subtotal.
+
+A3. The PDF quotation/order report sees price_unit × qty == price_subtotal
+    consistently — no penny drift on any single line.
+
+A4. Regression test: create a SO with a pricelist that produces a
+    non-terminating decimal price_unit. Assert A1 in both draft and after
+    action_confirm().
+"""
+from odoo.fields import Command
+from odoo.tests import Form, tagged
+from odoo.tools import float_compare
+
+from odoo.addons.sale.tests.common import SaleCommon
+
+
+@tagged("post_install", "-at_install")
+class TestPriceSubtotalConsistency(SaleCommon):
+    """Regression tests for Bug 1: price_subtotal must be computed from the
+    rounded price_unit, not the raw float returned by pricelist computation."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._enable_pricelists()
+
+        # Product whose standard_price produces non-terminating decimal when
+        # a formula pricelist is applied. We use 375.024 as the "supplier cost"
+        # and a 23.07% discount to get 375.024 * (1 - 0.2307) = 288.480769...
+        #
+        # Actually we model it with price_discount = 23.07 on a formula rule
+        # (base = lst_price), so:
+        #   raw = lst_price * (1 - 23.07/100) = 375.024 * 0.7693 = 288.480...
+        #
+        # Set lst_price to 375.024 to reproduce the irrational value.
+        cls.product.lst_price = 375.024
+        cls.product.standard_price = 375.024
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _make_supplierinfo_pricelist(self, name="Supplierinfo Pricelist"):
+        """Create a percentage-discount pricelist that yields a non-terminating
+        decimal from our product's lst_price (375.024 * (1 - 0.2307) ≈ 288.48).
+        """
+        pricelist = self.env["product.pricelist"].create({
+            "name": name,
+            "currency_id": self.env.company.currency_id.id,
+            "item_ids": [Command.create({
+                "compute_price": "percentage",
+                "percent_price": 23.07,
+                "applied_on": "3_global",
+            })],
+        })
+        return pricelist
+
+    def _make_so_with_pricelist(self, pricelist):
+        """Create a sale order using Form (pricelist set before product line)."""
+        with Form(self.env["sale.order"]) as order_form:
+            order_form.partner_id = self.partner
+            order_form.pricelist_id = pricelist
+            with order_form.order_line.new() as line_form:
+                line_form.product_id = self.product
+        return order_form.record
+
+    def _assert_subtotal_consistent(self, line):
+        """Assert price_subtotal == rounded_price_unit * qty within 1 cent."""
+        currency = line.currency_id or self.env.company.currency_id
+        dp = self.env["decimal.precision"].precision_get("Product Price")
+        rounded_unit = currency.round(line.price_unit)
+        expected_subtotal = rounded_unit * line.product_uom_qty
+        diff = abs(line.price_subtotal - expected_subtotal)
+        self.assertLess(
+            diff,
+            10 ** -dp,
+            f"price_subtotal {line.price_subtotal!r} != "
+            f"round(price_unit={line.price_unit!r}, {dp}) * "
+            f"qty={line.product_uom_qty!r} = {expected_subtotal!r} "
+            f"(diff={diff!r})",
+        )
+
+    def _assert_price_unit_rounded(self, line):
+        """Assert price_unit itself is already rounded to currency precision."""
+        currency = line.currency_id or self.env.company.currency_id
+        rounded = currency.round(line.price_unit)
+        self.assertEqual(
+            line.price_unit,
+            rounded,
+            f"price_unit {line.price_unit!r} is not rounded; expected {rounded!r}",
+        )
+
+    # ------------------------------------------------------------------
+    # A1 / A4 — draft state
+    # ------------------------------------------------------------------
+
+    def test_price_subtotal_equals_rounded_unit_times_qty_draft(self):
+        """A1/A4 (draft): price_subtotal uses the rounded price_unit, not the
+        raw float from the pricelist percentage rule.
+
+        375.024 * (1 - 0.2307) = 288.480...  — non-terminating.
+        After rounding: price_unit = 288.48 (2 dp).
+        price_subtotal must equal 288.48 * qty.
+        """
+        pricelist = self._make_supplierinfo_pricelist()
+        order = self._make_so_with_pricelist(pricelist)
+        line = order.order_line[:1]
+
+        # Verify the raw computation would be non-round
+        raw = 375.024 * (1 - 23.07 / 100)
+        dp = self.env["decimal.precision"].precision_get("Product Price")
+        self.assertNotEqual(
+            raw,
+            round(raw, dp),
+            "Test setup error: choose values that produce irrational decimals",
+        )
+
+        self._assert_price_unit_rounded(line)
+        self._assert_subtotal_consistent(line)
+
+    # ------------------------------------------------------------------
+    # A2 — sale state (after action_confirm)
+    # ------------------------------------------------------------------
+
+    def test_price_subtotal_consistent_after_action_confirm(self):
+        """A2/A4 (sale state): price_subtotal is still consistent with the
+        rounded price_unit after the SO is confirmed.
+        """
+        pricelist = self._make_supplierinfo_pricelist()
+        order = self._make_so_with_pricelist(pricelist)
+        line = order.order_line[:1]
+
+        order.action_confirm()
+        line.invalidate_recordset()
+
+        self._assert_price_unit_rounded(line)
+        self._assert_subtotal_consistent(line)
+
+    # ------------------------------------------------------------------
+    # A2 — qty change recomputes cleanly
+    # ------------------------------------------------------------------
+
+    def test_price_subtotal_after_qty_change_recomputes_cleanly(self):
+        """A2: changing product_uom_qty recomputes price_subtotal from the
+        rounded price_unit, not the raw float.
+        """
+        pricelist = self._make_supplierinfo_pricelist()
+        order = self._make_so_with_pricelist(pricelist)
+        line = order.order_line[:1]
+
+        # Verify initial state
+        self._assert_price_unit_rounded(line)
+        self._assert_subtotal_consistent(line)
+
+        # Change qty and re-assert
+        with Form(order) as order_form:
+            with order_form.order_line.edit(0) as line_form:
+                line_form.product_uom_qty = 3.0
+        line = order.order_line[:1]
+
+        self._assert_price_unit_rounded(line)
+        self._assert_subtotal_consistent(line)
+
+    # ------------------------------------------------------------------
+    # A2 — pricelist change recomputes cleanly
+    # ------------------------------------------------------------------
+
+    def test_price_subtotal_after_pricelist_change(self):
+        """A2: swapping the pricelist triggers a fresh _reset_price_unit, and
+        the resulting price_subtotal is still consistent with the rounded
+        price_unit.
+        """
+        pricelist1 = self._make_supplierinfo_pricelist("Pricelist 23.07%")
+        pricelist2 = self.env["product.pricelist"].create({
+            "name": "Pricelist 10.03%",
+            "currency_id": self.env.company.currency_id.id,
+            "item_ids": [Command.create({
+                "compute_price": "percentage",
+                "percent_price": 10.03,
+                "applied_on": "3_global",
+            })],
+        })
+
+        order = self._make_so_with_pricelist(pricelist1)
+        line = order.order_line[:1]
+
+        self._assert_price_unit_rounded(line)
+        self._assert_subtotal_consistent(line)
+
+        # Swap pricelist
+        with Form(order) as order_form:
+            order_form.pricelist_id = pricelist2
+        line = order.order_line[:1]
+
+        self._assert_price_unit_rounded(line)
+        self._assert_subtotal_consistent(line)

--- a/bemade_sale_price_rounding/tests/test_purchase_price_rounding.py
+++ b/bemade_sale_price_rounding/tests/test_purchase_price_rounding.py
@@ -1,0 +1,203 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for Bug 2 — purchase_price (cost) stored unrounded on quotes.
+
+Acceptance criteria:
+
+B1. On a quote (state in ('draft', 'sent')), sale.order.line.purchase_price
+    has at most Product Price decimal precision digits (2 on Durpro). No
+    trailing 3rd/4th/.../14th decimal, regardless of UoM conversion arithmetic.
+
+B2. The fix produces identical results whether the SO is in draft, sent,
+    sale, or done. After the fix, draft SOs match confirmed ones.
+
+B3. The fix is applied by rounding the stored value on write/compute (option
+    B3(a)): no migration of historical data required, but new writes must round.
+
+B4. Regression test: reproduce SO28003 / SO28203 conditions — a product with
+    standard_price = 4789.95 in a "Box of 21" UoM sold in "Each", yielding
+    4789.95 / 21 = 228.09285714..., create a quote, assert purchase_price is
+    rounded (≤ 2 decimals). Re-assert after action_confirm().
+"""
+import unittest
+
+from odoo.fields import Command
+from odoo.tests import Form, tagged
+from odoo.tools import float_compare
+
+from odoo.addons.sale.tests.common import SaleCommon
+
+
+@tagged("post_install", "-at_install")
+class TestPurchasePriceRounding(SaleCommon):
+    """Regression tests for Bug 2: purchase_price must be rounded to Product
+    Price precision on quotes, not just after confirmation."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # Skip entire class if sale_margin is not installed (defense-in-depth;
+        # the module hard-depends on it, but guard tests too).
+        if "sale.order.line" not in cls.env or not hasattr(
+            cls.env["sale.order.line"], "purchase_price"
+        ):
+            raise unittest.SkipTest("sale_margin not installed — skipping")
+
+        # Product that reproduces SO28003: standard_price per Box-of-21,
+        # sold per Each → 4789.95 / 21 = 228.09285714285714...
+        #
+        # We use a simpler approach: set standard_price on the product directly
+        # to a value that is not representable at 2 dp when multiplied through
+        # the UoM factor.  We create a UoM "Box21" with ratio 21.0 so that
+        # _compute_purchase_price calls uom._compute_price(standard_price, sol_uom)
+        # → standard_price / 21.
+        # The Unit field on SO lines is gated by uom.group_uom in the form view
+        cls.env.user.group_ids |= cls.env.ref("uom.group_uom")
+        cls._setup_uom_product()
+
+    @classmethod
+    def _setup_uom_product(cls):
+        """Create a Box-of-21 UoM and a product priced per box."""
+        uom_unit = cls.env.ref("uom.product_uom_unit")
+
+        cls.uom_box21 = cls.env["uom.uom"].create({
+            "name": "Box of 21",
+            "relative_uom_id": uom_unit.id,
+            "relative_factor": 21.0,
+        })
+
+        # Cost is per box (product UoM); selling per Each forces the /21
+        # conversion in _compute_purchase_price.
+        cls.product_box = cls.env["product.product"].create({
+            "name": "Test Box Product",
+            "type": "consu",
+            "uom_id": cls.uom_box21.id,
+            "uom_ids": [Command.link(uom_unit.id)],
+            "standard_price": 4789.95,
+            "lst_price": 9999.00,
+        })
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _make_so_with_product(self, product, uom=None):
+        """Create a draft SO with the given product (and optional UoM)."""
+        with Form(self.env["sale.order"]) as order_form:
+            order_form.partner_id = self.partner
+            with order_form.order_line.new() as line_form:
+                line_form.product_id = product
+                if uom:
+                    line_form.product_uom_id = uom
+        return order_form.record
+
+    def _assert_purchase_price_rounded(self, line):
+        """Assert purchase_price has no extra decimals beyond Product Price DP."""
+        dp = self.env["decimal.precision"].precision_get("Product Price")
+        rounded = round(line.purchase_price, dp)
+        cmp = float_compare(
+            line.purchase_price,
+            rounded,
+            precision_digits=dp + 4,
+        )
+        self.assertEqual(
+            cmp,
+            0,
+            f"purchase_price {line.purchase_price!r} has extra decimals "
+            f"beyond dp={dp}; expected {rounded!r}",
+        )
+
+    # ------------------------------------------------------------------
+    # B1 / B4 — draft state, UoM conversion path
+    # ------------------------------------------------------------------
+
+    def test_purchase_price_rounded_on_quote_via_uom_conversion(self):
+        """B1/B4 (draft): purchase_price from UoM conversion is rounded.
+
+        standard_price = 4789.95 (per box of 21); sold per Each.
+        _compute_purchase_price: uom_box21._compute_price(4789.95, uom_unit)
+          = 4789.95 / 21 = 228.09285714285714...
+        After rounding: purchase_price must equal 228.09 (at dp=2).
+        """
+        uom_unit = self.env.ref("uom.product_uom_unit")
+        # Sell per Each while cost is per box: forces the /21 conversion
+        order = self._make_so_with_product(self.product_box, uom=uom_unit)
+        line = order.order_line[:1]
+
+        # Verify the raw computation would be unrounded
+        raw = 4789.95 / 21
+        dp = self.env["decimal.precision"].precision_get("Product Price")
+        self.assertNotEqual(
+            raw,
+            round(raw, dp),
+            "Test setup error: choose values that produce irrational decimals",
+        )
+
+        self._assert_purchase_price_rounded(line)
+
+    # ------------------------------------------------------------------
+    # B2 — after action_confirm
+    # ------------------------------------------------------------------
+
+    def test_purchase_price_rounded_after_action_confirm(self):
+        """B2/B4 (sale state): purchase_price remains rounded after confirmation.
+
+        Covers the sale_stock_margin._compute_purchase_price re-trigger path.
+        For a consumable (no stock moves), the base sale_margin compute runs
+        and the value must still be rounded.
+        """
+        uom_unit = self.env.ref("uom.product_uom_unit")
+        order = self._make_so_with_product(self.product_box, uom=uom_unit)
+
+        order.action_confirm()
+        line = order.order_line[:1]
+        line.invalidate_recordset()
+
+        self._assert_purchase_price_rounded(line)
+
+    # ------------------------------------------------------------------
+    # B3 — direct write
+    # ------------------------------------------------------------------
+
+    def test_purchase_price_rounded_on_direct_write(self):
+        """B3: a direct write of purchase_price with extra decimals is rounded.
+
+        Covers API writes, imports, and other non-compute code paths.
+        """
+        order = self._make_so_with_product(self.product)
+        line = order.order_line[:1]
+
+        line.write({"purchase_price": 6.28812345})
+
+        dp = self.env["decimal.precision"].precision_get("Product Price")
+        expected = round(6.28812345, dp)  # 6.29
+        self._assert_purchase_price_rounded(line)
+        self.assertAlmostEqual(line.purchase_price, expected, places=dp)
+
+    # ------------------------------------------------------------------
+    # B4 — create with unrounded value
+    # ------------------------------------------------------------------
+
+    def test_purchase_price_rounded_on_create(self):
+        """B4: creating a line with an unrounded purchase_price stores it rounded.
+
+        Covers imports, programmatic line creation, and the
+        min_display_digits raw-stored backfill path on new lines.
+        """
+        order = self.env["sale.order"].create({
+            "partner_id": self.partner.id,
+        })
+        dp = self.env["decimal.precision"].precision_get("Product Price")
+
+        line = self.env["sale.order.line"].create({
+            "order_id": order.id,
+            "product_id": self.product.id,
+            "product_uom_qty": 1.0,
+            "price_unit": 9.99,
+            "purchase_price": 228.0928571,
+        })
+
+        expected = round(228.0928571, dp)  # 228.09
+        self._assert_purchase_price_rounded(line)
+        self.assertAlmostEqual(line.purchase_price, expected, places=dp)

--- a/bemade_sale_price_rounding/tests/test_sale_price_rounding.py
+++ b/bemade_sale_price_rounding/tests/test_sale_price_rounding.py
@@ -2,27 +2,27 @@
 """
 Tests for bemade_sale_price_rounding
 
-Use cases / acceptance criteria:
+Acceptance criteria:
 
-1. Percentage pricelist rule: when a pricelist applies a percentage discount
-   to a product, the resulting price_unit on the sale order line must be
-   rounded to the currency's rounding precision (e.g. 0.01 for USD/CAD).
-   Example: $9.99 at 33% off → stored as 6.69, not 6.6933.
+1. Percentage pricelist rule: price_unit must be rounded to currency precision.
+   E.g. $9.99 at 33% off → 6.69, not 6.6933.
 
-2. Formula pricelist rule (cost + markup): when a pricelist uses a formula
-   based on cost, the resulting price_unit must similarly be rounded to
-   currency precision.
+2. Formula pricelist rule (cost + markup): same rounding guarantee.
 
-3. Fixed pricelist price: a fixed price entered directly on a pricelist rule
-   should be unaffected (it is already exact by definition).
+3. Multi-step pricelist chain (realistic Durpro scenario): supplier cost →
+   base pricelist (+35% markup) → public pricelist (+42% markup) produces
+   irrational intermediate values that must be rounded on the SO line.
 
-4. Manual price override: if a user manually sets price_unit on a sale order
-   line, the value should be preserved exactly as entered. This module only
-   rounds prices that come from pricelist computation.
+4. Fixed pricelist price: already exact, must remain exact.
 
-5. Multi-currency: rounding must use the *order's* currency precision, not the
-   company currency. A foreign-currency order should round to that currency's
-   precision.
+5. Manual price override: a user-typed price_unit must not be altered by
+   this module (only pricelist-computed prices are touched).
+
+6. Multi-currency: rounding uses the *order* currency's precision.
+
+IMPORTANT — use Form to set pricelist BEFORE adding the SO line:
+   The pricelist must be set on the order before product lines are added so
+   that _reset_price_unit() can see the pricelist and apply the correct rule.
 """
 from odoo.fields import Command
 from odoo.tests import Form, tagged
@@ -32,104 +32,253 @@ from odoo.addons.sale.tests.common import SaleCommon
 
 @tagged("post_install", "-at_install")
 class TestSalePriceRounding(SaleCommon):
+    """Comprehensive tests verifying price_unit rounding to currency precision."""
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
         cls._enable_pricelists()
 
-        # A product whose price produces non-round numbers under percentage rules.
-        # 9.99 * (1 - 0.33) = 6.6933
-        cls.product.lst_price = 9.99
+        # Product with a price that produces non-round values under most rules.
+        # 87.50 * 1.35 = 118.125   (not round)
+        # 87.50 * 1.35 * 1.42 = 167.7375  (not round)
+        # These deliberately irrational results stress-test our rounding.
+        cls.product.lst_price = 87.50
+        cls.product.standard_price = 87.50
 
-        cls.pricelist = cls.env["product.pricelist"].create({
-            "name": "Test Pricelist",
-            "currency_id": cls.env.company.currency_id.id,
-        })
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
 
-    def _make_order(self, pricelist=None):
-        pricelist = pricelist or self.pricelist
-        return self.env["sale.order"].create({
-            "partner_id": self.partner.id,
-            "pricelist_id": pricelist.id,
-        })
+    def _make_pricelist(self, name, currency=None, items=None):
+        """Create a pricelist with optional rule items."""
+        vals = {
+            "name": name,
+            "currency_id": (currency or self.env.company.currency_id).id,
+        }
+        if items:
+            vals["item_ids"] = [Command.create(i) for i in items]
+        return self.env["product.pricelist"].create(vals)
 
-    def _add_line(self, order, product=None, qty=1):
-        product = product or self.product
-        return self.env["sale.order.line"].create({
-            "order_id": order.id,
-            "product_id": product.id,
-            "product_uom_qty": qty,
-        })
+    def _make_so_with_pricelist(self, pricelist):
+        """Create a sale order with pricelist set BEFORE adding the product line.
+
+        This simulates the real user flow: open SO form → set pricelist →
+        add product. Without this ordering, _reset_price_unit() may not see
+        the pricelist rule and defaults to lst_price (already 2 decimals).
+        """
+        with Form(self.env["sale.order"]) as order_form:
+            order_form.partner_id = self.partner
+            order_form.pricelist_id = pricelist
+            with order_form.order_line.new() as line_form:
+                line_form.product_id = self.product
+        return order_form.record
 
     def _assert_price_rounded(self, line):
         """Assert price_unit equals its currency-rounded value (exact equality)."""
-        currency = line.currency_id
+        currency = line.currency_id or self.env.company.currency_id
         rounded = currency.round(line.price_unit)
         self.assertEqual(
             line.price_unit,
             rounded,
-            f"price_unit {line.price_unit} is not rounded to currency precision "
+            f"price_unit {line.price_unit!r} is not rounded to currency precision "
             f"({currency.name}, rounding={currency.rounding}); "
-            f"expected {rounded}",
+            f"expected {rounded!r}",
         )
 
-    def test_percentage_pricelist_rounds_to_currency_precision(self):
-        """price_unit is rounded to currency precision after a % pricelist rule."""
-        self.env["product.pricelist.item"].create({
-            "pricelist_id": self.pricelist.id,
-            "compute_price": "percentage",
-            "percent_price": 33,  # 9.99 * 0.67 = 6.6933
-        })
-        order = self._make_order()
-        line = self._add_line(order)
+    # ------------------------------------------------------------------
+    # Test cases
+    # ------------------------------------------------------------------
+
+    def test_pricelist_chain_rounds_price_unit(self):
+        """Multi-step pricelist chain produces a rounded price_unit.
+
+        Mimics the real Durpro scenario:
+          - base_pricelist: standard_price × 1.35  →  87.50 × 1.35 = 118.125
+          - public_pricelist (based on base): × 1.42  →  118.125 × 1.42 = 167.7375
+
+        Without the fix, 167.7375 (or a similar irrational float) ends up
+        stored on the SO line.  With the fix it must be 167.74.
+        """
+        base_pricelist = self._make_pricelist(
+            "Base Cost +35%",
+            items=[{
+                "compute_price": "formula",
+                "base": "standard_price",
+                "price_discount": -35,   # negative = markup: cost * (1 - (-0.35)) = cost * 1.35
+                "applied_on": "3_global",
+            }],
+        )
+        public_pricelist = self._make_pricelist(
+            "Public +42% on base",
+            items=[{
+                "compute_price": "formula",
+                "base": "pricelist",
+                "base_pricelist_id": base_pricelist.id,
+                "price_discount": -42,   # base * 1.42
+                "applied_on": "3_global",
+            }],
+        )
+
+        order = self._make_so_with_pricelist(public_pricelist)
+        line = order.order_line[:1]
+
+        # Verify the raw math would be non-round
+        raw = 87.50 * 1.35 * 1.42
+        self.assertNotEqual(raw, round(raw, 2),
+                            "Test setup error: choose numbers that produce irrational values")
+
         self._assert_price_rounded(line)
 
-    def test_formula_pricelist_rounds_to_currency_precision(self):
-        """price_unit is rounded to currency precision after a formula pricelist rule."""
-        self.product.standard_price = 7.77
-        self.env["product.pricelist.item"].create({
-            "pricelist_id": self.pricelist.id,
-            "compute_price": "formula",
-            "base": "standard_price",
-            "price_discount": -30,  # cost * 1.30 = 7.77 * 1.30 = 10.101
-        })
-        order = self._make_order()
-        line = self._add_line(order)
+    def test_percentage_pricelist_rounds(self):
+        """Single percentage rule: price_unit is rounded to currency precision.
+
+        87.50 * (1 - 0.33) = 58.625  → should be 58.63 (or 58.62 depending
+        on rounding direction), but never 58.625.
+        """
+        pricelist = self._make_pricelist(
+            "33% Discount",
+            items=[{
+                "compute_price": "percentage",
+                "percent_price": 33,
+                "applied_on": "3_global",
+            }],
+        )
+        order = self._make_so_with_pricelist(pricelist)
+        line = order.order_line[:1]
         self._assert_price_rounded(line)
 
-    def test_fixed_pricelist_price_unaffected(self):
-        """A fixed pricelist price produces an exact price_unit with no unexpected rounding."""
-        self.env["product.pricelist.item"].create({
-            "pricelist_id": self.pricelist.id,
-            "compute_price": "fixed",
-            "fixed_price": 15.00,
-        })
-        order = self._make_order()
-        line = self._add_line(order)
+    def test_formula_pricelist_rounds(self):
+        """Formula rule based on cost: price_unit is rounded to currency precision.
+
+        standard_price = 87.50, markup -30 (= ×1.30) → 87.50 × 1.30 = 113.75
+        That's already round, so we add a markup that isn't:
+        standard_price = 77.77, markup -30 → 77.77 × 1.30 = 101.101
+        """
+        self.product.standard_price = 77.77
+        pricelist = self._make_pricelist(
+            "Cost +30%",
+            items=[{
+                "compute_price": "formula",
+                "base": "standard_price",
+                "price_discount": -30,
+                "applied_on": "3_global",
+            }],
+        )
+        order = self._make_so_with_pricelist(pricelist)
+        line = order.order_line[:1]
+
+        raw = 77.77 * 1.30
+        self.assertNotEqual(raw, round(raw, 2),
+                            "Test setup error: use numbers that produce irrational values")
+        self._assert_price_rounded(line)
+
+    def test_fixed_price_unaffected(self):
+        """A fixed pricelist price produces an exact price_unit, and our rounding
+        does not alter it in any unexpected way."""
+        pricelist = self._make_pricelist(
+            "Fixed $15.00",
+            items=[{
+                "compute_price": "fixed",
+                "fixed_price": 15.00,
+                "applied_on": "3_global",
+            }],
+        )
+        order = self._make_so_with_pricelist(pricelist)
+        line = order.order_line[:1]
         self._assert_price_rounded(line)
         self.assertEqual(line.price_unit, 15.00)
 
-    def test_manual_price_not_modified(self):
-        """A manually set price_unit is not touched by this module."""
-        order = self._make_order()
-        line = self._add_line(order)
-        line.price_unit = 12.345678
-        self.assertEqual(line.price_unit, 12.345678)
+    def test_pricelist_set_before_line_required(self):
+        """Demonstrate correct vs incorrect workflow for pricelist + SO line.
+
+        CORRECT workflow: set pricelist on the order BEFORE adding the product
+        line → _reset_price_unit() runs with pricelist context → price gets
+        rounded.
+
+        We also verify that once the pricelist IS set first, the irrational
+        value from the pricelist chain does not appear on the line.
+        """
+        base_pricelist = self._make_pricelist(
+            "Workflow test - base +35%",
+            items=[{
+                "compute_price": "formula",
+                "base": "standard_price",
+                "price_discount": -35,
+                "applied_on": "3_global",
+            }],
+        )
+
+        # CORRECT workflow: pricelist set before line
+        with Form(self.env["sale.order"]) as order_form:
+            order_form.partner_id = self.partner
+            order_form.pricelist_id = base_pricelist  # set FIRST
+            with order_form.order_line.new() as line_form:
+                line_form.product_id = self.product
+        order = order_form.record
+        line = order.order_line[:1]
+
+        # price must be rounded
+        self._assert_price_rounded(line)
 
     def test_multicurrency_uses_order_currency_rounding(self):
-        """Rounding uses the order currency's precision, not the company currency's."""
+        """Rounding uses the order currency's precision, not the company currency.
+
+        We create a EUR pricelist with a percentage rule on our non-round
+        product price.  The SO line must be rounded to EUR's precision (0.01).
+        """
         eur = self.env.ref("base.EUR")
-        eur_pricelist = self.env["product.pricelist"].create({
-            "name": "EUR Pricelist",
-            "currency_id": eur.id,
-        })
-        self.env["product.pricelist.item"].create({
-            "pricelist_id": eur_pricelist.id,
-            "compute_price": "percentage",
-            "percent_price": 33,  # 9.99 EUR * 0.67 → non-round
-        })
-        order = self._make_order(pricelist=eur_pricelist)
-        line = self._add_line(order)
-        self.assertEqual(line.currency_id, eur)
+        # Make sure EUR has a rate so conversion doesn't fail
+        if not self.env["res.currency.rate"].search(
+            [("currency_id", "=", eur.id), ("company_id", "=", self.env.company.id)]
+        ):
+            self.env["res.currency.rate"].create({
+                "currency_id": eur.id,
+                "rate": 1.35,
+                "company_id": self.env.company.id,
+            })
+
+        eur_pricelist = self._make_pricelist(
+            "EUR 33% Discount",
+            currency=eur,
+            items=[{
+                "compute_price": "percentage",
+                "percent_price": 33,
+                "applied_on": "3_global",
+            }],
+        )
+        order = self._make_so_with_pricelist(eur_pricelist)
+        line = order.order_line[:1]
+
+        self.assertEqual(line.currency_id, eur,
+                         "Order line currency should be EUR")
+        self._assert_price_rounded(line)
+
+    def test_direct_write_of_price_unit_is_rounded(self):
+        """A direct write of price_unit with extra decimals must be rounded.
+
+        Reproduces the Durpro production bug (IBS Tuboquip / HF 40-40E):
+        in Odoo 18 ``sale.order.line.price_unit`` is declared with
+        ``min_display_digits='Product Price'`` (no ``digits``), so the Float
+        column stores values at full FLOAT8 precision — no automatic rounding
+        on write.  The form view formats display via ``min_display_digits``
+        (looks fine), but the printed PDF uses a code path that surfaces the
+        full stored precision (6+ decimals).
+
+        Our existing ``_get_display_price_ignore_combo`` /
+        ``_reset_price_unit`` overrides only run on the compute path.  Any
+        other code path that writes ``price_unit`` directly (e.g. a
+        downstream module, an import, an API call) leaves an unrounded float
+        in the DB.  This test asserts that *any* write to price_unit ends
+        up rounded to currency precision.
+        """
+        # Plain pricelist so the order has a known currency
+        pricelist = self._make_pricelist("Plain pricelist for direct-write test")
+        order = self._make_so_with_pricelist(pricelist)
+        line = order.order_line[:1]
+
+        # Simulate a non-compute code path writing an unrounded float
+        line.price_unit = 6.100121999999999
+        # The assertion below mirrors the production bug: stored value
+        # leaks 6+ decimals onto the printed PDF.
         self._assert_price_rounded(line)


### PR DESCRIPTION
Updates **bemade_sale_price_rounding** from v19.0.1.0.0 to **v19.0.2.0.0**, syncing the more advanced copy vendored in DurPro (in production on odoo19.durpro.com). The DurPro version additionally rounds the **cost (purchase price)** to Product Price precision, not just the unit price.

Resolves a divergence between the vendored DurPro copy and bemade-addons, prerequisite to restoring the symlink (single-source) structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)