### PR TITLE
test(product_supplierinfo_tracking): count only own chatter messages

### DIFF
--- a/product_supplierinfo_tracking/tests/test_product_supplierinfo_tracking.py
+++ b/product_supplierinfo_tracking/tests/test_product_supplierinfo_tracking.py
@@ -260,8 +260,15 @@ class TestProductSupplierinfoTracking(TransactionCase):
         supplierinfo1.write({"price": 12.0})
         supplierinfo2.write({"price": 9.0})
 
-        # Should have messages for both modifications
-        messages = self.product_template.message_ids
+        # Should have messages for both modifications. Count only this
+        # module's supplierinfo-tracking messages (identified by their
+        # "Price modified for" header text): other modules installed alongside
+        # may post their own messages on the template when a supplierinfo is
+        # written. Match on the human text rather than the data-oe-model
+        # attribute, which Odoo's HTML sanitizer rewrites.
+        messages = self.product_template.message_ids.filtered(
+            lambda m: m.body and "Price modified for" in m.body
+        )
         self.assertEqual(
             len(messages), 2, "Should have messages for both supplierinfo modifications"
         )


### PR DESCRIPTION
`test_multiple_supplierinfo_tracking` assertait exactement 2 messages sur le template — fragile car d'autres modules postent aussi sur le chatter lors d'un write supplierinfo (install complète DurPro). Filtre sur le texte 'Price modified for' du module. Validé contre le set complet bemade-addons. Débloque le re-symlink dans DurPro (MR #380).

🤖 Generated with [Claude Code](https://claude.com/claude-code)