### PR TITLE
fix(odoo_herd_portal): log-viewer token handoff load-order race

### DIFF
--- a/odoo_herd_portal/static/src/js/log_viewer.js
+++ b/odoo_herd_portal/static/src/js/log_viewer.js
@@ -57,6 +57,15 @@
                 post();
             }
         });
+
+        // This script ships in the LAZY frontend bundle, so it usually runs
+        // AFTER the iframe has already loaded (its "load" fired before our
+        // listener) AND after the SPA sent its one-shot token request (so the
+        // handler above missed it) -- which left the viewer stuck "waiting for
+        // a token". By the time we run, the iframe and the SPA's message
+        // receiver are up, so post immediately; the listeners above remain as
+        // fallbacks for the rare case where this script loads before the iframe.
+        post();
     }
 
     function init() {


### PR DESCRIPTION
## Problem
On staging the log viewer iframe loaded but stayed *"waiting for an access token"*. Root cause: `log_viewer.js` is bundled into `web.assets_frontend_lazy` (loads ~532ms), **after** the iframe has loaded and the SPA has fired its one-shot `herd-log-token-request` — so it misses both the iframe `load` event and the request, and never posts the token. (Manually posting the token from the console delivered it fine, confirming the diagnosis.)

## Fix
`handoff()` now **posts the token immediately** when the script runs (by then the iframe + the SPA's message receiver are ready), keeping the `load`/request handlers as fallbacks for the rare script-loads-before-iframe ordering. JS/asset-only change.

After merge: bump `19.0-staging` + upgrade `odoo_herd_portal` so the rebuilt bundle includes the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)