### PR TITLE
fix: relabel bemade_task_template_id to avoid duplicate label (19.0)

### DIFF
--- a/bemade_fsm/models/product_template.py
+++ b/bemade_fsm/models/product_template.py
@@ -6,7 +6,7 @@ class ProductTemplate(models.Model):
 
     bemade_task_template_id = fields.Many2one(
         comodel_name="project.task.template",
-        string="Task Template",
+        string="FSM Task Template",
         ondelete="restrict",
     )
 


### PR DESCRIPTION
## Summary
`bemade_task_template_id` on `product.template` shared its "Task Template"
label with `sale_project`'s `task_template_id`, which logged a
`Two fields ... have the same label: Task Template` warning on every load
in Odoo 19.0. Relabel it **"FSM Task Template"** (no functional change).

## Test plan
- [x] `-i bemade_fsm` on 19.0: module loads, the "same label" warning for
      `bemade_task_template_id` is gone.