### PR TITLE
test(bemade_mail_gateway): make no-route test catch-all independent

### DIFF
--- a/bemade_mail_gateway/tests/test_controller.py
+++ b/bemade_mail_gateway/tests/test_controller.py
@@ -135,11 +135,20 @@ class TestMailGatewayController(HttpCase):
         self.assertEqual(body["error"], "bad_request")
 
     def test_process_with_no_alias_returns_422(self):
-        """No `alias@example.org` exists in this DB → 422 no_route."""
+        """A recipient on a domain Odoo has no alias_domain for cannot be
+        routed (no matching alias, no catch-all) → 422 no_route.
+
+        Use an unknown domain rather than `example.org`: DBs that configure a
+        catch-all on the alias domain (e.g. DurPro) would otherwise route the
+        unmatched mail to it and return 200.
+        """
         _, raw = self.Token.action_generate("ctl-no-alias")
+        unroutable = SAMPLE_RAW.replace(
+            b"To: alias@example.org", b"To: alias@no-such-domain.invalid"
+        )
         r = self._post(
             "/bemade/mail-gateway/process",
-            body=SAMPLE_RAW,
+            body=unroutable,
             headers={"X-Bemade-Token": raw},
         )
         self.assertEqual(r.status_code, 422)


### PR DESCRIPTION
`test_process_with_no_alias_returns_422` envoyait à `alias@example.org`, routable via le catch-all du domaine alias dans les DB qui en configurent un (ex: DurPro) → le mail non matché était capté → 200 au lieu de 422.

Fix: envoyer à un domaine inconnu (sans `alias_domain`) → ni alias ni catch-all → 422 déterministe partout. Découvert en re-symlinkant le module dans DurPro (CI DurPro échouait, CI bemade passait). Validé localement avec un catch-all configuré sur example.org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)