### PR TITLE
fix(odoo_herd_portal): silence routine backup notifications, author as OdooBot, show backend chatter

### DIFF
--- a/odoo_herd_portal/controllers/portal.py
+++ b/odoo_herd_portal/controllers/portal.py
@@ -435,9 +435,11 @@ class CustomerPortal(CustomerPortal):
                 )
             )
             backup_wizard.action_create_backup()
-            _record_portal_initiator(
-                "k8s.odoo.backup", instance.id, initiator_partner_id
-            )
+            # NOTE: the pre-upgrade guardrail backup is deliberately NOT stamped
+            # with portal_initiator_id. It is an internal guardrail, not a
+            # user-requested "Backup now", so it must stay silent -- only the
+            # upgrade job (stamped below) notifies the initiator. Stamping it
+            # would double-notify for a single user action.
             # GUARDRAIL 2 -- standard upgrade, server-fixed module list only.
             upgrade_wizard = (
                 request.env["k8s.upgrade.wizard"]

--- a/odoo_herd_portal/models/k8s_odoo_backup.py
+++ b/odoo_herd_portal/models/k8s_odoo_backup.py
@@ -84,27 +84,37 @@ class K8sOdooBackup(models.Model):
         """Best-effort: STATUS-ONLY completion/failure comment to the client.
 
         Fires only on the real terminal-state transition (the operator webhook
-        drives ``mark_completed`` / ``mark_failed`` in prod). The direct
-        recipient (``partner_ids``) is the recorded ``portal_initiator_id`` --
-        ONLY that partner, never the whole ``allowed_partner_ids`` set. Posting
-        with the ``mail.mt_comment`` subtype additionally reaches the instance's
-        EXISTING followers (intended). If no initiator was recorded, followers
-        are notified but no direct ``partner_ids`` recipient is set. NO standing
-        follower subscription is added; the raw operator ``message`` blob is
-        never included. Wrapped so a failure never blocks the state write.
+        drives ``mark_completed`` / ``mark_failed`` in prod). PORTAL-INITIATED
+        JOBS ONLY: if no ``portal_initiator_id`` was recorded, NOTHING is posted
+        -- scheduled/recurring/operator-driven backups (cron, auto-backup before
+        upgrade) stay silent. The direct recipient (``partner_ids``) is the
+        recorded ``portal_initiator_id`` -- ONLY that partner, never the whole
+        ``allowed_partner_ids`` set. Posting with the ``mail.mt_comment`` subtype
+        additionally reaches the instance's EXISTING followers (intended). The
+        message is authored as OdooBot (``base.partner_root``) via ``sudo`` so it
+        is never attributed to the public user behind the operator webhook
+        (an ``auth="public"`` route). NO standing follower subscription is added;
+        the raw operator ``message`` blob is never included. Wrapped so a failure
+        never blocks the state write.
         """
+        odoobot_id = self.env.ref("base.partner_root").id
         for record in self:
+            initiator = record.sudo().portal_initiator_id
+            # Gate: only notify for portal-initiated jobs. Scheduled/recurring
+            # and operator-driven jobs (no initiator) post nothing.
+            if not initiator:
+                continue
             instance = record.instance_id.sudo()
             if not instance:
                 continue
-            initiator = record.sudo().portal_initiator_id
             if outcome == "completed":
                 body = "Backup completed."
             else:
                 body = "Backup failed — Bemade has been notified."
             try:
-                instance.message_post(
+                instance.sudo().message_post(
                     body=body,
+                    author_id=odoobot_id,
                     partner_ids=initiator.ids,
                     message_type="comment",
                     subtype_xmlid="mail.mt_comment",

--- a/odoo_herd_portal/models/k8s_odoo_staging_refresh.py
+++ b/odoo_herd_portal/models/k8s_odoo_staging_refresh.py
@@ -58,27 +58,35 @@ class K8sOdooStagingRefresh(models.Model):
     def _notify_instance_terminal(self, outcome):
         """Best-effort: STATUS-ONLY completion/failure comment to the client.
 
-        The direct recipient (``partner_ids``) is the recorded
-        ``portal_initiator_id`` -- ONLY that partner, never the whole
-        ``allowed_partner_ids`` set. Posting with the ``mail.mt_comment`` subtype
-        additionally reaches the TARGET instance's EXISTING followers (intended).
-        If no initiator was recorded, followers are notified but no direct
-        ``partner_ids`` recipient is set. NO standing follower subscription is
-        added; the raw operator ``message`` blob is never included. Wrapped so a
-        failure never blocks the state write.
+        PORTAL-INITIATED JOBS ONLY: if no ``portal_initiator_id`` was recorded,
+        NOTHING is posted -- operator-driven refreshes stay silent. The direct
+        recipient (``partner_ids``) is the recorded ``portal_initiator_id`` --
+        ONLY that partner, never the whole ``allowed_partner_ids`` set. Posting
+        with the ``mail.mt_comment`` subtype additionally reaches the TARGET
+        instance's EXISTING followers (intended). The message is authored as
+        OdooBot (``base.partner_root``) via ``sudo`` so it is never attributed to
+        the public user behind the operator webhook (an ``auth="public"``
+        route). NO standing follower subscription is added; the raw operator
+        ``message`` blob is never included. Wrapped so a failure never blocks the
+        state write.
         """
+        odoobot_id = self.env.ref("base.partner_root").id
         for record in self:
+            initiator = record.sudo().portal_initiator_id
+            # Gate: only notify for portal-initiated jobs.
+            if not initiator:
+                continue
             instance = record.target_instance_id.sudo()
             if not instance:
                 continue
-            initiator = record.sudo().portal_initiator_id
             if outcome == "completed":
                 body = "Staging refresh completed."
             else:
                 body = "Staging refresh failed — Bemade has been notified."
             try:
-                instance.message_post(
+                instance.sudo().message_post(
                     body=body,
+                    author_id=odoobot_id,
                     partner_ids=initiator.ids,
                     message_type="comment",
                     subtype_xmlid="mail.mt_comment",

--- a/odoo_herd_portal/models/k8s_odoo_upgrade.py
+++ b/odoo_herd_portal/models/k8s_odoo_upgrade.py
@@ -71,23 +71,32 @@ class K8sOdooUpgrade(models.Model):
         """Best-effort: post a STATUS-ONLY completion/failure comment.
 
         Fires only on the real terminal-state transition (the operator webhook
-        drives ``mark_completed`` / ``mark_failed`` in prod). The direct
-        recipient (``partner_ids``) is the recorded ``portal_initiator_id`` --
-        ONLY that partner, never the whole ``allowed_partner_ids`` set. Posting
-        with the ``mail.mt_comment`` subtype additionally reaches the instance's
-        EXISTING followers (intended). If no initiator was recorded, followers
-        are notified but no direct ``partner_ids`` recipient is set. NO standing
-        follower subscription is added; the raw operator ``message`` blob is
-        never included. Wrapped so a failure never blocks the state write.
+        drives ``mark_completed`` / ``mark_failed`` in prod). PORTAL-INITIATED
+        JOBS ONLY: if no ``portal_initiator_id`` was recorded, NOTHING is posted
+        -- operator-driven jobs stay silent. The direct recipient
+        (``partner_ids``) is the recorded ``portal_initiator_id`` -- ONLY that
+        partner, never the whole ``allowed_partner_ids`` set. Posting with the
+        ``mail.mt_comment`` subtype additionally reaches the instance's EXISTING
+        followers (intended). The message is authored as OdooBot
+        (``base.partner_root``) via ``sudo`` so it is never attributed to the
+        public user behind the operator webhook (an ``auth="public"`` route).
+        NO standing follower subscription is added; the raw operator ``message``
+        blob is never included. Wrapped so a failure never blocks the state
+        write.
         """
+        odoobot_id = self.env.ref("base.partner_root").id
         for record in self:
+            initiator = record.sudo().portal_initiator_id
+            # Gate: only notify for portal-initiated jobs.
+            if not initiator:
+                continue
             instance = record.instance_id.sudo()
             if not instance:
                 continue
-            initiator = record.sudo().portal_initiator_id
             try:
-                instance.message_post(
+                instance.sudo().message_post(
                     body=record._terminal_notification_body(outcome),
+                    author_id=odoobot_id,
                     partner_ids=initiator.ids,
                     message_type="comment",
                     subtype_xmlid="mail.mt_comment",

--- a/odoo_herd_portal/tests/test_backend_view.py
+++ b/odoo_herd_portal/tests/test_backend_view.py
@@ -77,6 +77,27 @@ class TestBackendView(TransactionCase):
         # failed or the field name is wrong).
         self.assertIn("allowed_partner_ids", form._view["fields"])
 
+    def test_form_renders_chatter_for_k8s_user(self):
+        """The backend chatter widget is rendered in the form arch.
+
+        Internal k8s staff must see the instance audit trail (portal-action
+        notes + terminal notifications). The <chatter/> element is gated to
+        group_k8s_user; the manager implies that group, so it must appear in the
+        built arch for them.
+        """
+        view = self.env.ref(
+            "odoo_herd_portal.view_k8s_odoo_instance_form_portal"
+        )
+        arch = (
+            self.instance.with_user(self.manager)
+            .get_view(view_id=view.id, view_type="form")["arch"]
+        )
+        self.assertIn(
+            "chatter",
+            arch,
+            "The backend form must render a chatter widget for k8s staff.",
+        )
+
     def test_manager_assigns_allowed_partner_via_form(self):
         """A manager sets allowed_partner_ids through the form and it persists."""
         form = Form(

--- a/odoo_herd_portal/tests/test_lifecycle.py
+++ b/odoo_herd_portal/tests/test_lifecycle.py
@@ -339,6 +339,13 @@ class TestLifecycleNotification(TransactionCase):
             1,
             "Exactly one terminal client comment is expected, got %s." % len(message),
         )
+        # Authored as OdooBot, never the public user behind the operator webhook.
+        self.assertEqual(
+            message.author_id,
+            self.env.ref("base.partner_root"),
+            "Terminal client notification must be authored by OdooBot "
+            "(base.partner_root), never the public user.",
+        )
         comment_subtype = self.env.ref("mail.mt_comment")
         note_subtype = self.env.ref("mail.mt_note")
         self.assertEqual(
@@ -487,8 +494,13 @@ class TestLifecycleNotification(TransactionCase):
             not_recipient=(self.company_a,),
         )
 
-    def test_terminal_notification_without_initiator_notifies_followers_only(self):
-        """Herd/operator-driven op (no initiator): followers only, no direct partner."""
+    def test_terminal_notification_without_initiator_posts_nothing(self):
+        """Operator/scheduled-driven op (no initiator) posts NO notification.
+
+        Gating fix: scheduled/recurring cron backups and the auto-backup before
+        upgrade run on the operator webhook with no ``portal_initiator_id`` and
+        must be silent -- not even existing followers are pinged.
+        """
         follower = self.env["res.partner"].create(
             {"name": "Life Follower 2", "email": "follower2@example.com"}
         )
@@ -500,17 +512,43 @@ class TestLifecycleNotification(TransactionCase):
         before = set(self.inst_a_prod.message_ids.ids)
         upgrade.mark_completed(message="done")
         new = self._new_messages(self.inst_a_prod, before)
-        # No initiator => no direct partner_ids recipient at all.
-        self._assert_client_comment(
-            new,
-            None,
-            followers=(follower,),
-            not_recipient=(self.company_a,),
-        )
         self.assertFalse(
-            new.partner_ids,
-            "With no portal initiator there must be no direct partner_ids "
-            "recipient (followers are reached via the subtype).",
+            new,
+            "A job with no portal_initiator_id must post NO terminal "
+            "notification (operator/scheduled jobs stay silent).",
+        )
+
+    def test_scheduled_backup_without_initiator_posts_nothing(self):
+        """A backup completing with no initiator (cron) posts no message."""
+        with patch(_BACKUP_CR):
+            backup = self.env["k8s.odoo.backup"].create(
+                {"instance_id": self.inst_a_prod.id, "format": "zip"}
+            )
+        before = set(self.inst_a_prod.message_ids.ids)
+        backup.mark_completed(message="INTERNAL: object_key s3://x")
+        new = self._new_messages(self.inst_a_prod, before)
+        self.assertFalse(
+            new,
+            "A scheduled/operator backup (no portal_initiator_id) must post "
+            "no terminal notification.",
+        )
+
+    def test_refresh_without_initiator_posts_nothing(self):
+        """A staging refresh with no initiator posts no message."""
+        with patch(_REFRESH_CR):
+            refresh = self.env["k8s.odoo.staging.refresh"].create(
+                {
+                    "target_instance_id": self.inst_a_staging.id,
+                    "source_instance_id": self.inst_a_prod.id,
+                }
+            )
+        before = set(self.inst_a_staging.message_ids.ids)
+        refresh.mark_completed(message="INTERNAL: snapshot detail")
+        new = self._new_messages(self.inst_a_staging, before)
+        self.assertFalse(
+            new,
+            "An operator-driven staging refresh (no initiator) must post "
+            "no terminal notification.",
         )
 
     def test_terminal_notification_excludes_non_allowed_partner(self):
@@ -605,6 +643,76 @@ class TestLifecycleSelfService(HttpCase):
             backup.create_date,
             upgrade.create_date,
             "Backup must be created before (or at) the upgrade.",
+        )
+
+    def test_preupgrade_backup_has_no_initiator_and_stays_silent(self):
+        """The auto-backup before an upgrade is NOT stamped with an initiator.
+
+        Only the user-facing upgrade job carries the initiator. The pre-upgrade
+        guardrail backup must have no ``portal_initiator_id`` so that when it
+        completes it posts NO ping (single user action, single notification),
+        while the upgrade job itself still notifies on completion.
+        """
+        self.authenticate("life_user_a", "life_user_a")
+        Upgrade = self.env["k8s.odoo.upgrade"]
+        Backup = self.env["k8s.odoo.backup"]
+        with patch(_UPGRADE_CR), patch(_BACKUP_CR):
+            resp = self.url_open(
+                "/my/instances/%d/upgrade" % self.inst_a_prod.id,
+                data={"csrf_token": self._csrf_token()},
+            )
+        self.assertEqual(resp.status_code, 200)
+        backup = Backup.sudo().search(
+            [("instance_id", "=", self.inst_a_prod.id)],
+            order="create_date desc, id desc",
+            limit=1,
+        )
+        upgrade = Upgrade.sudo().search(
+            [("instance_id", "=", self.inst_a_prod.id)],
+            order="create_date desc, id desc",
+            limit=1,
+        )
+        # Pre-upgrade backup must NOT be stamped; the upgrade MUST be.
+        self.assertFalse(
+            backup.portal_initiator_id,
+            "The pre-upgrade guardrail backup must not carry a "
+            "portal_initiator_id (it must stay silent).",
+        )
+        self.assertEqual(
+            upgrade.portal_initiator_id,
+            self.user_a.partner_id,
+            "The upgrade job must carry the initiator so it notifies.",
+        )
+        # The backup completing posts NO ping; the upgrade completing DOES.
+        odoobot = self.env.ref("base.partner_root")
+        before = set(self.inst_a_prod.message_ids.ids)
+        backup.mark_completed(message="INTERNAL: pre-upgrade backup")
+        self.inst_a_prod.invalidate_recordset()
+        after_backup = self.inst_a_prod.message_ids.filtered(
+            lambda m: m.id not in before
+        )
+        self.assertFalse(
+            after_backup,
+            "The silent pre-upgrade backup must not post a terminal ping.",
+        )
+        before = set(self.inst_a_prod.message_ids.ids)
+        upgrade.mark_completed(message="INTERNAL: upgrade trace")
+        self.inst_a_prod.invalidate_recordset()
+        after_upgrade = self.inst_a_prod.message_ids.filtered(
+            lambda m: m.id not in before
+        )
+        self.assertEqual(
+            len(after_upgrade), 1, "The upgrade completion must post one ping."
+        )
+        self.assertEqual(
+            after_upgrade.author_id,
+            odoobot,
+            "The upgrade completion ping must be authored by OdooBot.",
+        )
+        self.assertIn(
+            self.user_a.partner_id,
+            after_upgrade.partner_ids,
+            "The upgrade completion ping must reach the initiator.",
         )
 
     def test_upgrade_non_owned_refused(self):

--- a/odoo_herd_portal/views/k8s_odoo_instance_views.xml
+++ b/odoo_herd_portal/views/k8s_odoo_instance_views.xml
@@ -44,6 +44,20 @@
                 <attribute name="groups">odoo_herd.group_k8s_user</attribute>
             </xpath>
 
+            <!--
+                Backend chatter so internal k8s staff can see the audit trail
+                (Feature D portal-action notes + Feature E terminal
+                notifications), which is otherwise invisible in the backend.
+                k8s.odoo.instance inherits mail.thread (odoo_herd). Odoo 19
+                renders chatter via the <chatter/> element placed after the
+                <sheet> (the old oe_chatter div is gone). Gated to
+                group_k8s_user: portal users never open this backend form, and
+                gating avoids any cross-group view-access warning.
+            -->
+            <xpath expr="//sheet" position="after">
+                <chatter groups="odoo_herd.group_k8s_user"/>
+            </xpath>
+
             <xpath expr="//notebook" position="inside">
                 <page string="Portal Access" name="portal_access"
                       groups="odoo_herd.group_k8s_user">


### PR DESCRIPTION
## Summary

The Feature E terminal-state notification (`mark_completed` / `mark_failed` overrides on `k8s.odoo.backup`, `k8s.odoo.upgrade`, `k8s.odoo.staging.refresh`) was noisy and mis-attributed in staging/prod. Four related fixes:

### 1. Gate to portal-initiated jobs only
`_notify_instance_terminal` now does **nothing** when `portal_initiator_id` is unset. The overrides fire on the operator webhook for *every* terminal transition, so scheduled/recurring cron backups and the auto-backup-before-upgrade (which have no initiator) previously posted a "Backup completed." message on each run. They now stay silent.

### 2. Author as OdooBot (was "Public user")
The operator webhook is an `auth="public"` route, so `self.env.user` is the public user and `message_post` authored the message as **"Public user"**. The notification now sets `author_id = self.env.ref("base.partner_root").id` and posts via `instance.sudo().message_post(...)`, so the author is **OdooBot**. `partner_ids=initiator.ids` and `subtype_xmlid="mail.mt_comment"` (status-only body) are unchanged.

### 3. Suppress the pre-upgrade guardrail backup ping
The upgrade controller (`controllers/portal.py`) no longer stamps `portal_initiator_id` on the auto-backup it creates before the upgrade. Only the user-facing **"Backup now"**, the upgrade job, and staging-refresh get an initiator. Net effect: portal "Backup now" notifies; pre-upgrade backup is silent; upgrade completion notifies — one user action, one notification.

### 4. Backend chatter widget
`k8s.odoo.instance` inherits `mail.thread` but its backend form had no chatter, so the audit trail (Feature D portal-action notes + the Feature E terminal notifications) was invisible to internal staff. Added a `<chatter/>` element (Odoo 19 syntax: `<xpath expr="//sheet" position="after"><chatter/></xpath>`, copied from `odoo/addons/account/views/account_journal_views.xml` and the inherited pattern in `odoo/addons/iap_mail/views/iap_views.xml`), gated to `odoo_herd.group_k8s_user` (as core does, e.g. `odoo/addons/point_of_sale/views/pos_order_view.xml`) so portal users never hit it.

## Tests
New coverage in `tests/test_lifecycle.py` and `tests/test_backend_view.py`:
- A backup/upgrade/refresh completing with **no** `portal_initiator_id` posts **no** message (scheduled/operator case).
- Each terminal notification, when initiated, posts exactly one `mt_comment` authored by **OdooBot** (`base.partner_root`), with the initiator as recipient and a status-only body.
- The pre-upgrade auto-backup has **no** `portal_initiator_id` and posts no ping, while the upgrade itself still notifies.
- The backend chatter renders in the form arch for a k8s user.

Full module suite green: **86 odoo_herd_portal tests, 0 failed**. RED→GREEN verified (4 new behavioral tests fail against the pre-fix source).