### PR TITLE
[MIG] bemade_documents_link: migrate to 19.0

### DIFF
--- a/bemade_documents_link/__init__.py
+++ b/bemade_documents_link/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizard

--- a/bemade_documents_link/__manifest__.py
+++ b/bemade_documents_link/__manifest__.py
@@ -1,0 +1,50 @@
+{
+    "name": "Documents - Link Existing",
+    "version": "19.0.1.0.0",
+    "summary": "Easily link an existing Documents record (incl. spreadsheets) "
+               "to any mail.thread record, from either side.",
+    "description": """
+Documents - Link Existing
+=========================
+
+Adds two generic, reusable entry points for linking an **existing** document
+(including a spreadsheet) to a business record, without uploading a new file:
+
+* **From the record side** — a *Link existing document* item appears in the
+  cog menu of every ``mail.thread`` form view. It opens a small wizard that
+  lets the user pick one or more already-existing, unlinked Documents records
+  and links them to the current record.
+* **From the Documents side** — a generic *Link to Record* item is added to the
+  Documents app's "Action" dropdown (the enterprise Documents app renders a
+  bespoke action dropdown, not the standard ``ActionMenus``, so a
+  ``binding_model_id`` server action does not surface there). It lets the user
+  first choose the target model (limited to ``mail.thread`` models) and then the
+  record, reusing the stock Documents ``link_to_record_wizard``.
+
+Linking sets ``res_model`` / ``res_id`` on the chosen ``documents.document``
+records. When the target is a product, a matching ``product.document`` is also
+created so the linked file appears under the product's *Documents* smart button
+(which reads ``product.document``, not ``documents.document``).
+""",
+    "category": "Productivity/Documents",
+    "author": "Bemade Inc.",
+    "maintainer": "Marc Durepos <marc@bemade.org>",
+    "website": "https://www.bemade.org",
+    "license": "LGPL-3",
+    "depends": ["documents"],
+    "data": [
+        "security/ir.model.access.csv",
+        "wizard/documents_link_wizard_views.xml",
+        "data/ir_actions_server_data.xml",
+    ],
+    "assets": {
+        "web.assets_backend": [
+            "bemade_documents_link/static/src/link_document_cog_menu/*.js",
+            "bemade_documents_link/static/src/link_document_cog_menu/*.xml",
+            "bemade_documents_link/static/src/link_to_record/*.js",
+            "bemade_documents_link/static/src/link_to_record/*.xml",
+        ],
+    },
+    "installable": True,
+    "auto_install": False,
+}

--- a/bemade_documents_link/data/ir_actions_server_data.xml
+++ b/bemade_documents_link/data/ir_actions_server_data.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+
+        <!--
+            Generic Documents-side entry point: a contextual "Link to record"
+            action on documents.document. Bound to the model (binding_model_id),
+            so it shows in the Action menu of the Documents views for one or more
+            selected documents. It calls the stock action_link_to_record() with
+            NO model argument, so the user first picks the target model (limited
+            to mail.thread models) and then the record, via the stock
+            documents.link_to_record_wizard.
+        -->
+        <record id="ir_actions_server_link_to_record" model="ir.actions.server">
+            <field name="name">Link to record</field>
+            <field name="model_id" ref="documents.model_documents_document"/>
+            <field name="binding_model_id" ref="documents.model_documents_document"/>
+            <field name="binding_view_types">list,kanban,form</field>
+            <field name="group_ids" eval="[Command.link(ref('base.group_user'))]"/>
+            <field name="state">code</field>
+            <field name="code">
+action = records.action_link_to_record()
+            </field>
+        </record>
+
+    </data>
+</odoo>

--- a/bemade_documents_link/models/__init__.py
+++ b/bemade_documents_link/models/__init__.py
@@ -1,0 +1,2 @@
+from . import documents_document
+from . import documents_link_to_record_wizard

--- a/bemade_documents_link/models/documents_document.py
+++ b/bemade_documents_link/models/documents_document.py
@@ -1,0 +1,60 @@
+from odoo import models
+
+
+class DocumentsDocument(models.Model):
+    _inherit = "documents.document"
+
+    def _bemade_sync_product_document(self):
+        """Ensure a ``product.document`` exists for any of these documents that
+        are linked to a product.
+
+        The product "Documents" smart button reads the **``product.document``**
+        model (filtered by ``res_model`` / ``res_id`` on the shared
+        ``ir.attachment``), NOT ``documents.document``. When a file is uploaded
+        from a product, the stock ``ir.attachment.create`` override creates the
+        ``product.document`` for us; but when an *existing* ``documents.document``
+        is merely *re-linked* to a product (the whole point of this module), only
+        its ``res_model`` / ``res_id`` change — via a ``write`` that propagates to
+        the attachment with ``no_document=True`` — so no ``product.document`` is
+        ever created and the document never appears under the product's smart
+        button (task #3678 defect 2).
+
+        This bridges that gap: for each document now linked to a product and
+        backed by a real attachment, create the matching ``product.document``
+        (idempotently) so it surfaces on the product. The bridge is a soft
+        dependency — it is a no-op when ``documents_product`` (which provides the
+        ``product.document`` smart-button integration) is not installed.
+        """
+        ProductDocument = self.env.get("product.document")
+        if ProductDocument is None:
+            # documents_product not installed -> no product smart button to feed.
+            return
+        product_models = ("product.template", "product.product")
+        to_bridge = self.filtered(
+            lambda d: d.res_model in product_models
+            and d.res_id
+            and d.attachment_id
+        )
+        if not to_bridge:
+            return
+        # Only create what is missing — keep idempotent across repeated links.
+        existing = self.env["product.document"].sudo().search(
+            [("ir_attachment_id", "in", to_bridge.attachment_id.ids)]
+        )
+        existing_attachment_ids = set(existing.mapped("ir_attachment_id").ids)
+        vals_list = [
+            {"ir_attachment_id": doc.attachment_id.id}
+            for doc in to_bridge
+            if doc.attachment_id.id not in existing_attachment_ids
+        ]
+        if not vals_list:
+            return
+        # The attachment already carries res_model / res_id (propagated by
+        # documents.document._inverse_res_model) AND already has its own
+        # documents.document. Create the product.document with no_document=True
+        # so the documents bridge does not try to create a SECOND
+        # documents.document for the same attachment (which would violate the
+        # documents_document_attachment_unique constraint).
+        self.env["product.document"].sudo().with_context(
+            no_document=True
+        ).create(vals_list)

--- a/bemade_documents_link/models/documents_link_to_record_wizard.py
+++ b/bemade_documents_link/models/documents_link_to_record_wizard.py
@@ -1,0 +1,15 @@
+from odoo import models
+
+
+class LinkToRecordWizard(models.TransientModel):
+    _inherit = "documents.link_to_record_wizard"
+
+    def link_to(self):
+        """Extend the stock Documents-side link wizard so a document linked to a
+        product also surfaces under the product's "Documents" smart button
+        (task #3678 defect 2). This is the wizard our Documents-side
+        "Link to Record" entry point opens.
+        """
+        res = super().link_to()
+        self.document_ids._bemade_sync_product_document()
+        return res

--- a/bemade_documents_link/security/ir.model.access.csv
+++ b/bemade_documents_link/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_documents_link_wizard_user,documents.link.wizard.user,model_documents_link_wizard,base.group_user,1,1,1,1

--- a/bemade_documents_link/static/src/link_document_cog_menu/link_document_cog_menu.js
+++ b/bemade_documents_link/static/src/link_document_cog_menu/link_document_cog_menu.js
@@ -1,0 +1,74 @@
+/** @odoo-module **/
+
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { registry } from "@web/core/registry";
+import { Component } from "@odoo/owl";
+import { useService } from "@web/core/utils/hooks";
+import { _t } from "@web/core/l10n/translation";
+
+const cogMenuRegistry = registry.category("cogMenu");
+
+/**
+ * "Link existing document" cog-menu item.
+ *
+ * Appears in the cog menu of every mail.thread form view and opens the
+ * record-side documents.link.wizard with the current record in context, so the
+ * user can link one or more existing Documents records to it.
+ *
+ * Modeled on enterprise `sign`'s SignRequestCogMenu: the current record's
+ * model/id are read from the action service's current controller, and the
+ * mail.thread gate uses the presence of the `message_ids` field in the search
+ * view fields (no extra RPC).
+ */
+export class LinkDocumentCogMenu extends Component {
+    static template = "bemade_documents_link.LinkDocumentCogMenu";
+    static components = { DropdownItem };
+    static props = {};
+
+    setup() {
+        this.action = useService("action");
+    }
+
+    linkDocument() {
+        // resModel is static on the controller props; resId comes from the
+        // mutable current state (it changes for newly created records).
+        const resModel = this.action.currentController.props.resModel;
+        const resId = this.action.currentController.currentState?.resId;
+        if (!resModel || !resId) {
+            return;
+        }
+        this.action.doAction(
+            {
+                name: _t("Link Existing Document"),
+                type: "ir.actions.act_window",
+                res_model: "documents.link.wizard",
+                view_mode: "form",
+                views: [[false, "form"]],
+                target: "new",
+            },
+            {
+                additionalContext: {
+                    active_model: resModel,
+                    active_id: resId,
+                },
+            }
+        );
+    }
+}
+
+export const LinkDocumentCogMenuItem = {
+    Component: LinkDocumentCogMenu,
+    groupNumber: 20,
+    isDisplayed: ({ config, searchModel }) => {
+        // A mail.thread model exposes a `message_ids` field in its (search) view.
+        const isMailThread = Boolean(searchModel.searchViewFields?.["message_ids"]);
+        return (
+            isMailThread &&
+            config.actionType === "ir.actions.act_window" &&
+            config.viewType === "form" &&
+            searchModel.resModel !== "documents.document"
+        );
+    },
+};
+
+cogMenuRegistry.add("link-document-menu", LinkDocumentCogMenuItem, { sequence: 20 });

--- a/bemade_documents_link/static/src/link_document_cog_menu/link_document_cog_menu.xml
+++ b/bemade_documents_link/static/src/link_document_cog_menu/link_document_cog_menu.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="bemade_documents_link.LinkDocumentCogMenu">
+        <DropdownItem class="'o_link_existing_document'" onSelected.bind="linkDocument">
+            <i class="fa fa-link fa-fw"/> Link existing document
+        </DropdownItem>
+    </t>
+
+</templates>

--- a/bemade_documents_link/static/src/link_to_record/documents_control_panel.xml
+++ b/bemade_documents_link/static/src/link_to_record/documents_control_panel.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <!--
+        Add a "Link to Record" item to the Documents app's custom "Action"
+        dropdown (task #3678 defect 1). The Documents app renders its own
+        dropdown rather than the standard ActionMenus, so a bound server action
+        never shows up here; we add the entry point explicitly.
+    -->
+    <t t-name="bemade_documents_link.ControlPanel"
+       t-inherit="documents.ControlPanel"
+       t-inherit-mode="extension">
+        <xpath expr="//button[contains(@t-on-click, 'onDuplicate')]" position="after">
+            <button class="dropdown-item w-100 o_documents_link_to_record"
+                t-on-click="() => this.onLinkToRecord()"
+                t-if="canLinkToRecord">
+                <i class="fa fa-fw fa-link me-1"/>
+                <span class="d-inline-block">Link to Record</span>
+            </button>
+        </xpath>
+    </t>
+
+</templates>

--- a/bemade_documents_link/static/src/link_to_record/documents_control_panel_patch.js
+++ b/bemade_documents_link/static/src/link_to_record/documents_control_panel_patch.js
@@ -1,0 +1,63 @@
+/** @odoo-module **/
+
+import { DocumentsControlPanel } from "@documents/views/search/documents_control_panel";
+import { patch } from "@web/core/utils/patch";
+
+/**
+ * Documents-side "Link to Record" entry point (task #3678 defect 1).
+ *
+ * The enterprise Documents app does NOT render the standard ActionMenus
+ * component, so a server action bound via `binding_model_id` /
+ * `binding_view_types` never surfaces in the Documents UI. The Documents app
+ * builds its own "Action" dropdown in the `documents.ControlPanel` template and
+ * a hard-coded cog-menu whitelist. So the only way to expose a new contextual
+ * action is to add it to that custom dropdown.
+ *
+ * This patch adds an `onLinkToRecord` handler that reuses the stock
+ * `documents.document.action_link_to_record()` (the same method our server
+ * action calls), which opens the generic `link_to_record_wizard` (model picker
+ * limited to mail.thread models, then record picker).
+ */
+patch(DocumentsControlPanel.prototype, {
+    /**
+     * True when every selected record is an unlinked workspace document
+     * (res_model is falsy in 19.0; enterprise documents maps the old
+     * self-referential 'documents.document' to False), i.e. eligible to be
+     * linked to a record. Mirrors the stock action's own guard, which refuses
+     * already-linked documents.
+     */
+    get canLinkToRecord() {
+        const records = this.targetRecords;
+        return (
+            this.documentService.userIsInternal &&
+            this.currentFolderId !== "TRASH" &&
+            records.length > 0 &&
+            records.every(
+                (r) =>
+                    r.data.type === "binary" &&
+                    r.data.attachment_id &&
+                    !r.data.res_model
+            )
+        );
+    },
+
+    /**
+     * Open the stock "Link to Record" wizard on the selected documents.
+     */
+    async onLinkToRecord() {
+        const documentIds = this.targetRecords.map((record) => record.data.id);
+        if (!documentIds.length) {
+            return;
+        }
+        const action = await this.orm.call(
+            "documents.document",
+            "action_link_to_record",
+            [documentIds]
+        );
+        if (action) {
+            await this.action.doAction(action, {
+                onClose: () => this.notifyChange(),
+            });
+        }
+    },
+});

--- a/bemade_documents_link/tests/__init__.py
+++ b/bemade_documents_link/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_documents_link

--- a/bemade_documents_link/tests/test_documents_link.py
+++ b/bemade_documents_link/tests/test_documents_link.py
@@ -1,0 +1,228 @@
+import base64
+import unittest
+
+from odoo.tests import Form, tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("post_install", "-at_install")
+class TestDocumentsLink(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner = cls.env["res.partner"].create({"name": "Link Target Partner"})
+        cls.doc = cls._make_doc(cls.env, "Existing Doc")
+
+    @classmethod
+    def _make_doc(cls, env, name="Doc"):
+        """Create a realistic app-managed Documents record: with an attachment,
+        so that — as in the real app — it ends up unlinked. In 19.0 an unlinked
+        document has res_model = False (enterprise documents maps the old
+        self-referential 'documents.document' to False)."""
+        return env["documents.document"].create({
+            "name": name,
+            "type": "binary",
+            "datas": base64.b64encode(b"hello").decode(),
+        })
+
+    def _new_doc(self, name="Doc"):
+        return self._make_doc(self.env, name)
+
+    def test_record_side_link(self):
+        """Record-side: action_link() sets res_model/res_id on the chosen
+        existing (unlinked) document, and res_name reflects the target."""
+        # An unlinked, app-managed document has res_model = False in 19.0.
+        self.assertFalse(self.doc.res_model,
+                         "Fixture doc must start unlinked (workspace document)")
+        wizard = self.env["documents.link.wizard"].with_context(
+            active_model="res.partner",
+            active_id=self.partner.id,
+        ).create({"document_ids": [(6, 0, self.doc.ids)]})
+        # Defaults pulled from context.
+        self.assertEqual(wizard.res_model, "res.partner")
+        self.assertEqual(wizard.res_id, self.partner.id)
+
+        wizard.action_link()
+
+        self.assertEqual(self.doc.res_model, "res.partner")
+        self.assertEqual(self.doc.res_id, self.partner.id)
+        self.assertEqual(self.doc.res_name, self.partner.display_name)
+
+    def test_documents_side_model_filter(self):
+        """Documents-side: the stock link_to_record_wizard offers ONLY
+        mail.thread models, and link_to() writes the link our server action
+        relies on."""
+        wizard = self.env["documents.link_to_record_wizard"].create({
+            "document_ids": [(6, 0, self.doc.ids)],
+        })
+        target_models = {
+            model for model, _name in wizard._selection_target_model()
+        }
+        # res.partner is a mail.thread model -> present.
+        self.assertIn("res.partner", target_models)
+        # ir.model is not a mail.thread model -> absent; documents.document
+        # itself is explicitly excluded.
+        self.assertNotIn("ir.model", target_models)
+        self.assertNotIn("documents.document", target_models)
+
+        wizard.write({
+            "model_id": self.env["ir.model"]._get_id("res.partner"),
+            "resource_ref": f"res.partner,{self.partner.id}",
+        })
+        wizard.link_to()
+        self.assertEqual(self.doc.res_model, "res.partner")
+        self.assertEqual(self.doc.res_id, self.partner.id)
+
+    def test_server_action_opens_generic_wizard(self):
+        """Server-action wiring: running our ir.actions.server on a
+        documents.document returns an act_window opening the stock generic
+        link_to_record_wizard (no model preselected)."""
+        server_action = self.env.ref(
+            "bemade_documents_link.ir_actions_server_link_to_record"
+        )
+        doc = self._new_doc("Server Action Doc")
+        action = server_action.with_context(
+            active_model="documents.document",
+            active_id=doc.id,
+            active_ids=doc.ids,
+        ).run()
+        self.assertEqual(action["type"], "ir.actions.act_window")
+        self.assertEqual(action["res_model"], "documents.link_to_record_wizard")
+        # Generic: no model preselected, so the user picks it in the wizard.
+        self.assertFalse(action["context"].get("default_model_id"))
+        self.assertEqual(action["context"].get("default_document_ids"), doc.ids)
+
+    def test_record_side_form_smoke(self):
+        """Form smoke: the record-side wizard view compiles, defaults populate
+        from context, and document_ids is editable."""
+        form = Form(
+            self.env["documents.link.wizard"].with_context(
+                active_model="res.partner",
+                active_id=self.partner.id,
+            )
+        )
+        self.assertEqual(form.res_model, "res.partner")
+        self.assertEqual(form.res_id, self.partner.id)
+        form.document_ids.add(self.doc)
+        wizard = form.save()
+        self.assertIn(self.doc, wizard.document_ids)
+
+    def test_documents_side_action_on_recordset(self):
+        """Documents-side entry point (#3678 defect 1).
+
+        The Documents app does not render the standard ActionMenus, so the
+        documents-side entry point is a custom control-panel button whose JS
+        handler calls ``documents.document.action_link_to_record()`` over the
+        selected ids. This asserts that contract: calling the stock method on a
+        (multi-record) recordset of *unlinked* documents returns the generic
+        ``link_to_record_wizard`` act_window with no model preselected and the
+        documents passed through.
+        """
+        doc_a = self._new_doc("Action Doc A")
+        doc_b = self._new_doc("Action Doc B")
+        recs = doc_a + doc_b
+        action = recs.action_link_to_record()
+        self.assertEqual(action["type"], "ir.actions.act_window")
+        self.assertEqual(action["res_model"], "documents.link_to_record_wizard")
+        self.assertFalse(action["context"].get("default_model_id"))
+        self.assertEqual(
+            set(action["context"].get("default_document_ids")), set(recs.ids)
+        )
+
+
+@tagged("post_install", "-at_install")
+class TestDocumentsLinkProductBridge(TransactionCase):
+    """#3678 defect 2: linking an existing document to a product must make it
+    appear under the product's "Documents" smart button, which reads the
+    ``product.document`` model (not ``documents.document``)."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        if "product.document" not in cls.env:
+            raise unittest.SkipTest("documents_product not installed")
+        # Enable the documents/product bridge and give products a workspace.
+        cls.folder = cls.env["documents.document"].create(
+            {"name": "Product WS", "type": "folder"}
+        )
+        cls.env.company.write({
+            "product_folder_id": cls.folder.id,
+            "documents_product_settings": True,
+        })
+        cls.template = cls.env["product.template"].create({"name": "Bridge Product"})
+        cls.product = cls.template.product_variant_id
+
+    def _make_doc(self, name="Doc"):
+        return self.env["documents.document"].create({
+            "name": name,
+            "type": "binary",
+            "datas": base64.b64encode(b"hello").decode(),
+        })
+
+    def _product_document_count(self):
+        """Mirror the smart button: count product.document in the template's
+        documents domain (what action_open_documents / the stat button show)."""
+        return self.env["product.document"].search_count(
+            self.template._get_product_document_domain()
+        )
+
+    def test_record_side_link_feeds_product_smart_button(self):
+        """Record-side wizard: linking a document to a product template creates a
+        product.document so it shows under the product's Documents smart button.
+        Fails on the old behavior (which only set res_model/res_id on
+        documents.document, never creating a product.document)."""
+        doc = self._make_doc("Spec Sheet")
+        self.assertEqual(self._product_document_count(), 0)
+
+        wizard = self.env["documents.link.wizard"].with_context(
+            active_model="product.template",
+            active_id=self.template.id,
+        ).create({"document_ids": [(6, 0, doc.ids)]})
+        wizard.action_link()
+
+        self.assertEqual(doc.res_model, "product.template")
+        self.assertEqual(doc.res_id, self.template.id)
+        # The whole point: it now appears under the product's smart button.
+        self.assertEqual(
+            self._product_document_count(), 1,
+            "Linked document should appear under the product Documents button",
+        )
+        # And it reuses the SAME underlying attachment (one file, two facades).
+        pdoc = self.env["product.document"].search(
+            self.template._get_product_document_domain()
+        )
+        self.assertEqual(pdoc.ir_attachment_id, doc.attachment_id)
+
+    def test_documents_side_link_feeds_product_smart_button(self):
+        """Documents-side wizard (link_to_record_wizard.link_to): same outcome —
+        the linked document surfaces under the product smart button."""
+        doc = self._make_doc("Docside Spec")
+        self.assertEqual(self._product_document_count(), 0)
+
+        wizard = self.env["documents.link_to_record_wizard"].create({
+            "document_ids": [(6, 0, doc.ids)],
+        })
+        wizard.write({
+            "model_id": self.env["ir.model"]._get_id("product.template"),
+            "resource_ref": f"product.template,{self.template.id}",
+        })
+        wizard.link_to()
+
+        self.assertEqual(doc.res_model, "product.template")
+        self.assertEqual(doc.res_id, self.template.id)
+        self.assertEqual(
+            self._product_document_count(), 1,
+            "Doc linked from the Documents side should appear under the product",
+        )
+
+    def test_link_is_idempotent(self):
+        """Re-linking the same document must not create duplicate
+        product.document rows."""
+        doc = self._make_doc("Idem Doc")
+        for _i in range(2):
+            wizard = self.env["documents.link.wizard"].with_context(
+                active_model="product.template",
+                active_id=self.template.id,
+            ).create({"document_ids": [(6, 0, doc.ids)]})
+            wizard.action_link()
+        self.assertEqual(self._product_document_count(), 1)

--- a/bemade_documents_link/wizard/__init__.py
+++ b/bemade_documents_link/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import documents_link_wizard

--- a/bemade_documents_link/wizard/documents_link_wizard.py
+++ b/bemade_documents_link/wizard/documents_link_wizard.py
@@ -1,0 +1,61 @@
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
+
+class DocumentsLinkWizard(models.TransientModel):
+    """Record-side wizard: link one or more existing, unlinked
+    ``documents.document`` records to the record the user is currently on
+    (resolved from the ``active_model`` / ``active_id`` context).
+    """
+
+    _name = "documents.link.wizard"
+    _description = "Link Existing Documents to Record"
+
+    res_model = fields.Char(
+        string="Target Model",
+        required=True,
+        default=lambda self: self.env.context.get("active_model"),
+    )
+    res_id = fields.Integer(
+        string="Target Record",
+        required=True,
+        default=lambda self: self.env.context.get("active_id"),
+    )
+    document_ids = fields.Many2many(
+        "documents.document",
+        string="Documents",
+        # Offer only existing, not-yet-linked documents. In 19.0 an app-managed
+        # document not linked to a business record has res_model = False:
+        # enterprise `documents._compute_res_record` maps the old self-
+        # referential 'documents.document' to False, and a constraint now
+        # forbids res_model == 'documents.document'. So False is the "unlinked"
+        # marker.
+        domain=[("res_model", "=", False)],
+    )
+
+    def action_link(self):
+        self.ensure_one()
+        if not self.document_ids:
+            raise UserError(_("Select at least one document to link."))
+
+        # Gate on the user's *write* access to the target record, mirroring the
+        # stock Documents link wizard's access logic, so a user cannot link a
+        # document to a record they are not allowed to modify.
+        target_model = self.res_model
+        if target_model not in self.env or self.env[target_model]._abstract:
+            raise UserError(_("Cannot link documents to model %s.", target_model))
+        target = self.env[target_model].browse(self.res_id)
+        if not target.exists():
+            raise UserError(_("The record to link the documents to no longer exists."))
+        target.check_access("write")
+
+        # res_name recomputes automatically from res_model/res_id on
+        # documents.document; mirror the stock wizard's write payload.
+        self.document_ids.write({
+            "res_model": self.res_model,
+            "res_id": self.res_id,
+            "is_editable_attachment": True,
+        })
+        # Surface the link under a product's "Documents" smart button (#3678).
+        self.document_ids._bemade_sync_product_document()
+        return {"type": "ir.actions.act_window_close"}

--- a/bemade_documents_link/wizard/documents_link_wizard_views.xml
+++ b/bemade_documents_link/wizard/documents_link_wizard_views.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="documents_link_wizard_view_form" model="ir.ui.view">
+        <field name="name">documents.link.wizard.form</field>
+        <field name="model">documents.link.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Link Existing Documents">
+                <sheet>
+                    <group>
+                        <field name="res_model" invisible="1"/>
+                        <field name="res_id" invisible="1"/>
+                        <field name="document_ids"
+                               widget="many2many_tags"
+                               options="{'no_create': True}"
+                               placeholder="Choose existing documents to link..."/>
+                    </group>
+                </sheet>
+                <footer>
+                    <button name="action_link" type="object" string="Link"
+                            class="btn-primary" data-hotkey="q"/>
+                    <button string="Cancel" class="btn-secondary"
+                            special="cancel" data-hotkey="x"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_documents_link_wizard" model="ir.actions.act_window">
+        <field name="name">Link Existing Document</field>
+        <field name="res_model">documents.link.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+        <field name="view_id" ref="documents_link_wizard_view_form"/>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Module installé en prod 18.0, oublié lors de la migration 18->19.

## Changement clé (19.0)
Enterprise `documents` a transformé `res_model` en champ **calculé** (stored, avec inverse). Son `_compute_res_record` mappe l'ancienne valeur auto-référentielle `'documents.document'` (marqueur d'un document workspace non-lié en 18.0) vers **`False`**, et une **constraint** interdit désormais `res_model == 'documents.document'`.

Le module utilisait `res_model == 'documents.document'` comme marqueur 'non-lié'. Remplacé par `False` dans : domain du wizard, garde OWL `canLinkToRecord`, tests. `res_model` reste writable (inverse) → `action_link` inchangé.

- version 19.0.1.0.0, `groups_id`->`group_ids`. Tests 5/5.

Dernier des 6 modules prod oubliés par la migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)