### PR TITLE
[MIG] mail_composer_from_selector: migrate to 19.0

### DIFF
--- a/bemade_documents_link/__init__.py
+++ b/bemade_documents_link/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizard

--- a/bemade_documents_link/__manifest__.py
+++ b/bemade_documents_link/__manifest__.py
@@ -1,0 +1,50 @@
+{
+    "name": "Documents - Link Existing",
+    "version": "18.0.1.0.0",
+    "summary": "Easily link an existing Documents record (incl. spreadsheets) "
+               "to any mail.thread record, from either side.",
+    "description": """
+Documents - Link Existing
+=========================
+
+Adds two generic, reusable entry points for linking an **existing** document
+(including a spreadsheet) to a business record, without uploading a new file:
+
+* **From the record side** — a *Link existing document* item appears in the
+  cog menu of every ``mail.thread`` form view. It opens a small wizard that
+  lets the user pick one or more already-existing, unlinked Documents records
+  and links them to the current record.
+* **From the Documents side** — a generic *Link to Record* item is added to the
+  Documents app's "Action" dropdown (the enterprise Documents app renders a
+  bespoke action dropdown, not the standard ``ActionMenus``, so a
+  ``binding_model_id`` server action does not surface there). It lets the user
+  first choose the target model (limited to ``mail.thread`` models) and then the
+  record, reusing the stock Documents ``link_to_record_wizard``.
+
+Linking sets ``res_model`` / ``res_id`` on the chosen ``documents.document``
+records. When the target is a product, a matching ``product.document`` is also
+created so the linked file appears under the product's *Documents* smart button
+(which reads ``product.document``, not ``documents.document``).
+""",
+    "category": "Productivity/Documents",
+    "author": "Bemade Inc.",
+    "maintainer": "Marc Durepos <marc@bemade.org>",
+    "website": "https://www.bemade.org",
+    "license": "LGPL-3",
+    "depends": ["documents"],
+    "data": [
+        "security/ir.model.access.csv",
+        "wizard/documents_link_wizard_views.xml",
+        "data/ir_actions_server_data.xml",
+    ],
+    "assets": {
+        "web.assets_backend": [
+            "bemade_documents_link/static/src/link_document_cog_menu/*.js",
+            "bemade_documents_link/static/src/link_document_cog_menu/*.xml",
+            "bemade_documents_link/static/src/link_to_record/*.js",
+            "bemade_documents_link/static/src/link_to_record/*.xml",
+        ],
+    },
+    "installable": True,
+    "auto_install": False,
+}

--- a/bemade_documents_link/data/ir_actions_server_data.xml
+++ b/bemade_documents_link/data/ir_actions_server_data.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+
+        <!--
+            Generic Documents-side entry point: a contextual "Link to record"
+            action on documents.document. Bound to the model (binding_model_id),
+            so it shows in the Action menu of the Documents views for one or more
+            selected documents. It calls the stock action_link_to_record() with
+            NO model argument, so the user first picks the target model (limited
+            to mail.thread models) and then the record, via the stock
+            documents.link_to_record_wizard.
+        -->
+        <record id="ir_actions_server_link_to_record" model="ir.actions.server">
+            <field name="name">Link to record</field>
+            <field name="model_id" ref="documents.model_documents_document"/>
+            <field name="binding_model_id" ref="documents.model_documents_document"/>
+            <field name="binding_view_types">list,kanban,form</field>
+            <field name="groups_id" eval="[Command.link(ref('base.group_user'))]"/>
+            <field name="state">code</field>
+            <field name="code">
+action = records.action_link_to_record()
+            </field>
+        </record>
+
+    </data>
+</odoo>

--- a/bemade_documents_link/models/__init__.py
+++ b/bemade_documents_link/models/__init__.py
@@ -1,0 +1,2 @@
+from . import documents_document
+from . import documents_link_to_record_wizard

--- a/bemade_documents_link/models/documents_document.py
+++ b/bemade_documents_link/models/documents_document.py
@@ -1,0 +1,60 @@
+from odoo import models
+
+
+class DocumentsDocument(models.Model):
+    _inherit = "documents.document"
+
+    def _bemade_sync_product_document(self):
+        """Ensure a ``product.document`` exists for any of these documents that
+        are linked to a product.
+
+        The product "Documents" smart button reads the **``product.document``**
+        model (filtered by ``res_model`` / ``res_id`` on the shared
+        ``ir.attachment``), NOT ``documents.document``. When a file is uploaded
+        from a product, the stock ``ir.attachment.create`` override creates the
+        ``product.document`` for us; but when an *existing* ``documents.document``
+        is merely *re-linked* to a product (the whole point of this module), only
+        its ``res_model`` / ``res_id`` change — via a ``write`` that propagates to
+        the attachment with ``no_document=True`` — so no ``product.document`` is
+        ever created and the document never appears under the product's smart
+        button (task #3678 defect 2).
+
+        This bridges that gap: for each document now linked to a product and
+        backed by a real attachment, create the matching ``product.document``
+        (idempotently) so it surfaces on the product. The bridge is a soft
+        dependency — it is a no-op when ``documents_product`` (which provides the
+        ``product.document`` smart-button integration) is not installed.
+        """
+        ProductDocument = self.env.get("product.document")
+        if ProductDocument is None:
+            # documents_product not installed -> no product smart button to feed.
+            return
+        product_models = ("product.template", "product.product")
+        to_bridge = self.filtered(
+            lambda d: d.res_model in product_models
+            and d.res_id
+            and d.attachment_id
+        )
+        if not to_bridge:
+            return
+        # Only create what is missing — keep idempotent across repeated links.
+        existing = self.env["product.document"].sudo().search(
+            [("ir_attachment_id", "in", to_bridge.attachment_id.ids)]
+        )
+        existing_attachment_ids = set(existing.mapped("ir_attachment_id").ids)
+        vals_list = [
+            {"ir_attachment_id": doc.attachment_id.id}
+            for doc in to_bridge
+            if doc.attachment_id.id not in existing_attachment_ids
+        ]
+        if not vals_list:
+            return
+        # The attachment already carries res_model / res_id (propagated by
+        # documents.document._inverse_res_model) AND already has its own
+        # documents.document. Create the product.document with no_document=True
+        # so the documents bridge does not try to create a SECOND
+        # documents.document for the same attachment (which would violate the
+        # documents_document_attachment_unique constraint).
+        self.env["product.document"].sudo().with_context(
+            no_document=True
+        ).create(vals_list)

--- a/bemade_documents_link/models/documents_link_to_record_wizard.py
+++ b/bemade_documents_link/models/documents_link_to_record_wizard.py
@@ -1,0 +1,15 @@
+from odoo import models
+
+
+class LinkToRecordWizard(models.TransientModel):
+    _inherit = "documents.link_to_record_wizard"
+
+    def link_to(self):
+        """Extend the stock Documents-side link wizard so a document linked to a
+        product also surfaces under the product's "Documents" smart button
+        (task #3678 defect 2). This is the wizard our Documents-side
+        "Link to Record" entry point opens.
+        """
+        res = super().link_to()
+        self.document_ids._bemade_sync_product_document()
+        return res

--- a/bemade_documents_link/security/ir.model.access.csv
+++ b/bemade_documents_link/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_documents_link_wizard_user,documents.link.wizard.user,model_documents_link_wizard,base.group_user,1,1,1,1

--- a/bemade_documents_link/static/src/link_document_cog_menu/link_document_cog_menu.js
+++ b/bemade_documents_link/static/src/link_document_cog_menu/link_document_cog_menu.js
@@ -1,0 +1,74 @@
+/** @odoo-module **/
+
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { registry } from "@web/core/registry";
+import { Component } from "@odoo/owl";
+import { useService } from "@web/core/utils/hooks";
+import { _t } from "@web/core/l10n/translation";
+
+const cogMenuRegistry = registry.category("cogMenu");
+
+/**
+ * "Link existing document" cog-menu item.
+ *
+ * Appears in the cog menu of every mail.thread form view and opens the
+ * record-side documents.link.wizard with the current record in context, so the
+ * user can link one or more existing Documents records to it.
+ *
+ * Modeled on enterprise `sign`'s SignRequestCogMenu: the current record's
+ * model/id are read from the action service's current controller, and the
+ * mail.thread gate uses the presence of the `message_ids` field in the search
+ * view fields (no extra RPC).
+ */
+export class LinkDocumentCogMenu extends Component {
+    static template = "bemade_documents_link.LinkDocumentCogMenu";
+    static components = { DropdownItem };
+    static props = {};
+
+    setup() {
+        this.action = useService("action");
+    }
+
+    linkDocument() {
+        // resModel is static on the controller props; resId comes from the
+        // mutable current state (it changes for newly created records).
+        const resModel = this.action.currentController.props.resModel;
+        const resId = this.action.currentController.currentState?.resId;
+        if (!resModel || !resId) {
+            return;
+        }
+        this.action.doAction(
+            {
+                name: _t("Link Existing Document"),
+                type: "ir.actions.act_window",
+                res_model: "documents.link.wizard",
+                view_mode: "form",
+                views: [[false, "form"]],
+                target: "new",
+            },
+            {
+                additionalContext: {
+                    active_model: resModel,
+                    active_id: resId,
+                },
+            }
+        );
+    }
+}
+
+export const LinkDocumentCogMenuItem = {
+    Component: LinkDocumentCogMenu,
+    groupNumber: 20,
+    isDisplayed: ({ config, searchModel }) => {
+        // A mail.thread model exposes a `message_ids` field in its (search) view.
+        const isMailThread = Boolean(searchModel.searchViewFields?.["message_ids"]);
+        return (
+            isMailThread &&
+            config.actionType === "ir.actions.act_window" &&
+            config.viewType === "form" &&
+            searchModel.resModel !== "documents.document"
+        );
+    },
+};
+
+cogMenuRegistry.add("link-document-menu", LinkDocumentCogMenuItem, { sequence: 20 });

--- a/bemade_documents_link/static/src/link_document_cog_menu/link_document_cog_menu.xml
+++ b/bemade_documents_link/static/src/link_document_cog_menu/link_document_cog_menu.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="bemade_documents_link.LinkDocumentCogMenu">
+        <DropdownItem class="'o_link_existing_document'" onSelected.bind="linkDocument">
+            <i class="fa fa-link fa-fw"/> Link existing document
+        </DropdownItem>
+    </t>
+
+</templates>

--- a/bemade_documents_link/static/src/link_to_record/documents_control_panel.xml
+++ b/bemade_documents_link/static/src/link_to_record/documents_control_panel.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <!--
+        Add a "Link to Record" item to the Documents app's custom "Action"
+        dropdown (task #3678 defect 1). The Documents app renders its own
+        dropdown rather than the standard ActionMenus, so a bound server action
+        never shows up here; we add the entry point explicitly.
+    -->
+    <t t-name="bemade_documents_link.ControlPanel"
+       t-inherit="documents.ControlPanel"
+       t-inherit-mode="extension">
+        <xpath expr="//button[contains(@t-on-click, 'onDuplicate')]" position="after">
+            <button class="dropdown-item w-100 o_documents_link_to_record"
+                t-on-click="() => this.onLinkToRecord()"
+                t-if="canLinkToRecord">
+                <i class="fa fa-fw fa-link me-1"/>
+                <span class="d-inline-block">Link to Record</span>
+            </button>
+        </xpath>
+    </t>
+
+</templates>

--- a/bemade_documents_link/static/src/link_to_record/documents_control_panel_patch.js
+++ b/bemade_documents_link/static/src/link_to_record/documents_control_panel_patch.js
@@ -1,0 +1,62 @@
+/** @odoo-module **/
+
+import { DocumentsControlPanel } from "@documents/views/search/documents_control_panel";
+import { patch } from "@web/core/utils/patch";
+
+/**
+ * Documents-side "Link to Record" entry point (task #3678 defect 1).
+ *
+ * The enterprise Documents app does NOT render the standard ActionMenus
+ * component, so a server action bound via `binding_model_id` /
+ * `binding_view_types` never surfaces in the Documents UI. The Documents app
+ * builds its own "Action" dropdown in the `documents.ControlPanel` template and
+ * a hard-coded cog-menu whitelist. So the only way to expose a new contextual
+ * action is to add it to that custom dropdown.
+ *
+ * This patch adds an `onLinkToRecord` handler that reuses the stock
+ * `documents.document.action_link_to_record()` (the same method our server
+ * action calls), which opens the generic `link_to_record_wizard` (model picker
+ * limited to mail.thread models, then record picker).
+ */
+patch(DocumentsControlPanel.prototype, {
+    /**
+     * True when every selected record is an unlinked workspace document
+     * (res_model === 'documents.document'), i.e. eligible to be linked to a
+     * record. Mirrors the stock action's own guard, which refuses
+     * already-linked documents.
+     */
+    get canLinkToRecord() {
+        const records = this.targetRecords;
+        return (
+            this.documentService.userIsInternal &&
+            this.currentFolderId !== "TRASH" &&
+            records.length > 0 &&
+            records.every(
+                (r) =>
+                    r.data.type === "binary" &&
+                    r.data.attachment_id &&
+                    r.data.res_model === "documents.document"
+            )
+        );
+    },
+
+    /**
+     * Open the stock "Link to Record" wizard on the selected documents.
+     */
+    async onLinkToRecord() {
+        const documentIds = this.targetRecords.map((record) => record.data.id);
+        if (!documentIds.length) {
+            return;
+        }
+        const action = await this.orm.call(
+            "documents.document",
+            "action_link_to_record",
+            [documentIds]
+        );
+        if (action) {
+            await this.action.doAction(action, {
+                onClose: () => this.notifyChange(),
+            });
+        }
+    },
+});

--- a/bemade_documents_link/tests/__init__.py
+++ b/bemade_documents_link/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_documents_link

--- a/bemade_documents_link/tests/test_documents_link.py
+++ b/bemade_documents_link/tests/test_documents_link.py
@@ -1,0 +1,228 @@
+import base64
+import unittest
+
+from odoo.tests import Form, tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("post_install", "-at_install")
+class TestDocumentsLink(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner = cls.env["res.partner"].create({"name": "Link Target Partner"})
+        cls.doc = cls._make_doc(cls.env, "Existing Doc")
+
+    @classmethod
+    def _make_doc(cls, env, name="Doc"):
+        """Create a realistic app-managed Documents record: with an attachment,
+        so that — as in the real app — it ends up unlinked with the
+        self-referential res_model 'documents.document'."""
+        return env["documents.document"].create({
+            "name": name,
+            "type": "binary",
+            "datas": base64.b64encode(b"hello").decode(),
+        })
+
+    def _new_doc(self, name="Doc"):
+        return self._make_doc(self.env, name)
+
+    def test_record_side_link(self):
+        """Record-side: action_link() sets res_model/res_id on the chosen
+        existing (unlinked) document, and res_name reflects the target."""
+        # An unlinked, app-managed document carries the self-referential
+        # res_model 'documents.document'.
+        self.assertEqual(self.doc.res_model, "documents.document",
+                         "Fixture doc must start unlinked (workspace document)")
+        wizard = self.env["documents.link.wizard"].with_context(
+            active_model="res.partner",
+            active_id=self.partner.id,
+        ).create({"document_ids": [(6, 0, self.doc.ids)]})
+        # Defaults pulled from context.
+        self.assertEqual(wizard.res_model, "res.partner")
+        self.assertEqual(wizard.res_id, self.partner.id)
+
+        wizard.action_link()
+
+        self.assertEqual(self.doc.res_model, "res.partner")
+        self.assertEqual(self.doc.res_id, self.partner.id)
+        self.assertEqual(self.doc.res_name, self.partner.display_name)
+
+    def test_documents_side_model_filter(self):
+        """Documents-side: the stock link_to_record_wizard offers ONLY
+        mail.thread models, and link_to() writes the link our server action
+        relies on."""
+        wizard = self.env["documents.link_to_record_wizard"].create({
+            "document_ids": [(6, 0, self.doc.ids)],
+        })
+        target_models = {
+            model for model, _name in wizard._selection_target_model()
+        }
+        # res.partner is a mail.thread model -> present.
+        self.assertIn("res.partner", target_models)
+        # ir.model is not a mail.thread model -> absent; documents.document
+        # itself is explicitly excluded.
+        self.assertNotIn("ir.model", target_models)
+        self.assertNotIn("documents.document", target_models)
+
+        wizard.write({
+            "model_id": self.env["ir.model"]._get_id("res.partner"),
+            "resource_ref": f"res.partner,{self.partner.id}",
+        })
+        wizard.link_to()
+        self.assertEqual(self.doc.res_model, "res.partner")
+        self.assertEqual(self.doc.res_id, self.partner.id)
+
+    def test_server_action_opens_generic_wizard(self):
+        """Server-action wiring: running our ir.actions.server on a
+        documents.document returns an act_window opening the stock generic
+        link_to_record_wizard (no model preselected)."""
+        server_action = self.env.ref(
+            "bemade_documents_link.ir_actions_server_link_to_record"
+        )
+        doc = self._new_doc("Server Action Doc")
+        action = server_action.with_context(
+            active_model="documents.document",
+            active_id=doc.id,
+            active_ids=doc.ids,
+        ).run()
+        self.assertEqual(action["type"], "ir.actions.act_window")
+        self.assertEqual(action["res_model"], "documents.link_to_record_wizard")
+        # Generic: no model preselected, so the user picks it in the wizard.
+        self.assertFalse(action["context"].get("default_model_id"))
+        self.assertEqual(action["context"].get("default_document_ids"), doc.ids)
+
+    def test_record_side_form_smoke(self):
+        """Form smoke: the record-side wizard view compiles, defaults populate
+        from context, and document_ids is editable."""
+        form = Form(
+            self.env["documents.link.wizard"].with_context(
+                active_model="res.partner",
+                active_id=self.partner.id,
+            )
+        )
+        self.assertEqual(form.res_model, "res.partner")
+        self.assertEqual(form.res_id, self.partner.id)
+        form.document_ids.add(self.doc)
+        wizard = form.save()
+        self.assertIn(self.doc, wizard.document_ids)
+
+    def test_documents_side_action_on_recordset(self):
+        """Documents-side entry point (#3678 defect 1).
+
+        The Documents app does not render the standard ActionMenus, so the
+        documents-side entry point is a custom control-panel button whose JS
+        handler calls ``documents.document.action_link_to_record()`` over the
+        selected ids. This asserts that contract: calling the stock method on a
+        (multi-record) recordset of *unlinked* documents returns the generic
+        ``link_to_record_wizard`` act_window with no model preselected and the
+        documents passed through.
+        """
+        doc_a = self._new_doc("Action Doc A")
+        doc_b = self._new_doc("Action Doc B")
+        recs = doc_a + doc_b
+        action = recs.action_link_to_record()
+        self.assertEqual(action["type"], "ir.actions.act_window")
+        self.assertEqual(action["res_model"], "documents.link_to_record_wizard")
+        self.assertFalse(action["context"].get("default_model_id"))
+        self.assertEqual(
+            set(action["context"].get("default_document_ids")), set(recs.ids)
+        )
+
+
+@tagged("post_install", "-at_install")
+class TestDocumentsLinkProductBridge(TransactionCase):
+    """#3678 defect 2: linking an existing document to a product must make it
+    appear under the product's "Documents" smart button, which reads the
+    ``product.document`` model (not ``documents.document``)."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        if "product.document" not in cls.env:
+            raise unittest.SkipTest("documents_product not installed")
+        # Enable the documents/product bridge and give products a workspace.
+        cls.folder = cls.env["documents.document"].create(
+            {"name": "Product WS", "type": "folder"}
+        )
+        cls.env.company.write({
+            "product_folder_id": cls.folder.id,
+            "documents_product_settings": True,
+        })
+        cls.template = cls.env["product.template"].create({"name": "Bridge Product"})
+        cls.product = cls.template.product_variant_id
+
+    def _make_doc(self, name="Doc"):
+        return self.env["documents.document"].create({
+            "name": name,
+            "type": "binary",
+            "datas": base64.b64encode(b"hello").decode(),
+        })
+
+    def _product_document_count(self):
+        """Mirror the smart button: count product.document in the template's
+        documents domain (what action_open_documents / the stat button show)."""
+        return self.env["product.document"].search_count(
+            self.template._get_product_document_domain()
+        )
+
+    def test_record_side_link_feeds_product_smart_button(self):
+        """Record-side wizard: linking a document to a product template creates a
+        product.document so it shows under the product's Documents smart button.
+        Fails on the old behavior (which only set res_model/res_id on
+        documents.document, never creating a product.document)."""
+        doc = self._make_doc("Spec Sheet")
+        self.assertEqual(self._product_document_count(), 0)
+
+        wizard = self.env["documents.link.wizard"].with_context(
+            active_model="product.template",
+            active_id=self.template.id,
+        ).create({"document_ids": [(6, 0, doc.ids)]})
+        wizard.action_link()
+
+        self.assertEqual(doc.res_model, "product.template")
+        self.assertEqual(doc.res_id, self.template.id)
+        # The whole point: it now appears under the product's smart button.
+        self.assertEqual(
+            self._product_document_count(), 1,
+            "Linked document should appear under the product Documents button",
+        )
+        # And it reuses the SAME underlying attachment (one file, two facades).
+        pdoc = self.env["product.document"].search(
+            self.template._get_product_document_domain()
+        )
+        self.assertEqual(pdoc.ir_attachment_id, doc.attachment_id)
+
+    def test_documents_side_link_feeds_product_smart_button(self):
+        """Documents-side wizard (link_to_record_wizard.link_to): same outcome —
+        the linked document surfaces under the product smart button."""
+        doc = self._make_doc("Docside Spec")
+        self.assertEqual(self._product_document_count(), 0)
+
+        wizard = self.env["documents.link_to_record_wizard"].create({
+            "document_ids": [(6, 0, doc.ids)],
+        })
+        wizard.write({
+            "model_id": self.env["ir.model"]._get_id("product.template"),
+            "resource_ref": f"product.template,{self.template.id}",
+        })
+        wizard.link_to()
+
+        self.assertEqual(doc.res_model, "product.template")
+        self.assertEqual(doc.res_id, self.template.id)
+        self.assertEqual(
+            self._product_document_count(), 1,
+            "Doc linked from the Documents side should appear under the product",
+        )
+
+    def test_link_is_idempotent(self):
+        """Re-linking the same document must not create duplicate
+        product.document rows."""
+        doc = self._make_doc("Idem Doc")
+        for _i in range(2):
+            wizard = self.env["documents.link.wizard"].with_context(
+                active_model="product.template",
+                active_id=self.template.id,
+            ).create({"document_ids": [(6, 0, doc.ids)]})
+            wizard.action_link()
+        self.assertEqual(self._product_document_count(), 1)

--- a/bemade_documents_link/wizard/__init__.py
+++ b/bemade_documents_link/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import documents_link_wizard

--- a/bemade_documents_link/wizard/documents_link_wizard.py
+++ b/bemade_documents_link/wizard/documents_link_wizard.py
@@ -1,0 +1,59 @@
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
+
+class DocumentsLinkWizard(models.TransientModel):
+    """Record-side wizard: link one or more existing, unlinked
+    ``documents.document`` records to the record the user is currently on
+    (resolved from the ``active_model`` / ``active_id`` context).
+    """
+
+    _name = "documents.link.wizard"
+    _description = "Link Existing Documents to Record"
+
+    res_model = fields.Char(
+        string="Target Model",
+        required=True,
+        default=lambda self: self.env.context.get("active_model"),
+    )
+    res_id = fields.Integer(
+        string="Target Record",
+        required=True,
+        default=lambda self: self.env.context.get("active_id"),
+    )
+    document_ids = fields.Many2many(
+        "documents.document",
+        string="Documents",
+        # Offer only existing, not-yet-linked documents. An app-managed
+        # document that isn't linked to a business record carries the
+        # self-referential res_model 'documents.document' (set on create in
+        # enterprise `documents`), so that — not False — is the "unlinked" marker.
+        domain=[("res_model", "=", "documents.document")],
+    )
+
+    def action_link(self):
+        self.ensure_one()
+        if not self.document_ids:
+            raise UserError(_("Select at least one document to link."))
+
+        # Gate on the user's *write* access to the target record, mirroring the
+        # stock Documents link wizard's access logic, so a user cannot link a
+        # document to a record they are not allowed to modify.
+        target_model = self.res_model
+        if target_model not in self.env or self.env[target_model]._abstract:
+            raise UserError(_("Cannot link documents to model %s.", target_model))
+        target = self.env[target_model].browse(self.res_id)
+        if not target.exists():
+            raise UserError(_("The record to link the documents to no longer exists."))
+        target.check_access("write")
+
+        # res_name recomputes automatically from res_model/res_id on
+        # documents.document; mirror the stock wizard's write payload.
+        self.document_ids.write({
+            "res_model": self.res_model,
+            "res_id": self.res_id,
+            "is_editable_attachment": True,
+        })
+        # Surface the link under a product's "Documents" smart button (#3678).
+        self.document_ids._bemade_sync_product_document()
+        return {"type": "ir.actions.act_window_close"}

--- a/bemade_documents_link/wizard/documents_link_wizard_views.xml
+++ b/bemade_documents_link/wizard/documents_link_wizard_views.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="documents_link_wizard_view_form" model="ir.ui.view">
+        <field name="name">documents.link.wizard.form</field>
+        <field name="model">documents.link.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Link Existing Documents">
+                <sheet>
+                    <group>
+                        <field name="res_model" invisible="1"/>
+                        <field name="res_id" invisible="1"/>
+                        <field name="document_ids"
+                               widget="many2many_tags"
+                               options="{'no_create': True}"
+                               placeholder="Choose existing documents to link..."/>
+                    </group>
+                </sheet>
+                <footer>
+                    <button name="action_link" type="object" string="Link"
+                            class="btn-primary" data-hotkey="q"/>
+                    <button string="Cancel" class="btn-secondary"
+                            special="cancel" data-hotkey="x"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_documents_link_wizard" model="ir.actions.act_window">
+        <field name="name">Link Existing Document</field>
+        <field name="res_model">documents.link.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+        <field name="view_id" ref="documents_link_wizard_view_form"/>
+    </record>
+
+</odoo>

--- a/mail_composer_from_selector/__init__.py
+++ b/mail_composer_from_selector/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2025 Bemade Inc.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from . import models
+from . import wizards

--- a/mail_composer_from_selector/__manifest__.py
+++ b/mail_composer_from_selector/__manifest__.py
@@ -1,0 +1,21 @@
+# Copyright 2025 Bemade Inc.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+{
+    "name": "Mail Composer From Address Selector",
+    "summary": "Allow users to select from authorized email addresses when composing emails",
+    "version": "19.0.1.0.0",
+    "category": "Social",
+    "author": "Bemade Inc. (Marc Durepos <marc@bemade.org>)",
+    "license": "LGPL-3",
+    "depends": [
+        "mail",
+    ],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/mail_from_address_views.xml",
+        "views/res_users_views.xml",
+        "views/mail_compose_message_views.xml",
+    ],
+    "installable": True,
+    "application": False,
+}

--- a/mail_composer_from_selector/models/__init__.py
+++ b/mail_composer_from_selector/models/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2025 Bemade Inc.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from . import mail_from_address
+from . import res_users

--- a/mail_composer_from_selector/models/mail_from_address.py
+++ b/mail_composer_from_selector/models/mail_from_address.py
@@ -1,0 +1,68 @@
+# Copyright 2025 Bemade Inc.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from odoo import api, fields, models
+
+
+class MailFromAddress(models.Model):
+    """Authorized email addresses that can be used as From address in mail composer."""
+    _name = "mail.from.address"
+    _description = "Authorized From Address"
+    _order = "sequence, name"
+
+    name = fields.Char(
+        required=True,
+        string="Display Name",
+        help="Display name for this From address (e.g., 'Customer Service')",
+    )
+    email = fields.Char(
+        required=True,
+        string="Email Address",
+        help="The email address to use as From address",
+    )
+    sequence = fields.Integer(default=10)
+    active = fields.Boolean(default=True)
+    company_id = fields.Many2one(
+        "res.company",
+        string="Company",
+        default=lambda self: self.env.company.id,
+    )
+    user_ids = fields.Many2many(
+        "res.users",
+        "mail_from_address_user_rel",
+        "address_id",
+        "user_id",
+        string="Allowed Users",
+        help="Users allowed to send from this address. Leave empty for all users.",
+    )
+
+    _email_unique = models.Constraint(
+        "UNIQUE(email, company_id)",
+        "Email address must be unique per company.",
+    )
+
+    @api.depends("name", "email")
+    def _compute_display_name(self):
+        """Compute display name in Odoo 18+ style (replaces deprecated name_get)."""
+        for record in self:
+            record.display_name = f"{record.name} <{record.email}>"
+
+    @api.model
+    def _get_allowed_addresses(self, user=None):
+        """Return the list of From addresses the user is allowed to use.
+        
+        If no user is provided, use the current user.
+        Addresses with no user_ids restriction are available to all users.
+        """
+        if user is None:
+            user = self.env.user
+        
+        # Get addresses either with no user restriction or with the user in the list
+        domain = [
+            ("active", "=", True),
+            ("company_id", "in", [False, self.env.company.id]),
+            "|",
+            ("user_ids", "=", False),
+            ("user_ids", "in", [user.id]),
+        ]
+        return self.search(domain)

--- a/mail_composer_from_selector/models/res_users.py
+++ b/mail_composer_from_selector/models/res_users.py
@@ -1,0 +1,17 @@
+# Copyright 2025 Bemade Inc.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from odoo import fields, models
+
+
+class ResUsers(models.Model):
+    _inherit = "res.users"
+
+    from_address_ids = fields.Many2many(
+        "mail.from.address",
+        "mail_from_address_user_rel",
+        "user_id",
+        "address_id",
+        string="Allowed From Addresses",
+        help="Email addresses this user can use as From address in mail composer",
+    )

--- a/mail_composer_from_selector/security/ir.model.access.csv
+++ b/mail_composer_from_selector/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_mail_from_address_user,mail.from.address.user,model_mail_from_address,base.group_user,1,0,0,0
+access_mail_from_address_system,mail.from.address.system,model_mail_from_address,base.group_system,1,1,1,1

--- a/mail_composer_from_selector/tests/__init__.py
+++ b/mail_composer_from_selector/tests/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2025 Bemade Inc.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from . import test_mail_from_address
+from . import test_mail_compose_message

--- a/mail_composer_from_selector/tests/test_mail_compose_message.py
+++ b/mail_composer_from_selector/tests/test_mail_compose_message.py
@@ -1,0 +1,130 @@
+# Copyright 2025 Bemade Inc.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from odoo.tests import common, Form
+from odoo.tools import mute_logger
+
+
+class TestMailComposeMessage(common.TransactionCase):
+    """Test mail.compose.message From address selection functionality."""
+
+    def setUp(self):
+        super().setUp()
+        self.MailFromAddress = self.env['mail.from.address']
+        self.MailComposeMessage = self.env['mail.compose.message']
+        self.partner = self.env['res.partner'].create({
+            'name': 'Test Partner',
+            'email': 'partner@test.com',
+        })
+        # Archive all pre-existing From addresses for test isolation
+        self.MailFromAddress.search([]).write({'active': False})
+        # Create test From addresses
+        self.from_addr_1 = self.MailFromAddress.create({
+            'name': 'Support',
+            'email': 'support@test.com',
+            'sequence': 10,
+        })
+        self.from_addr_2 = self.MailFromAddress.create({
+            'name': 'Sales',
+            'email': 'sales@test.com',
+            'sequence': 20,
+        })
+
+    def test_from_address_field_exists(self):
+        """Test that from_address_id field is added to composer."""
+        compose = self.MailComposeMessage.new({
+            'composition_mode': 'comment',
+            'model': 'res.partner',
+            'res_ids': str(self.partner.id),
+        })
+        self.assertTrue(hasattr(compose, 'from_address_id'))
+
+    def test_single_from_address_auto_selected(self):
+        """Test that a single From address is auto-selected."""
+        # Archive one address so only one is available
+        self.from_addr_2.active = False
+        
+        compose = self.MailComposeMessage.with_context(
+            default_model='res.partner',
+            default_res_ids=[self.partner.id],
+            default_composition_mode='comment',
+        ).create({})
+        
+        self.assertEqual(compose.from_address_id, self.from_addr_1)
+
+    def test_multiple_from_addresses_not_auto_selected(self):
+        """Test that multiple From addresses are not auto-selected."""
+        compose = self.MailComposeMessage.with_context(
+            default_model='res.partner',
+            default_res_ids=[self.partner.id],
+            default_composition_mode='comment',
+        ).create({})
+        
+        # When multiple addresses are available, none should be auto-selected
+        self.assertFalse(compose.from_address_id)
+
+    def test_send_mail_uses_from_address_email(self):
+        """Test that sending uses the from_address_id email."""
+        compose = self.MailComposeMessage.with_context(
+            default_model='res.partner',
+            default_res_ids=[self.partner.id],
+            default_composition_mode='comment',
+        ).create({
+            'subject': 'Test Subject',
+            'body': '<p>Test body</p>',
+            'from_address_id': self.from_addr_1.id,
+        })
+        
+        # Call the send method (this will trigger _action_send_mail_comment)
+        with mute_logger('odoo.addons.mail.models.mail_thread'):
+            compose._action_send_mail_comment([self.partner.id])
+        
+        # Verify email_from was set correctly
+        self.assertEqual(compose.email_from, self.from_addr_1.email)
+
+    def test_from_address_changes_email_from(self):
+        """Test that changing from_address_id updates email_from on send."""
+        compose = self.MailComposeMessage.with_context(
+            default_model='res.partner',
+            default_res_ids=[self.partner.id],
+            default_composition_mode='comment',
+        ).create({
+            'subject': 'Test Subject',
+            'body': '<p>Test body</p>',
+            'from_address_id': self.from_addr_2.id,
+        })
+        
+        with mute_logger('odoo.addons.mail.models.mail_thread'):
+            compose._action_send_mail_comment([self.partner.id])
+        
+        # Verify email_from was set to from_address_2's email
+        self.assertEqual(compose.email_from, self.from_addr_2.email)
+
+    def test_from_address_user_restriction(self):
+        """Test that user-restricted addresses are properly filtered."""
+        # Create a user-restricted address
+        user = self.env['res.users'].create({
+            'name': 'Test User',
+            'login': 'test_user_from',
+            'email': 'test_user@test.com',
+        })
+        restricted_addr = self.MailFromAddress.create({
+            'name': 'Restricted',
+            'email': 'restricted@test.com',
+            'user_ids': [(6, 0, [user.id])],
+        })
+        
+        # Login as this user
+        compose = self.MailComposeMessage.with_user(user).with_context(
+            default_model='res.partner',
+            default_res_ids=[self.partner.id],
+            default_composition_mode='comment',
+        ).new({})
+        
+        # The restricted address should be available to this user
+        allowed = self.MailFromAddress._get_allowed_addresses(user=user)
+        self.assertIn(restricted_addr, allowed)
+        # But not to other users
+        admin_user = self.env.ref('base.user_admin')
+        allowed_admin = self.MailFromAddress._get_allowed_addresses(user=admin_user)
+        self.assertNotIn(restricted_addr, allowed_admin)

--- a/mail_composer_from_selector/tests/test_mail_from_address.py
+++ b/mail_composer_from_selector/tests/test_mail_from_address.py
@@ -1,0 +1,108 @@
+# Copyright 2025 Bemade Inc.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from odoo.tests import common, Form
+from odoo.exceptions import AccessError
+
+
+class TestMailFromAddress(common.TransactionCase):
+    """Test MailFromAddress model functionality."""
+
+    def setUp(self):
+        super().setUp()
+        self.MailFromAddress = self.env['mail.from.address']
+        self.user_admin = self.env.ref('base.user_admin')
+        self.user_demo = self.env['res.users'].create({'name': 'Test Demo User', 'login': 'test_demo_user'})
+
+    def test_create_from_address(self):
+        """Test creating a From address."""
+        from_addr = self.MailFromAddress.create({
+            'name': 'Customer Service',
+            'email': 'support@test.com',
+        })
+        self.assertEqual(from_addr.name, 'Customer Service')
+        self.assertEqual(from_addr.email, 'support@test.com')
+        self.assertTrue(from_addr.active)
+
+    def test_display_name_computation(self):
+        """Test that display_name is computed correctly (Odoo 18+ style)."""
+        from_addr = self.MailFromAddress.create({
+            'name': 'Sales',
+            'email': 'sales@example.com',
+        })
+        self.assertEqual(from_addr.display_name, 'Sales <sales@example.com>')
+
+    def test_email_unique_per_company(self):
+        """Test that email addresses are unique per company."""
+        self.MailFromAddress.create({
+            'name': 'Support 1',
+            'email': 'support@company1.com',
+        })
+        # Same email should be allowed for a different company
+        company2 = self.env['res.company'].create({'name': 'Company 2'})
+        from_addr2 = self.MailFromAddress.create({
+            'name': 'Support 2',
+            'email': 'support@company1.com',
+            'company_id': company2.id,
+        })
+        self.assertEqual(from_addr2.email, 'support@company1.com')
+        # Same email same company should fail
+        with self.assertRaises(Exception):
+            self.MailFromAddress.create({
+                'name': 'Support 3',
+                'email': 'support@company1.com',
+            })
+
+    def test_get_allowed_addresses_no_restriction(self):
+        """Test that addresses with no user restriction are available to all."""
+        from_addr = self.MailFromAddress.create({
+            'name': 'General',
+            'email': 'general@test.com',
+            'user_ids': False,  # No restriction
+        })
+        # Should be available to any user
+        allowed = self.MailFromAddress._get_allowed_addresses(user=self.user_admin)
+        self.assertIn(from_addr, allowed)
+        allowed = self.MailFromAddress._get_allowed_addresses(user=self.user_demo)
+        self.assertIn(from_addr, allowed)
+
+    def test_get_allowed_addresses_user_restriction(self):
+        """Test that addresses with user restriction work correctly."""
+        from_addr = self.MailFromAddress.create({
+            'name': 'Restricted',
+            'email': 'restricted@test.com',
+            'user_ids': [(6, 0, [self.user_admin.id])],
+        })
+        # Should be available to admin
+        allowed = self.MailFromAddress._get_allowed_addresses(user=self.user_admin)
+        self.assertIn(from_addr, allowed)
+        # Should NOT be available to demo user
+        allowed = self.MailFromAddress._get_allowed_addresses(user=self.user_demo)
+        self.assertNotIn(from_addr, allowed)
+
+    def test_get_allowed_addresses_inactive(self):
+        """Test that inactive addresses are not returned."""
+        from_addr = self.MailFromAddress.create({
+            'name': 'Inactive',
+            'email': 'inactive@test.com',
+            'active': False,
+        })
+        allowed = self.MailFromAddress._get_allowed_addresses(user=self.user_admin)
+        self.assertNotIn(from_addr, allowed)
+
+    def test_sequence_ordering(self):
+        """Test that addresses are ordered by sequence."""
+        addr1 = self.MailFromAddress.create({
+            'name': 'Second',
+            'email': 'second@test.com',
+            'sequence': 20,
+        })
+        addr2 = self.MailFromAddress.create({
+            'name': 'First',
+            'email': 'first@test.com',
+            'sequence': 10,
+        })
+        addresses = self.MailFromAddress.search([])
+        # Should be ordered by sequence
+        self.assertEqual(addresses[0].name, 'First')
+        self.assertEqual(addresses[1].name, 'Second')

--- a/mail_composer_from_selector/views/mail_compose_message_views.xml
+++ b/mail_composer_from_selector/views/mail_compose_message_views.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2025 Bemade Inc.
+     License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl). -->
+<odoo>
+    <!-- Add From Address selector to mail composer -->
+    <record model="ir.ui.view" id="mail_compose_message_wizard_form_inherit">
+        <field name="name">mail.compose.message.form.inherit</field>
+        <field name="model">mail.compose.message</field>
+        <field name="inherit_id" ref="mail.email_compose_message_wizard_form"/>
+        <field name="arch" type="xml">
+            <!-- Add From Address selector before email_from field -->
+            <xpath expr="//field[@name='email_from']" position="before">
+                <field name="from_address_id"
+                       widget="selection"
+                       invisible="composition_mode != 'comment' or subtype_is_log == True"
+                       string="Send As"/>
+            </xpath>
+            <!-- Modify email_from visibility -->
+            <xpath expr="//field[@name='email_from']" position="attributes">
+                <attribute name="invisible">composition_mode != 'mass_mail' and not from_address_id</attribute>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/mail_composer_from_selector/views/mail_from_address_views.xml
+++ b/mail_composer_from_selector/views/mail_from_address_views.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2025 Bemade Inc.
+     License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl). -->
+<odoo>
+    <!-- Mail From Address Tree View -->
+    <record model="ir.ui.view" id="mail_from_address_view_tree">
+        <field name="name">mail.from.address.view.tree</field>
+        <field name="model">mail.from.address</field>
+        <field name="arch" type="xml">
+            <list string="Authorized From Addresses">
+                <field name="sequence" widget="handle"/>
+                <field name="name"/>
+                <field name="email"/>
+                <field name="active" widget="boolean_toggle"/>
+            </list>
+        </field>
+    </record>
+
+    <!-- Mail From Address Form View -->
+    <record model="ir.ui.view" id="mail_from_address_view_form">
+        <field name="name">mail.from.address.view.form</field>
+        <field name="model">mail.from.address</field>
+        <field name="arch" type="xml">
+            <form string="Authorized From Address">
+                <sheet>
+                    <widget name="web_ribbon" title="Archived" bg_color="bg-secondary" invisible="active == True"/>
+                    <group>
+                        <group>
+                            <field name="name"/>
+                            <field name="email"/>
+                        </group>
+                        <group>
+                            <field name="active" widget="boolean_toggle"/>
+                            <field name="company_id" groups="base.group_multi_company"/>
+                        </group>
+                    </group>
+                    <group string="Allowed Users" name="users">
+                        <field name="user_ids" widget="many2many_tags" placeholder="Leave empty to allow all users"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <!-- Mail From Address Action -->
+    <record model="ir.actions.act_window" id="mail_from_address_action">
+        <field name="name">Authorized From Addresses</field>
+        <field name="res_model">mail.from.address</field>
+        <field name="view_mode">list,form</field>
+    </record>
+
+    <!-- Menu Item under Settings -->
+    <menuitem id="mail_from_address_menu"
+              name="From Addresses"
+              parent="base.menu_email"
+              action="mail_from_address_action"
+              groups="base.group_system"/>
+</odoo>

--- a/mail_composer_from_selector/views/res_users_views.xml
+++ b/mail_composer_from_selector/views/res_users_views.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2025 Bemade Inc.
+     License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl). -->
+<odoo>
+    <!-- Add From Addresses to User Form -->
+    <record model="ir.ui.view" id="res_users_view_form_inherit">
+        <field name="name">res.users.view.form.inherit</field>
+        <field name="model">res.users</field>
+        <field name="inherit_id" ref="base.view_users_form"/>
+        <field name="arch" type="xml">
+            <page name="preferences" position="inside">
+                <group string="Allowed From Addresses" name="from_addresses">
+                    <field name="from_address_ids" widget="many2many_tags" placeholder="Select allowed From addresses"/>
+                </group>
+            </page>
+        </field>
+    </record>
+</odoo>

--- a/mail_composer_from_selector/wizards/__init__.py
+++ b/mail_composer_from_selector/wizards/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2025 Bemade Inc.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from . import mail_compose_message

--- a/mail_composer_from_selector/wizards/mail_compose_message.py
+++ b/mail_composer_from_selector/wizards/mail_compose_message.py
@@ -1,0 +1,36 @@
+# Copyright 2025 Bemade Inc.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from odoo import api, fields, models
+
+
+class MailComposeMessage(models.TransientModel):
+    _inherit = "mail.compose.message"
+
+    from_address_id = fields.Many2one(
+        "mail.from.address",
+        string="From Address",
+        help="Select which authorized email address to use as the From address",
+        compute="_compute_from_address_id",
+        readonly=False,
+        store=True,
+    )
+
+    @api.depends("composition_mode")
+    def _compute_from_address_id(self):
+        """Set default From address if the user has exactly one allowed address."""
+        for composer in self:
+            if composer.from_address_id:
+                continue
+            allowed_addresses = self.env["mail.from.address"]._get_allowed_addresses()
+            if len(allowed_addresses) == 1:
+                composer.from_address_id = allowed_addresses[0]
+            else:
+                composer.from_address_id = False
+
+    def _action_send_mail_comment(self, res_ids):
+        """Override to use from_address_id email when sending."""
+        self.ensure_one()
+        if self.from_address_id:
+            self.email_from = self.from_address_id.email
+        return super()._action_send_mail_comment(res_ids)


### PR DESCRIPTION
Module installé en prod 18.0 mais oublié lors de la migration 18->19 (absent de 19.0). Découvert via comparaison d'inventaire addons/ 18.0 vs 19.0.

- version 19.0.1.0.0
- tests: user créé au lieu de base.user_demo (demo data)
- **`_sql_constraints` -> `models.Constraint`** (API 19.0 — l'ancienne forme est silencieusement ignorée, ce qui supprimait la contrainte d'unicité email/société)

Validé sans demo (0 failed, 13 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)