### PR TITLE
feat(odoo_herd_portal): auto-provision log-viewer secret to the cluster

### DIFF
--- a/odoo_herd_portal/__manifest__.py
+++ b/odoo_herd_portal/__manifest__.py
@@ -48,6 +48,7 @@ See ``docs/SPEC.md`` for the full epic specification.
     "data": [
         "security/ir.model.access.csv",
         "security/k8s_portal_security.xml",
+        "views/k8s_cluster_views.xml",
         "views/k8s_odoo_instance_views.xml",
         "views/portal_templates.xml",
     ],

--- a/odoo_herd_portal/models/k8s_cluster.py
+++ b/odoo_herd_portal/models/k8s_cluster.py
@@ -1,7 +1,29 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
-from odoo import fields, models
+import base64
+import logging
+
+from kubernetes import client
+from kubernetes.client.rest import ApiException
+
+from odoo import _, fields, models
+from odoo.exceptions import UserError
+
+from .k8s_odoo_instance import LOG_TOKEN_SECRET_PARAM
+
+_logger = logging.getLogger(__name__)
 
 _K8S_GROUP = "odoo_herd.group_k8s_user"
+
+# The log-stream sidecar runs in this namespace and reads the shared HMAC
+# secret from this Secret/key (see docs/SIDECAR.md). The key name matches the
+# ir.config_parameter so the contract is obvious at both ends.
+LOG_SIDECAR_NAMESPACE = "log-sidecar"
+LOG_SIDECAR_SECRET_NAME = "log-sidecar-token-secret"
+LOG_SIDECAR_SECRET_KEY = "log_token_secret"
+
+
+class _LogSidecarNamespaceMissing(Exception):
+    """Internal signal: the log-sidecar namespace does not exist yet."""
 
 
 class K8sCluster(models.Model):
@@ -13,6 +35,11 @@ class K8sCluster(models.Model):
     credential. The missing portal ACL on ``k8s.cluster`` does NOT block a
     related read from a readable instance, so we gate the fields themselves with
     ``groups="odoo_herd.group_k8s_user"``.
+
+    This module also auto-provisions the log-viewer HMAC secret into the
+    cluster (``_ensure_log_viewer_secret``) so the value Odoo mints log tokens
+    with (``ir.config_parameter`` ``odoo_herd_portal.log_token_secret``) never
+    has to be hand-copied into the ``log-sidecar`` namespace.
     """
 
     _inherit = "k8s.cluster"
@@ -29,3 +56,145 @@ class K8sCluster(models.Model):
     connection_error = fields.Text(groups=_K8S_GROUP)
     connection_status = fields.Selection(groups=_K8S_GROUP)
     last_sync = fields.Datetime(groups=_K8S_GROUP)
+
+    # ==================================================================
+    # Log-viewer HMAC secret provisioning
+    # ==================================================================
+    def _ensure_log_viewer_secret(self, raise_on_error=False):
+        """Write the log-viewer HMAC secret into the cluster, idempotently.
+
+        Source of truth is ``ir.config_parameter``
+        ``odoo_herd_portal.log_token_secret`` -- the SAME value
+        ``K8sOdooInstance._mint_log_token`` signs with. It is read via the
+        instance model's ``_get_log_token_secret`` so the param is generated
+        (``secrets.token_hex(32)``) on first use and never forked here.
+
+        The secret is mirrored into the ``log-sidecar-token-secret`` Secret in
+        the ``log-sidecar`` namespace under the ``log_token_secret`` key:
+
+        * namespace missing (``read_namespace`` 404) -> log + no-op (the sidecar
+          is not deployed yet, so there is nothing to mirror into);
+        * Secret missing (``read_namespaced_secret`` 404) -> create it;
+        * Secret present but value differs -> patch it;
+        * value matches -> no-op (no churn).
+
+        This runs with the cluster's stored credentials -- privileged by
+        nature; it must only ever be invoked from internal/manager paths.
+
+        ``raise_on_error`` controls error handling: from the instance write
+        path we pass ``False`` so a cluster/API failure is caught + logged and
+        never blocks the write; the manual button passes ``True`` so the user
+        sees a clear ``UserError``.
+        """
+        self.ensure_one()
+        secret_value = self.env["k8s.odoo.instance"]._get_log_token_secret()
+        try:
+            k8s_client = self._get_k8s_client()
+            core = client.CoreV1Api(k8s_client)
+            self._provision_log_viewer_secret(core, secret_value)
+        except UserError:
+            # _get_k8s_client wraps connection failures in UserError.
+            if raise_on_error:
+                raise
+            _logger.warning(
+                "Could not provision log-viewer secret for cluster %s: "
+                "failed to build a Kubernetes client.",
+                self.name,
+                exc_info=True,
+            )
+        except _LogSidecarNamespaceMissing:
+            msg = _(
+                "The '%s' namespace was not found on cluster %s. Deploy the "
+                "log-stream sidecar first, then provision the secret."
+            ) % (LOG_SIDECAR_NAMESPACE, self.name)
+            if raise_on_error:
+                raise UserError(msg)
+            _logger.info(msg)
+        except Exception as e:  # noqa: BLE001 - never let provisioning break the write
+            if raise_on_error:
+                raise UserError(
+                    _("Failed to provision log-viewer secret on cluster %s: %s")
+                    % (self.name, e)
+                )
+            _logger.warning(
+                "Could not provision log-viewer secret for cluster %s: %s",
+                self.name,
+                e,
+                exc_info=True,
+            )
+
+    def _provision_log_viewer_secret(self, core, secret_value):
+        """Create/patch the sidecar Secret to match ``secret_value``.
+
+        Raises ``_LogSidecarNamespaceMissing`` if the ``log-sidecar`` namespace
+        is absent (caller turns that into a graceful skip or a UserError).
+        """
+        # 1. Namespace must exist (sidecar deployed) before we touch anything.
+        try:
+            core.read_namespace(LOG_SIDECAR_NAMESPACE)
+        except ApiException as e:
+            if e.status == 404:
+                raise _LogSidecarNamespaceMissing()
+            raise
+
+        b64_value = base64.b64encode(secret_value.encode("utf-8")).decode("ascii")
+
+        # 2. Read the existing Secret; 404 -> create.
+        try:
+            existing = core.read_namespaced_secret(
+                LOG_SIDECAR_SECRET_NAME, LOG_SIDECAR_NAMESPACE
+            )
+        except ApiException as e:
+            if e.status != 404:
+                raise
+            core.create_namespaced_secret(
+                namespace=LOG_SIDECAR_NAMESPACE,
+                body=client.V1Secret(
+                    metadata=client.V1ObjectMeta(
+                        name=LOG_SIDECAR_SECRET_NAME,
+                        namespace=LOG_SIDECAR_NAMESPACE,
+                    ),
+                    type="Opaque",
+                    data={LOG_SIDECAR_SECRET_KEY: b64_value},
+                ),
+            )
+            _logger.info(
+                "Created log-viewer secret %s/%s on cluster %s.",
+                LOG_SIDECAR_NAMESPACE,
+                LOG_SIDECAR_SECRET_NAME,
+                self.name,
+            )
+            return
+
+        # 3. Secret exists: patch only if the value drifted.
+        current = (existing.data or {}).get(LOG_SIDECAR_SECRET_KEY)
+        if current == b64_value:
+            return
+        core.patch_namespaced_secret(
+            name=LOG_SIDECAR_SECRET_NAME,
+            namespace=LOG_SIDECAR_NAMESPACE,
+            body={"data": {LOG_SIDECAR_SECRET_KEY: b64_value}},
+        )
+        _logger.info(
+            "Updated log-viewer secret %s/%s on cluster %s.",
+            LOG_SIDECAR_NAMESPACE,
+            LOG_SIDECAR_SECRET_NAME,
+            self.name,
+        )
+
+    def action_provision_log_viewer_secret(self):
+        """Manual button: provision the secret, surfacing failures to the user."""
+        for cluster in self:
+            cluster._ensure_log_viewer_secret(raise_on_error=True)
+        return {
+            "type": "ir.actions.client",
+            "tag": "display_notification",
+            "params": {
+                "title": _("Log-Viewer Secret Provisioned"),
+                "message": _(
+                    "The log-viewer HMAC secret was written to the "
+                    "'%s' namespace."
+                ) % LOG_SIDECAR_NAMESPACE,
+                "type": "success",
+            },
+        }

--- a/odoo_herd_portal/models/k8s_odoo_instance.py
+++ b/odoo_herd_portal/models/k8s_odoo_instance.py
@@ -155,6 +155,36 @@ class K8sOdooInstance(models.Model):
         """True when the current user may read the hidden infra fields."""
         return self.env.su or self.env.user.has_group(_K8S_GROUP)
 
+    # ==================================================================
+    # Auto-provision the log-viewer secret when portal access is granted
+    # ==================================================================
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super().create(vals_list)
+        records._maybe_provision_log_viewer_secret()
+        return records
+
+    def write(self, vals):
+        res = super().write(vals)
+        # Only react when allowed_partner_ids was actually touched; the value
+        # AFTER the write is what matters (we never act on a clearing).
+        if "allowed_partner_ids" in vals:
+            self._maybe_provision_log_viewer_secret()
+        return res
+
+    def _maybe_provision_log_viewer_secret(self):
+        """Ensure the log-viewer secret on each cluster that just gained access.
+
+        Triggered from create/write: for instances that end up with a non-empty
+        ``allowed_partner_ids``, ensure the shared HMAC secret exists in their
+        cluster (deduped per cluster). Provisioning failures are swallowed there
+        (``_ensure_log_viewer_secret`` catches + logs) so the write never breaks.
+        We never *remove* the secret when access is cleared.
+        """
+        clusters = self.filtered("allowed_partner_ids").mapped("cluster_id")
+        for cluster in clusters:
+            cluster._ensure_log_viewer_secret()
+
     @api.model
     def _search(
         self,

--- a/odoo_herd_portal/tests/__init__.py
+++ b/odoo_herd_portal/tests/__init__.py
@@ -5,3 +5,4 @@ from . import test_backups
 from . import test_lifecycle
 from . import test_log_viewer
 from . import test_backend_view
+from . import test_secret_provisioning

--- a/odoo_herd_portal/tests/test_secret_provisioning.py
+++ b/odoo_herd_portal/tests/test_secret_provisioning.py
@@ -1,0 +1,350 @@
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+"""Auto-provisioning of the log-viewer HMAC secret into the cluster.
+
+Odoo writes the shared HMAC secret (the SAME ``ir.config_parameter``
+``odoo_herd_portal.log_token_secret`` that Feature C's ``_mint_log_token``
+uses) into a k8s ``Secret`` (``log-sidecar-token-secret`` in the
+``log-sidecar`` namespace) so it never has to be hand-copied.
+
+These tests mock the Kubernetes client exactly like ``odoo_herd``'s own tests
+(``test_create_instance_wizard.py``): they patch
+``K8sCluster._get_k8s_client`` to return a sentinel client and patch
+``kubernetes.client.CoreV1Api`` to return a fake CoreV1Api. No live cluster is
+touched.
+
+Acceptance criteria under test:
+
+* Setting ``allowed_partner_ids`` on an instance triggers
+  ``_ensure_log_viewer_secret`` and CREATES the secret when absent, with the
+  right name/namespace/key and a base64 value equal to the config param.
+* Secret exists and value matches -> idempotent: no create, no patch.
+* Secret exists but value differs -> patch with the new value.
+* ``log-sidecar`` namespace missing (read_namespace 404) -> skip gracefully,
+  no secret create, and the instance write still succeeds.
+* A cluster/API error during provisioning from the write path is swallowed:
+  the instance write still succeeds (warning logged).
+* The config param is generated when absent (and reused/stable if present).
+* The manual button action runs the ensure, and raises UserError on the
+  namespace-missing case.
+"""
+
+import base64
+from unittest.mock import patch
+
+from kubernetes.client.rest import ApiException
+from odoo.exceptions import UserError
+from odoo.tests.common import TransactionCase, tagged
+from odoo.tools import mute_logger
+
+SECRET_PARAM = "odoo_herd_portal.log_token_secret"
+SECRET_NAME = "log-sidecar-token-secret"
+SECRET_NS = "log-sidecar"
+SECRET_KEY = "log_token_secret"
+
+CLUSTER_PATH = "odoo.addons.odoo_herd.models.k8s_cluster.K8sCluster._get_k8s_client"
+CORE_API_PATH = "kubernetes.client.CoreV1Api"
+LOG_PATH = "odoo.addons.odoo_herd_portal.models.k8s_cluster"
+
+
+class _FakeSecret:
+    """Minimal stand-in for V1Secret with the .data dict we read back."""
+
+    def __init__(self, data):
+        self.data = dict(data)
+
+
+class FakeCoreV1Api:
+    """Records calls and simulates namespace / secret presence.
+
+    ``namespace_exists`` controls whether ``read_namespace`` succeeds.
+    ``existing_secret_value`` (decoded str) controls ``read_namespaced_secret``:
+    None -> 404 (no secret yet); otherwise a fake secret carrying that value.
+    ``raise_on`` names a method that should raise a generic ApiException(500)
+    to simulate a cluster/API error.
+    """
+
+    def __init__(
+        self,
+        *,
+        namespace_exists=True,
+        existing_secret_value=None,
+        raise_on=None,
+    ):
+        self.namespace_exists = namespace_exists
+        self.existing_secret_value = existing_secret_value
+        self.raise_on = raise_on
+        self.created = []
+        self.patched = []
+        self.read_namespace_calls = []
+        self.read_secret_calls = []
+
+    def _maybe_raise(self, method):
+        if self.raise_on == method:
+            raise ApiException(status=500, reason="boom")
+
+    def read_namespace(self, name):
+        self.read_namespace_calls.append(name)
+        self._maybe_raise("read_namespace")
+        if not self.namespace_exists:
+            raise ApiException(status=404, reason="Not Found")
+        return {"metadata": {"name": name}}
+
+    def read_namespaced_secret(self, name, namespace):
+        self.read_secret_calls.append((name, namespace))
+        self._maybe_raise("read_namespaced_secret")
+        if self.existing_secret_value is None:
+            raise ApiException(status=404, reason="Not Found")
+        return _FakeSecret(
+            {SECRET_KEY: base64.b64encode(
+                self.existing_secret_value.encode("utf-8")
+            ).decode("ascii")}
+        )
+
+    def create_namespaced_secret(self, namespace, body):
+        self._maybe_raise("create_namespaced_secret")
+        self.created.append({"namespace": namespace, "body": body})
+        return body
+
+    def patch_namespaced_secret(self, name, namespace, body):
+        self._maybe_raise("patch_namespaced_secret")
+        self.patched.append({"name": name, "namespace": namespace, "body": body})
+        return body
+
+
+@tagged("post_install", "-at_install", "odoo_herd_portal")
+class TestLogViewerSecretProvisioning(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner = cls.env["res.partner"].create(
+            {"name": "Secret Co", "is_company": True}
+        )
+        cls.cluster = cls.env["k8s.cluster"].create(
+            {
+                "name": "Secret Test Cluster",
+                "api_endpoint": "https://example.invalid:6443",
+                "kubeconfig": "apiVersion: v1\nkind: Config\n",
+                "default_namespace": "default",
+                "active": False,
+            }
+        )
+        cls.instance = cls.env["k8s.odoo.instance"].create(
+            {
+                "name": "secret-prod",
+                "namespace": "nsclient-secret",
+                "cluster_id": cls.cluster.id,
+                "environment": "production",
+            }
+        )
+
+    # --- helpers ---------------------------------------------------------
+    def _Param(self):
+        return self.env["ir.config_parameter"].sudo()
+
+    def _secret_value(self):
+        return self._Param().get_param(SECRET_PARAM)
+
+    def _run_ensure(self, fake_core):
+        """Call _ensure_log_viewer_secret with the k8s client mocked."""
+        with (
+            patch(CLUSTER_PATH, return_value="fake-client"),
+            patch(CORE_API_PATH, return_value=fake_core),
+        ):
+            self.cluster._ensure_log_viewer_secret()
+
+    # --- config param generation ----------------------------------------
+    def test_config_param_generated_when_absent(self):
+        self._Param().set_param(SECRET_PARAM, "")
+        fake_core = FakeCoreV1Api(namespace_exists=True, existing_secret_value=None)
+        self._run_ensure(fake_core)
+        value = self._secret_value()
+        self.assertTrue(value, "Secret param must be generated on first use.")
+        self.assertGreaterEqual(len(value), 64, "token_hex(32) -> 64 hex chars.")
+
+    def test_config_param_reused_when_present(self):
+        self._Param().set_param(SECRET_PARAM, "deadbeef" * 8)
+        fake_core = FakeCoreV1Api(
+            namespace_exists=True, existing_secret_value="deadbeef" * 8
+        )
+        self._run_ensure(fake_core)
+        self.assertEqual(self._secret_value(), "deadbeef" * 8)
+
+    # --- create when absent ---------------------------------------------
+    def test_secret_created_when_absent(self):
+        self._Param().set_param(SECRET_PARAM, "cafebabe" * 8)
+        fake_core = FakeCoreV1Api(namespace_exists=True, existing_secret_value=None)
+        self._run_ensure(fake_core)
+
+        self.assertEqual(len(fake_core.created), 1)
+        self.assertEqual(fake_core.patched, [])
+        call = fake_core.created[0]
+        self.assertEqual(call["namespace"], SECRET_NS)
+        body = call["body"]
+        # V1Secret object: metadata.name + data[key] = base64(value).
+        self.assertEqual(body.metadata.name, SECRET_NAME)
+        self.assertEqual(body.metadata.namespace, SECRET_NS)
+        self.assertEqual(
+            body.data[SECRET_KEY],
+            base64.b64encode(("cafebabe" * 8).encode("utf-8")).decode("ascii"),
+        )
+
+    # --- idempotent when matching ---------------------------------------
+    def test_no_churn_when_secret_matches(self):
+        self._Param().set_param(SECRET_PARAM, "abc123" * 10)
+        fake_core = FakeCoreV1Api(
+            namespace_exists=True, existing_secret_value="abc123" * 10
+        )
+        self._run_ensure(fake_core)
+        self.assertEqual(fake_core.created, [])
+        self.assertEqual(fake_core.patched, [])
+
+    # --- patch when differs ---------------------------------------------
+    def test_secret_patched_when_differs(self):
+        self._Param().set_param(SECRET_PARAM, "newvalue" * 8)
+        fake_core = FakeCoreV1Api(
+            namespace_exists=True, existing_secret_value="oldvalue" * 8
+        )
+        self._run_ensure(fake_core)
+        self.assertEqual(fake_core.created, [])
+        self.assertEqual(len(fake_core.patched), 1)
+        call = fake_core.patched[0]
+        self.assertEqual(call["name"], SECRET_NAME)
+        self.assertEqual(call["namespace"], SECRET_NS)
+        # Patch body is a plain dict ({"data": {...}}), not a V1Secret.
+        self.assertEqual(
+            call["body"]["data"][SECRET_KEY],
+            base64.b64encode(("newvalue" * 8).encode("utf-8")).decode("ascii"),
+        )
+
+    # --- namespace missing ----------------------------------------------
+    @mute_logger(LOG_PATH)
+    def test_namespace_missing_skips_gracefully(self):
+        self._Param().set_param(SECRET_PARAM, "")
+        fake_core = FakeCoreV1Api(namespace_exists=False)
+        self._run_ensure(fake_core)
+        self.assertEqual(fake_core.created, [])
+        self.assertEqual(fake_core.patched, [])
+        self.assertEqual(fake_core.read_secret_calls, [])
+
+    # ====================================================================
+    # Auto-trigger via allowed_partner_ids on the instance
+    # ====================================================================
+    def test_setting_allowed_partner_triggers_ensure_and_creates(self):
+        self._Param().set_param(SECRET_PARAM, "")
+        fake_core = FakeCoreV1Api(namespace_exists=True, existing_secret_value=None)
+        with (
+            patch(CLUSTER_PATH, return_value="fake-client"),
+            patch(CORE_API_PATH, return_value=fake_core),
+        ):
+            self.instance.write(
+                {"allowed_partner_ids": [(6, 0, [self.partner.id])]}
+            )
+        # Secret created with the value of the (now generated) config param.
+        self.assertEqual(len(fake_core.created), 1)
+        body = fake_core.created[0]["body"]
+        self.assertEqual(
+            body.data[SECRET_KEY],
+            base64.b64encode(self._secret_value().encode("utf-8")).decode("ascii"),
+        )
+
+    def test_create_with_allowed_partner_triggers_ensure(self):
+        self._Param().set_param(SECRET_PARAM, "create99" * 8)
+        fake_core = FakeCoreV1Api(namespace_exists=True, existing_secret_value=None)
+        with (
+            patch(CLUSTER_PATH, return_value="fake-client"),
+            patch(CORE_API_PATH, return_value=fake_core),
+        ):
+            self.env["k8s.odoo.instance"].create(
+                {
+                    "name": "born-with-access",
+                    "namespace": "nsclient-born",
+                    "cluster_id": self.cluster.id,
+                    "environment": "staging",
+                    "allowed_partner_ids": [(6, 0, [self.partner.id])],
+                }
+            )
+        self.assertEqual(len(fake_core.created), 1)
+
+    def test_clearing_allowed_partner_does_not_provision_or_remove(self):
+        # Pre-seed access (with provisioning mocked away to a no-op cluster).
+        with patch(
+            "odoo.addons.odoo_herd_portal.models.k8s_cluster."
+            "K8sCluster._ensure_log_viewer_secret"
+        ) as ensure_mock:
+            self.instance.write(
+                {"allowed_partner_ids": [(6, 0, [self.partner.id])]}
+            )
+        ensure_mock.assert_called()
+
+        # Now clear it -- must NOT call ensure (and the test proves we never
+        # delete the secret because there is no delete path at all).
+        with patch(
+            "odoo.addons.odoo_herd_portal.models.k8s_cluster."
+            "K8sCluster._ensure_log_viewer_secret"
+        ) as ensure_mock:
+            self.instance.write({"allowed_partner_ids": [(5, 0, 0)]})
+        ensure_mock.assert_not_called()
+
+    @mute_logger(LOG_PATH)
+    def test_instance_write_succeeds_when_namespace_missing(self):
+        self._Param().set_param(SECRET_PARAM, "")
+        fake_core = FakeCoreV1Api(namespace_exists=False)
+        with (
+            patch(CLUSTER_PATH, return_value="fake-client"),
+            patch(CORE_API_PATH, return_value=fake_core),
+        ):
+            self.instance.write(
+                {"allowed_partner_ids": [(6, 0, [self.partner.id])]}
+            )
+        # Write committed despite no secret being provisioned.
+        self.assertIn(self.partner, self.instance.allowed_partner_ids)
+        self.assertEqual(fake_core.created, [])
+
+    @mute_logger(LOG_PATH)
+    def test_instance_write_succeeds_on_api_error(self):
+        self._Param().set_param(SECRET_PARAM, "")
+        fake_core = FakeCoreV1Api(
+            namespace_exists=True, raise_on="read_namespaced_secret"
+        )
+        with (
+            patch(CLUSTER_PATH, return_value="fake-client"),
+            patch(CORE_API_PATH, return_value=fake_core),
+        ):
+            self.instance.write(
+                {"allowed_partner_ids": [(6, 0, [self.partner.id])]}
+            )
+        # The cluster/API error did not propagate; write succeeded.
+        self.assertIn(self.partner, self.instance.allowed_partner_ids)
+
+    @mute_logger(LOG_PATH)
+    def test_instance_write_succeeds_when_get_client_fails(self):
+        """A failure building the k8s client (UserError) must not block write."""
+        self._Param().set_param(SECRET_PARAM, "")
+        with patch(CLUSTER_PATH, side_effect=UserError("no cluster")):
+            self.instance.write(
+                {"allowed_partner_ids": [(6, 0, [self.partner.id])]}
+            )
+        self.assertIn(self.partner, self.instance.allowed_partner_ids)
+
+    # ====================================================================
+    # Manual button action
+    # ====================================================================
+    def test_manual_action_runs_ensure(self):
+        self._Param().set_param(SECRET_PARAM, "")
+        fake_core = FakeCoreV1Api(namespace_exists=True, existing_secret_value=None)
+        with (
+            patch(CLUSTER_PATH, return_value="fake-client"),
+            patch(CORE_API_PATH, return_value=fake_core),
+        ):
+            self.cluster.action_provision_log_viewer_secret()
+        self.assertEqual(len(fake_core.created), 1)
+
+    def test_manual_action_raises_on_namespace_missing(self):
+        self._Param().set_param(SECRET_PARAM, "")
+        fake_core = FakeCoreV1Api(namespace_exists=False)
+        with (
+            patch(CLUSTER_PATH, return_value="fake-client"),
+            patch(CORE_API_PATH, return_value=fake_core),
+        ):
+            with self.assertRaises(UserError):
+                self.cluster.action_provision_log_viewer_secret()

--- a/odoo_herd_portal/views/k8s_cluster_views.xml
+++ b/odoo_herd_portal/views/k8s_cluster_views.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!--
+        Add a manual "Provision Log-Viewer Secret" button to the cluster form.
+
+        This writes the shared HMAC secret (ir.config_parameter
+        odoo_herd_portal.log_token_secret) into the log-sidecar namespace of
+        the cluster. It is normally auto-provisioned when an instance gains
+        portal access, but this button lets a k8s manager (re)provision on
+        demand, e.g. after deploying the sidecar for the first time. Gated to
+        group_k8s_manager: it runs with the cluster's privileged credentials.
+    -->
+    <record id="view_k8s_cluster_form_portal_secret" model="ir.ui.view">
+        <field name="name">k8s.cluster.form.portal.secret</field>
+        <field name="model">k8s.cluster</field>
+        <field name="inherit_id" ref="odoo_herd.view_k8s_cluster_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//header/button[@name='action_sync_instances']" position="after">
+                <button name="action_provision_log_viewer_secret"
+                        string="Provision Log-Viewer Secret"
+                        type="object"
+                        class="btn-secondary"
+                        groups="odoo_herd.group_k8s_manager"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Stacked on \`feat/odoo_herd_portal\`. Odoo writes the shared log-viewer HMAC secret into the cluster so it never has to be hand-copied.

> **Base note:** targets \`feat/odoo_herd_portal\` for a clean stacked diff. Retarget to \`19.0\` once #163 (the portal feature branch) merges.

## What

Auto-provisions the log-viewer HMAC secret — the SAME \`ir.config_parameter\` \`odoo_herd_portal.log_token_secret\` that Feature C's \`_mint_log_token\` signs with — into a k8s Secret (\`log-sidecar-token-secret\` in the \`log-sidecar\` namespace, key \`log_token_secret\`).

- **\`K8sCluster._ensure_log_viewer_secret()\`** (extends the model in \`odoo_herd_portal\`), idempotent, runs with the cluster's stored credentials:
  - Reads the secret via the instance model's \`_get_log_token_secret\` (generates \`secrets.token_hex(32)\` on first use; reuses, does not fork).
  - \`CoreV1Api.read_namespace('log-sidecar')\` 404 → log + no-op (sidecar not deployed).
  - \`read_namespaced_secret\` 404 → \`create_namespaced_secret\`; value differs → \`patch_namespaced_secret\`; value matches → no-op (no churn).
  - All k8s calls wrapped so a cluster/API error is caught + logged and does **not** propagate from the instance-write path.
- **Auto-trigger:** \`create\`/\`write\` on \`k8s.odoo.instance\` call ensure (per affected cluster, deduped) whenever \`allowed_partner_ids\` ends up non-empty. Provisioning failure never blocks the write. The secret is **never removed** when access is cleared.
- **Manual button:** \`action_provision_log_viewer_secret\` on \`k8s.cluster\` + a form button gated \`groups="odoo_herd.group_k8s_manager"\`. This surfaces failures as \`UserError\` (including the "namespace not found — deploy the sidecar first" case).
- No \`attrs\` (Odoo 19). The secret stays an \`ir.config_parameter\`, not exposed in any portal view/field.

## RBAC prerequisite

Before this works against a real cluster, the \`odoo_herd\` cluster ServiceAccount needs **\`get,create,update\` on \`secrets\`** and **\`get\` on \`namespaces\`** in the \`log-sidecar\` namespace.

## Tests

New \`tests/test_secret_provisioning.py\` mocks the k8s client exactly like \`odoo_herd\`'s own tests (patch \`K8sCluster._get_k8s_client\` + \`kubernetes.client.CoreV1Api\` → a \`FakeCoreV1Api\`). Covers: create-when-absent, idempotent-on-match, patch-on-differ, namespace-missing graceful skip (+ write still succeeds), API/client error swallowed (write still succeeds), config param generated/reused, auto-trigger on create/write, clearing does not provision or remove, and the manual button (runs ensure + raises UserError on namespace-missing).

Full \`odoo_herd_portal\` suite green: **104 tests, 0 failed, 0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)