### PR TITLE
fix(bemade_documents_link): migrate to 19.0 (unlinked marker)

### DIFF
--- a/bemade_documents_link/__manifest__.py
+++ b/bemade_documents_link/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Documents - Link Existing",
-    "version": "18.0.1.0.0",
+    "version": "19.0.1.0.0",
     "summary": "Easily link an existing Documents record (incl. spreadsheets) "
                "to any mail.thread record, from either side.",
     "description": """

--- a/bemade_documents_link/data/ir_actions_server_data.xml
+++ b/bemade_documents_link/data/ir_actions_server_data.xml
@@ -16,7 +16,7 @@
             <field name="model_id" ref="documents.model_documents_document"/>
             <field name="binding_model_id" ref="documents.model_documents_document"/>
             <field name="binding_view_types">list,kanban,form</field>
-            <field name="groups_id" eval="[Command.link(ref('base.group_user'))]"/>
+            <field name="group_ids" eval="[Command.link(ref('base.group_user'))]"/>
             <field name="state">code</field>
             <field name="code">
 action = records.action_link_to_record()

--- a/bemade_documents_link/static/src/link_to_record/documents_control_panel_patch.js
+++ b/bemade_documents_link/static/src/link_to_record/documents_control_panel_patch.js
@@ -35,7 +35,7 @@ patch(DocumentsControlPanel.prototype, {
                 (r) =>
                     r.data.type === "binary" &&
                     r.data.attachment_id &&
-                    r.data.res_model === "documents.document"
+                    !r.data.res_model
             )
         );
     },

--- a/bemade_documents_link/tests/test_documents_link.py
+++ b/bemade_documents_link/tests/test_documents_link.py
@@ -32,7 +32,7 @@ class TestDocumentsLink(TransactionCase):
         existing (unlinked) document, and res_name reflects the target."""
         # An unlinked, app-managed document carries the self-referential
         # res_model 'documents.document'.
-        self.assertEqual(self.doc.res_model, "documents.document",
+        self.assertFalse(self.doc.res_model,
                          "Fixture doc must start unlinked (workspace document)")
         wizard = self.env["documents.link.wizard"].with_context(
             active_model="res.partner",

--- a/bemade_documents_link/wizard/documents_link_wizard.py
+++ b/bemade_documents_link/wizard/documents_link_wizard.py
@@ -28,7 +28,7 @@ class DocumentsLinkWizard(models.TransientModel):
         # document that isn't linked to a business record carries the
         # self-referential res_model 'documents.document' (set on create in
         # enterprise `documents`), so that — not False — is the "unlinked" marker.
-        domain=[("res_model", "=", "documents.document")],
+        domain=[("res_model", "=", False)],
     )
 
     def action_link(self):


### PR DESCRIPTION
`bemade_documents_link` était déjà sur 19.0 comme **copie 18.0 non migrée** (version 18.0.1.0.0, ancien marqueur). Cette PR applique la vraie migration 19.0.

**Changement clé** : enterprise `documents` a transformé `res_model` en champ calculé/stored (avec inverse). Son `_compute_res_record` mappe l'ancien marqueur auto-référentiel `'documents.document'` (document workspace non-lié) vers **`False`**, et une constraint interdit `res_model == 'documents.document'`. Marqueur 'non-lié' = `False` désormais (wizard domain, garde OWL, test). `res_model` reste writable → action_link inchangé.

version 19.0.1.0.0, groups_id->group_ids. Tests 5/5. Dernier des 6 modules prod oubliés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)