### PR TITLE
[3705] commercial_invoice: explicit picking-selection delivery source (MR-1/4, 19.0 harmonize)

### DIFF
--- a/commercial_invoice/__manifest__.py
+++ b/commercial_invoice/__manifest__.py
@@ -1,12 +1,14 @@
 {
     'name': 'Commercial Invoice',
-    'version': '19.0.1.2.0',
+    'version': '19.0.1.3.0',
     'category': 'Accounting',
     'summary': 'Generate commercial invoices for cross-border shipments',
     'description': """
         Generate commercial invoices for cross-border shipments between Canada and the USA.
         Features:
         - Group multiple invoices into a single commercial invoice
+        - Build a commercial invoice from selected customer deliveries
+          (explicit picking selection or partner-search fallback)
         - Track additional costs (packaging, freight, insurance)
         - Print bilingual commercial invoice reports
     """,
@@ -16,11 +18,13 @@
     'depends': [
         'account',
         'stock_delivery',
+        'delivery',
         'mail',
     ],
     'data': [
         'security/ir.model.access.csv',
         'data/commercial_invoice_sequence.xml',
+        'data/stock_picking_actions.xml',
         'report/commercial_invoice_report.xml',
         'report/report_templates.xml',
         'views/account_move_views.xml',

--- a/commercial_invoice/__manifest__.py
+++ b/commercial_invoice/__manifest__.py
@@ -1,14 +1,15 @@
 {
     'name': 'Commercial Invoice',
-    'version': '19.0.1.3.0',
+    'version': '19.0.1.4.0',
     'category': 'Accounting',
     'summary': 'Generate commercial invoices for cross-border shipments',
     'description': """
         Generate commercial invoices for cross-border shipments between Canada and the USA.
         Features:
         - Group multiple invoices into a single commercial invoice
-        - Build a commercial invoice from selected customer deliveries
-          (explicit picking selection or partner-search fallback)
+        - Build a commercial invoice from explicitly selected customer
+          deliveries (picking_ids is the single source of truth); a
+          "Select all deliveries for this partner" action pre-fills the list
         - Track additional costs (packaging, freight, insurance)
         - Print bilingual commercial invoice reports
     """,

--- a/commercial_invoice/data/stock_picking_actions.xml
+++ b/commercial_invoice/data/stock_picking_actions.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Multi-select server action on stock.picking: build a commercial
+         invoice from the selected customer deliveries. Ported from
+         verajet_commercial_invoice (task 3705 MR-1). -->
+    <record id="action_picking_create_commercial_invoice" model="ir.actions.server">
+        <field name="name">Create CI from Deliveries</field>
+        <field name="model_id" ref="stock.model_stock_picking"/>
+        <field name="binding_model_id" ref="stock.model_stock_picking"/>
+        <field name="binding_view_types">list,form</field>
+        <field name="state">code</field>
+        <field name="code">action = records.action_create_commercial_invoice()</field>
+    </record>
+</odoo>

--- a/commercial_invoice/models/__init__.py
+++ b/commercial_invoice/models/__init__.py
@@ -1,3 +1,4 @@
 from . import account_move
 from . import commercial_invoice
+from . import stock_picking
 from . import res_config_settings

--- a/commercial_invoice/models/commercial_invoice.py
+++ b/commercial_invoice/models/commercial_invoice.py
@@ -1,4 +1,6 @@
-from odoo import api, fields, models, _
+from collections import Counter, OrderedDict
+
+from odoo import Command, api, fields, models, _
 from odoo.exceptions import UserError
 
 
@@ -54,6 +56,49 @@ class CommercialInvoice(models.Model):
     )
     payment_term_id = fields.Many2one("account.payment.term", string="Payment Terms")
     incoterm_id = fields.Many2one("account.incoterms", string="Incoterms")
+
+    # Delivery (stock.picking) source — explicit picking selection.
+    #
+    # NOTE (field-ownership intent, task 3705 MR-1): picking_ids is REUSING the
+    # exact relation/column names that ``verajet_commercial_invoice`` already
+    # uses for its own ``picking_ids`` M2M
+    # (rel ``commercial_invoice_picking_rel``, columns
+    # ``commercial_invoice_id`` / ``picking_id``).  This is deliberate so that
+    # a later move of field ownership from the Vera overlay down into this base
+    # module is a no-op at the database level (same table/columns) rather than
+    # a delete+recreate.  Verajet's own ``picking_ids`` declaration is removed
+    # in the downstream MR-2; until then both declare the same relation, which
+    # the ORM collapses onto one table.
+    picking_ids = fields.Many2many(
+        "stock.picking",
+        "commercial_invoice_picking_rel",
+        "commercial_invoice_id",
+        "picking_id",
+        string="Deliveries",
+        domain="[('picking_type_id.code', '=', 'outgoing')]",
+    )
+    po_numbers = fields.Char(
+        string="PO Numbers",
+        compute="_compute_delivery_header",
+        compute_sudo=True,
+        store=True,
+        readonly=False,
+    )
+    carrier_id = fields.Many2one(
+        "delivery.carrier",
+        string="Carrier",
+        compute="_compute_delivery_header",
+        compute_sudo=True,
+        store=True,
+        readonly=False,
+    )
+    ship_date = fields.Date(
+        string="Ship Date",
+        compute="_compute_delivery_header",
+        compute_sudo=True,
+        store=True,
+        readonly=False,
+    )
 
     # Shipping details
     number_of_packages = fields.Integer(string="Number of Packages")
@@ -138,25 +183,57 @@ class CommercialInvoice(models.Model):
             )
         return lines
 
-    def _get_report_lines_from_pickings(self):
-        """Build report lines from done outgoing stock.move records.
+    def _get_picking_source_pickings(self):
+        """Resolve the set of pickings that feed the picking-source report.
 
-        Pickings are filtered by commercial partner equality with this CI's
-        partner.  Moves are aggregated by (product_id, price_unit).
+        UNIFY DECISION (task 3705 MR-1): a single **selection-first,
+        partner-search-fallback** path.  When explicit ``picking_ids`` are
+        selected on this CI, those deliveries are the source — verbatim, no
+        ``state == 'done'`` filter (the Vera flow builds the document BEFORE
+        the picking is validated).  When no pickings are selected, fall back to
+        the pre-existing partner-search behaviour (all *done* outgoing pickings
+        whose commercial partner matches this CI's partner), so existing 19.0
+        partner-search commercial invoices keep working unchanged.
         """
+        self.ensure_one()
+        if self.picking_ids:
+            # Selection-first: trust the explicit selection.  Domain on the
+            # field already constrains to outgoing picking types.
+            return self.picking_ids
+        # Partner-search fallback (legacy behaviour).
         if not self.partner_id:
-            return []
+            return self.env["stock.picking"]
         commercial_partner = self.partner_id.commercial_partner_id
-        pickings = self.env["stock.picking"].search(
+        return self.env["stock.picking"].search(
             [
                 ("partner_id.commercial_partner_id", "=", commercial_partner.id),
                 ("picking_type_id.code", "=", "outgoing"),
                 ("state", "=", "done"),
             ]
         )
-        moves = pickings.mapped("move_ids").filtered(
-            lambda m: m.state == "done" and m.product_id
-        )
+
+    def _get_report_lines_from_pickings(self):
+        """Build report lines from outgoing stock.move records.
+
+        The source pickings are resolved by :meth:`_get_picking_source_pickings`
+        (selection-first, partner-search-fallback).  Moves are aggregated by
+        (product_id, price_unit).
+        """
+        pickings = self._get_picking_source_pickings()
+        if not pickings:
+            return []
+        # When sourced from an explicit selection the pickings may not yet be
+        # validated, so do not require move state 'done' in that case.  In the
+        # partner-search fallback every picking is already done, so this filter
+        # is a no-op there.
+        if self.picking_ids:
+            moves = pickings.mapped("move_ids").filtered(
+                lambda m: m.product_id and m.state != "cancel"
+            )
+        else:
+            moves = pickings.mapped("move_ids").filtered(
+                lambda m: m.state == "done" and m.product_id
+            )
 
         # Aggregate by (product_id, price_unit derived from sale_line_id)
         aggregated = {}
@@ -172,7 +249,12 @@ class CommercialInvoice(models.Model):
                     "quantity": 0.0,
                     "uom": move.product_uom,
                 }
-            aggregated[key]["quantity"] += move.quantity
+            # Selected (possibly unvalidated) pickings: use the demanded
+            # quantity, which is set before validation.  Partner-search
+            # fallback: every move is done, so use the actual done quantity.
+            aggregated[key]["quantity"] += (
+                move.product_uom_qty if self.picking_ids else move.quantity
+            )
 
         lines = []
         for (product_id, price_unit), data in aggregated.items():
@@ -197,6 +279,7 @@ class CommercialInvoice(models.Model):
         "invoice_ids.amount_total",
         "line_source",
         "partner_id",
+        "picking_ids",
         "packaging_cost",
         "freight_cost",
         "insurance_cost",
@@ -218,6 +301,51 @@ class CommercialInvoice(models.Model):
                 + record.other_cost
             )
 
+    @api.depends(
+        "picking_ids",
+        "picking_ids.sale_id",
+        "picking_ids.sale_id.client_order_ref",
+        "picking_ids.carrier_id",
+        "picking_ids.scheduled_date",
+        "picking_ids.date_done",
+    )
+    def _compute_delivery_header(self):
+        """Aggregate header fields from the selected deliveries.
+
+        Ported from ``verajet_commercial_invoice`` (task 3705 MR-1): PO
+        numbers, carrier and ship date are derived from ``picking_ids`` so a
+        delivery-sourced commercial invoice carries the shipment header that a
+        customs document needs.
+        """
+        for record in self:
+            pickings = record.picking_ids
+            # PO numbers: unique, keep insertion order, prefer client_order_ref,
+            # fall back to SO name when ref missing, then picking origin.
+            refs = OrderedDict()
+            for pick in pickings:
+                so = pick.sale_id
+                ref = (so.client_order_ref or so.name) if so else pick.origin
+                if ref:
+                    refs[ref] = True
+            record.po_numbers = ", ".join(refs.keys()) if refs else False
+
+            # Carrier: most common across pickings; ties broken by first seen.
+            carriers = [p.carrier_id for p in pickings if p.carrier_id]
+            if carriers:
+                counter = Counter(c.id for c in carriers)
+                most_common_id, _count = counter.most_common(1)[0]
+                record.carrier_id = most_common_id
+            else:
+                record.carrier_id = False
+
+            # Ship date: earliest of date_done (if validated) else scheduled_date.
+            candidates = []
+            for pick in pickings:
+                dt = pick.date_done or pick.scheduled_date
+                if dt:
+                    candidates.append(dt)
+            record.ship_date = min(candidates).date() if candidates else False
+
     def action_recompute_amounts(self):
         """Manually trigger amount recomputation.
 
@@ -228,6 +356,14 @@ class CommercialInvoice(models.Model):
         self._compute_amounts()
 
     def action_confirm(self):
+        for record in self:
+            if not record.invoice_ids and not record.picking_ids:
+                raise UserError(
+                    _(
+                        "A commercial invoice must have at least one invoice "
+                        "or one delivery linked."
+                    )
+                )
         self.write({"state": "done"})
 
     def action_draft(self):
@@ -286,4 +422,57 @@ class CommercialInvoice(models.Model):
     def create_from_invoices(self, invoices):
         """Create a commercial invoice from a set of invoices."""
         vals = self._prepare_commercial_invoice_from_invoices(invoices)
+        return self.create(vals)
+
+    @api.model
+    def _prepare_commercial_invoice_from_pickings(self, pickings):
+        """Prepare commercial invoice values from a set of deliveries.
+
+        Ported from ``verajet_commercial_invoice`` (task 3705 MR-1).  Sets
+        ``line_source='picking'`` so the report/totals use the delivery path,
+        and stores the explicit ``picking_ids`` so the selection-first
+        aggregation applies.
+        """
+        if not pickings:
+            raise UserError(_("No deliveries selected."))
+
+        companies = pickings.mapped("company_id")
+        if len(companies) > 1:
+            raise UserError(_("Selected deliveries are from different companies."))
+
+        # Shipping = partner on picking (consignee); importer = commercial partner.
+        shipping_partners = pickings.mapped("partner_id.commercial_partner_id")
+        consignee = shipping_partners[0] if len(shipping_partners) == 1 else False
+
+        # Align currency with the SO; fall back to USD (cross-border default).
+        sale_orders = pickings.mapped("sale_id")
+        currency = False
+        if sale_orders:
+            currencies = sale_orders.mapped("currency_id")
+            if len(currencies) == 1:
+                currency = currencies[0].id
+        if not currency:
+            currency = self.env.ref("base.USD").id
+
+        incoterms = sale_orders.mapped("incoterm")
+        payment_terms = sale_orders.mapped("payment_term_id")
+
+        vals = {
+            "line_source": "picking",
+            "picking_ids": [Command.set(pickings.ids)],
+            "company_id": companies[:1].id,
+            "currency_id": currency,
+            "partner_id": consignee.id if consignee else False,
+            "importer_id": consignee.id if consignee else False,
+            "incoterm_id": incoterms[0].id if len(incoterms) == 1 else False,
+            "payment_term_id": (
+                payment_terms[0].id if len(payment_terms) == 1 else False
+            ),
+        }
+        return vals
+
+    @api.model
+    def create_from_pickings(self, pickings):
+        """Create a commercial invoice from a set of deliveries."""
+        vals = self._prepare_commercial_invoice_from_pickings(pickings)
         return self.create(vals)

--- a/commercial_invoice/models/commercial_invoice.py
+++ b/commercial_invoice/models/commercial_invoice.py
@@ -28,6 +28,9 @@ class CommercialInvoice(models.Model):
         required=True,
         default="invoice",
         tracking=True,
+        help="Whether this commercial invoice sources its content from linked "
+        "Invoices or from explicitly selected Deliveries. With 'Deliveries' the "
+        "content comes solely from the Deliveries field (picking_ids).",
     )
 
     # Related parties
@@ -154,11 +157,13 @@ class CommercialInvoice(models.Model):
         When ``line_source == 'invoice'`` the data comes from
         ``account.move.line`` records linked through ``invoice_ids``.
 
-        When ``line_source == 'picking'`` the data comes from done outgoing
-        ``stock.move`` records whose picking's commercial partner matches this
-        CI's commercial partner.  Moves are aggregated by
-        (product_id, price_unit) so different unit prices for the same product
-        produce separate rows.
+        When ``line_source == 'picking'`` the data comes from the
+        ``stock.move`` records of the explicitly selected ``picking_ids``.
+        Moves are aggregated by (product_id, price_unit) so different unit
+        prices for the same product produce separate rows.  ``picking_ids`` is
+        the *single source of truth*: with no deliveries selected the picking
+        path yields no lines (task 3705 refinement — no partner-search
+        fallback; see :meth:`action_select_partner_deliveries`).
         """
         self.ensure_one()
         if self.line_source == "picking":
@@ -183,57 +188,38 @@ class CommercialInvoice(models.Model):
             )
         return lines
 
-    def _get_picking_source_pickings(self):
-        """Resolve the set of pickings that feed the picking-source report.
+    def _partner_outgoing_pickings_domain(self):
+        """Domain for the CI partner's done outgoing deliveries.
 
-        UNIFY DECISION (task 3705 MR-1): a single **selection-first,
-        partner-search-fallback** path.  When explicit ``picking_ids`` are
-        selected on this CI, those deliveries are the source — verbatim, no
-        ``state == 'done'`` filter (the Vera flow builds the document BEFORE
-        the picking is validated).  When no pickings are selected, fall back to
-        the pre-existing partner-search behaviour (all *done* outgoing pickings
-        whose commercial partner matches this CI's partner), so existing 19.0
-        partner-search commercial invoices keep working unchanged.
+        Used by :meth:`action_select_partner_deliveries` to PRE-FILL
+        ``picking_ids`` (a convenience sweep the user can then trim).  It is
+        NOT a content/sourcing path — report lines come only from the explicit
+        ``picking_ids`` selection (task 3705 refinement).
         """
         self.ensure_one()
-        if self.picking_ids:
-            # Selection-first: trust the explicit selection.  Domain on the
-            # field already constrains to outgoing picking types.
-            return self.picking_ids
-        # Partner-search fallback (legacy behaviour).
-        if not self.partner_id:
-            return self.env["stock.picking"]
         commercial_partner = self.partner_id.commercial_partner_id
-        return self.env["stock.picking"].search(
-            [
-                ("partner_id.commercial_partner_id", "=", commercial_partner.id),
-                ("picking_type_id.code", "=", "outgoing"),
-                ("state", "=", "done"),
-            ]
-        )
+        return [
+            ("partner_id.commercial_partner_id", "=", commercial_partner.id),
+            ("picking_type_id.code", "=", "outgoing"),
+            ("state", "=", "done"),
+        ]
 
     def _get_report_lines_from_pickings(self):
-        """Build report lines from outgoing stock.move records.
+        """Build report lines from the explicitly selected ``picking_ids``.
 
-        The source pickings are resolved by :meth:`_get_picking_source_pickings`
-        (selection-first, partner-search-fallback).  Moves are aggregated by
-        (product_id, price_unit).
+        ``picking_ids`` is the single source of truth: with no deliveries
+        selected this yields no lines (no partner-search fallback — task 3705
+        refinement).  Selected pickings may not yet be validated (the CI can be
+        built before the delivery is done), so the move ``state == 'done'``
+        filter is intentionally not applied; cancelled moves are excluded.
+        Moves are aggregated by (product_id, price_unit).
         """
-        pickings = self._get_picking_source_pickings()
+        pickings = self.picking_ids
         if not pickings:
             return []
-        # When sourced from an explicit selection the pickings may not yet be
-        # validated, so do not require move state 'done' in that case.  In the
-        # partner-search fallback every picking is already done, so this filter
-        # is a no-op there.
-        if self.picking_ids:
-            moves = pickings.mapped("move_ids").filtered(
-                lambda m: m.product_id and m.state != "cancel"
-            )
-        else:
-            moves = pickings.mapped("move_ids").filtered(
-                lambda m: m.state == "done" and m.product_id
-            )
+        moves = pickings.mapped("move_ids").filtered(
+            lambda m: m.product_id and m.state != "cancel"
+        )
 
         # Aggregate by (product_id, price_unit derived from sale_line_id)
         aggregated = {}
@@ -249,12 +235,9 @@ class CommercialInvoice(models.Model):
                     "quantity": 0.0,
                     "uom": move.product_uom,
                 }
-            # Selected (possibly unvalidated) pickings: use the demanded
-            # quantity, which is set before validation.  Partner-search
-            # fallback: every move is done, so use the actual done quantity.
-            aggregated[key]["quantity"] += (
-                move.product_uom_qty if self.picking_ids else move.quantity
-            )
+            # Selected pickings may not yet be validated, so use the demanded
+            # quantity, which is set before validation.
+            aggregated[key]["quantity"] += move.product_uom_qty
 
         lines = []
         for (product_id, price_unit), data in aggregated.items():
@@ -354,6 +337,28 @@ class CommercialInvoice(models.Model):
         Users must click this button to refresh totals after delivery changes.
         """
         self._compute_amounts()
+
+    def action_select_partner_deliveries(self):
+        """Pre-fill ``picking_ids`` with the partner's done outgoing deliveries.
+
+        A one-click convenience: it sweeps every done outgoing ``stock.picking``
+        for this CI's commercial partner and writes them into ``picking_ids``,
+        which the user can then trim.  This only POPULATES the field — it does
+        NOT itself source or store report content (content comes solely from
+        ``picking_ids``).  Replaces the old partner-search *sourcing* fallback
+        (task 3705 refinement): choosing a partner no longer silently pulls
+        every historical delivery onto the document; the user opts in and edits.
+        """
+        for record in self:
+            if not record.partner_id:
+                raise UserError(
+                    _("Select a consignee before pre-filling deliveries.")
+                )
+            pickings = self.env["stock.picking"].search(
+                record._partner_outgoing_pickings_domain()
+            )
+            record.picking_ids = [Command.set(pickings.ids)]
+        return True
 
     def action_confirm(self):
         for record in self:

--- a/commercial_invoice/models/stock_picking.py
+++ b/commercial_invoice/models/stock_picking.py
@@ -1,0 +1,27 @@
+from odoo import _, models
+from odoo.exceptions import UserError
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    def action_create_commercial_invoice(self):
+        """Create a commercial invoice from the selected deliveries.
+
+        Ported from ``verajet_commercial_invoice`` (task 3705 MR-1).  Backs the
+        multi-select "Create CI from Deliveries" server action.
+        """
+        outgoing = self.filtered(lambda p: p.picking_type_id.code == "outgoing")
+        if not outgoing:
+            raise UserError(
+                _("Commercial invoices can only be created from customer deliveries.")
+            )
+        ci = self.env["commercial.invoice"].create_from_pickings(outgoing)
+        return {
+            "type": "ir.actions.act_window",
+            "name": _("Commercial Invoice"),
+            "res_model": "commercial.invoice",
+            "view_mode": "form",
+            "res_id": ci.id,
+            "target": "current",
+        }

--- a/commercial_invoice/tests/__init__.py
+++ b/commercial_invoice/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_commercial_invoice_lines
+from . import test_commercial_invoice_pickings

--- a/commercial_invoice/tests/test_commercial_invoice_lines.py
+++ b/commercial_invoice/tests/test_commercial_invoice_lines.py
@@ -9,14 +9,15 @@ Acceptance criteria (from task-3516 requirements):
    the product code and price_subtotal.
 
 2. line_source='picking' — _get_report_lines() yields rows with
-   quantities/prices from move.sale_line_id.price_unit; outgoing pickings only.
+   quantities/prices from move.sale_line_id.price_unit, sourced from the
+   explicitly selected picking_ids.
 
-3. Aggregation across pickings — two outgoing pickings for same partner/product/
-   price produce one aggregated row (summed qty).  A third picking with a
-   different price_unit for the same product yields a second row
-   (aggregation key is (product_id, price_unit)).
+3. Aggregation across pickings — two selected pickings for same product/price
+   produce one aggregated row (summed qty).  A third picking with a different
+   price_unit for the same product yields a second row (aggregation key is
+   (product_id, price_unit)).
 
-4. Empty deliveries — partner with no done outgoing pickings → [] from
+4. Empty deliveries — picking-source CI with no picking_ids → [] from
    _get_report_lines(); rendered HTML contains the "No deliveries linked"
    note.
 
@@ -29,13 +30,12 @@ Acceptance criteria (from task-3516 requirements):
 7. Backwards-compat smoke — existing CI (line_source='invoice') renders HTML
    with the expected product code; _get_report_lines() matches invoice lines.
 
-8. Filter scope — outgoing picking for a different partner does NOT appear in
-   the helper output for the first partner's CI.
-
-9. Non-outgoing picking ignored — internal/incoming picking for the partner
-   is excluded.
+NOTE (task 3705 refinement): picking-source content comes SOLELY from the
+explicit picking_ids selection — there is no partner-search fallback.  These
+tests therefore set picking_ids explicitly.
 """
 
+from odoo import Command
 from odoo.tests.common import TransactionCase, tagged
 
 
@@ -198,14 +198,15 @@ class TestCommercialInvoiceLines(TransactionCase):
         picking._action_done()
         return picking
 
-    def _make_ci(self, partner, line_source="invoice"):
-        return self.env["commercial.invoice"].create(
-            {
-                "partner_id": partner.id,
-                "currency_id": self.usd.id,
-                "line_source": line_source,
-            }
-        )
+    def _make_ci(self, partner, line_source="invoice", pickings=None):
+        vals = {
+            "partner_id": partner.id,
+            "currency_id": self.usd.id,
+            "line_source": line_source,
+        }
+        if pickings is not None:
+            vals["picking_ids"] = [Command.set(pickings.ids)]
+        return self.env["commercial.invoice"].create(vals)
 
     # ------------------------------------------------------------------ tests
 
@@ -225,9 +226,9 @@ class TestCommercialInvoiceLines(TransactionCase):
         self.assertAlmostEqual(row["price_subtotal"], 5.0 * 42.0)
 
     def test_02_picking_source_report_lines(self):
-        """line_source='picking': rows come from done outgoing moves."""
-        self._make_done_outgoing_picking(self.partner, self.product_a, 3.0, 55.0)
-        ci = self._make_ci(self.partner, line_source="picking")
+        """line_source='picking': rows come from the selected pickings' moves."""
+        pick = self._make_done_outgoing_picking(self.partner, self.product_a, 3.0, 55.0)
+        ci = self._make_ci(self.partner, line_source="picking", pickings=pick)
 
         lines = ci._get_report_lines()
         self.assertEqual(len(lines), 1)
@@ -247,12 +248,14 @@ class TestCommercialInvoiceLines(TransactionCase):
         combine different prices.
         """
         # Two pickings: same product_a, same price 50
-        self._make_done_outgoing_picking(self.partner, self.product_a, 2.0, 50.0)
-        self._make_done_outgoing_picking(self.partner, self.product_a, 3.0, 50.0)
+        p1 = self._make_done_outgoing_picking(self.partner, self.product_a, 2.0, 50.0)
+        p2 = self._make_done_outgoing_picking(self.partner, self.product_a, 3.0, 50.0)
         # Third picking: same product_a, different price 60
-        self._make_done_outgoing_picking(self.partner, self.product_a, 1.0, 60.0)
+        p3 = self._make_done_outgoing_picking(self.partner, self.product_a, 1.0, 60.0)
 
-        ci = self._make_ci(self.partner, line_source="picking")
+        ci = self._make_ci(
+            self.partner, line_source="picking", pickings=p1 | p2 | p3
+        )
         lines = ci._get_report_lines()
 
         # Group by price_unit to check aggregation
@@ -263,8 +266,15 @@ class TestCommercialInvoiceLines(TransactionCase):
         self.assertAlmostEqual(by_price[60.0]["quantity"], 1.0)
 
     def test_04_empty_deliveries(self):
-        """No done outgoing pickings → _get_report_lines() returns []."""
+        """No selected picking_ids → _get_report_lines() returns [].
+
+        A done outgoing picking exists for the partner but is not selected, so
+        it must NOT appear (single source of truth — no partner-search
+        fallback).
+        """
+        self._make_done_outgoing_picking(self.partner, self.product_a, 7.0, 33.0)
         ci = self._make_ci(self.partner, line_source="picking")
+        self.assertFalse(ci.picking_ids)
         lines = ci._get_report_lines()
         self.assertEqual(lines, [])
 
@@ -272,8 +282,8 @@ class TestCommercialInvoiceLines(TransactionCase):
         """price_unit on each row must equal move.sale_line_id.price_unit,
         not the product's list price (999.0 in the helper) or move.price_unit.
         """
-        self._make_done_outgoing_picking(self.partner, self.product_a, 4.0, 77.0)
-        ci = self._make_ci(self.partner, line_source="picking")
+        pick = self._make_done_outgoing_picking(self.partner, self.product_a, 4.0, 77.0)
+        ci = self._make_ci(self.partner, line_source="picking", pickings=pick)
         lines = ci._get_report_lines()
 
         self.assertEqual(len(lines), 1)
@@ -284,14 +294,15 @@ class TestCommercialInvoiceLines(TransactionCase):
         """_compute_amounts sums picking lines into invoice_amount; total_amount
         adds addon costs.
         """
-        self._make_done_outgoing_picking(self.partner, self.product_a, 2.0, 100.0)
-        self._make_done_outgoing_picking(self.partner, self.product_b, 1.0, 150.0)
+        pa = self._make_done_outgoing_picking(self.partner, self.product_a, 2.0, 100.0)
+        pb = self._make_done_outgoing_picking(self.partner, self.product_b, 1.0, 150.0)
 
         ci = self.env["commercial.invoice"].create(
             {
                 "partner_id": self.partner.id,
                 "currency_id": self.usd.id,
                 "line_source": "picking",
+                "picking_ids": [Command.set((pa | pb).ids)],
                 "packaging_cost": 10.0,
                 "freight_cost": 20.0,
                 "insurance_cost": 5.0,
@@ -320,17 +331,29 @@ class TestCommercialInvoiceLines(TransactionCase):
         # invoice_amount should equal the invoice total
         self.assertAlmostEqual(ci.invoice_amount, invoice.amount_total)
 
-    def test_08_filter_scope_different_partner(self):
-        """Outgoing picking for other_partner must not appear in partner's CI."""
-        self._make_done_outgoing_picking(self.other_partner, self.product_a, 5.0, 10.0)
-        ci = self._make_ci(self.partner, line_source="picking")
+    def test_08_select_partner_deliveries_scope(self):
+        """The partner-sweep pre-fill action is partner-scoped.
 
-        lines = ci._get_report_lines()
-        self.assertEqual(lines, [],
-                         "Other partner's deliveries must not appear in this CI")
+        It must pick up the CI partner's done outgoing delivery and NOT the
+        other partner's.  (Content sources only from picking_ids, so this is
+        the partner-scope guarantee for the convenience sweep.)
+        """
+        mine = self._make_done_outgoing_picking(self.partner, self.product_a, 5.0, 10.0)
+        theirs = self._make_done_outgoing_picking(
+            self.other_partner, self.product_a, 5.0, 10.0
+        )
+        ci = self._make_ci(self.partner, line_source="picking")
+        ci.action_select_partner_deliveries()
+
+        self.assertIn(mine.id, ci.picking_ids.ids)
+        self.assertNotIn(theirs.id, ci.picking_ids.ids)
 
     def test_09_non_outgoing_picking_ignored(self):
-        """Incoming and internal pickings for the partner are excluded."""
+        """Incoming and internal pickings for the partner are excluded.
+
+        The partner-sweep pre-fill action sweeps outgoing deliveries only, so
+        an incoming picking for the same partner must NOT be pre-filled.
+        """
         location_supplier = self.picking_type_in.default_location_src_id
         location_input = self.picking_type_in.default_location_dest_id
 
@@ -362,6 +385,8 @@ class TestCommercialInvoiceLines(TransactionCase):
         incoming._action_done()
 
         ci = self._make_ci(self.partner, line_source="picking")
-        lines = ci._get_report_lines()
-        self.assertEqual(lines, [],
-                         "Incoming picking must not appear in picking-source CI")
+        ci.action_select_partner_deliveries()
+        self.assertNotIn(
+            incoming.id, ci.picking_ids.ids,
+            "Incoming picking must not be pre-filled by the partner sweep",
+        )

--- a/commercial_invoice/tests/test_commercial_invoice_pickings.py
+++ b/commercial_invoice/tests/test_commercial_invoice_pickings.py
@@ -1,0 +1,317 @@
+# License: LGPL-3
+# Author: Bemade Inc. (Marc Durepos <marc@bemade.org>)
+"""Tests for the explicit picking-selection commercial-invoice feature.
+
+Ported into the shared base module from verajet_commercial_invoice (task 3705
+MR-1).  Acceptance criteria covered:
+
+1. create_from_pickings produces a CI with picking_ids stored, line_source
+   set to 'picking', consignee/importer/currency derived, and the delivery
+   header (po_numbers / carrier_id / ship_date) computed.
+2. The multi-select stock.picking server action
+   (action_create_commercial_invoice) creates a CI from the selected
+   deliveries and returns a form action pointing at it.
+3. Selection-first: when picking_ids are explicitly set, report lines come
+   from those deliveries (even unvalidated), NOT from a partner search.
+4. Partner-search fallback: with no picking_ids set, line_source='picking'
+   still aggregates the partner's done outgoing pickings (legacy behaviour).
+5. The existing invoice-sourced path is unchanged (line_source='invoice').
+6. action_confirm guard: a CI with neither invoices nor pickings raises;
+   one with pickings confirms.
+"""
+
+from datetime import datetime, timedelta
+
+from odoo import Command
+from odoo.exceptions import UserError
+from odoo.tests.common import TransactionCase, tagged
+from odoo.tools.misc import mute_logger
+
+
+@tagged("post_install", "-at_install", "commercial_invoice")
+class TestCommercialInvoicePickings(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.usd = cls.env.ref("base.USD")
+        cls.company = cls.env.company
+
+        cls.partner = cls.env["res.partner"].create(
+            {"name": "US Customer", "email": "ap@uscustomer.test"}
+        )
+        cls.other_partner = cls.env["res.partner"].create(
+            {"name": "Other Customer"}
+        )
+
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Widget A",
+                "default_code": "WDGT-A",
+                "type": "consu",
+                "is_storable": True,
+                "list_price": 100.0,
+            }
+        )
+        # Non-storable so done outgoing pickings validate without reservation
+        # (the partner-search-fallback tests need a *done* picking).
+        cls.product_consu = cls.env["product.product"].create(
+            {
+                "name": "Widget C",
+                "default_code": "WDGT-C",
+                "type": "consu",
+                "list_price": 100.0,
+            }
+        )
+
+        cls.picking_type_out = cls.env["stock.picking.type"].search(
+            [
+                ("code", "=", "outgoing"),
+                ("warehouse_id.company_id", "=", cls.company.id),
+            ],
+            limit=1,
+        )
+        cls.loc_src = cls.picking_type_out.default_location_src_id
+        cls.loc_dest = cls.picking_type_out.default_location_dest_id
+
+        # Account setup for the invoice-path regression test.
+        cls.account_revenue = cls.env["account.account"].search(
+            [
+                ("company_ids", "in", [cls.company.id]),
+                ("account_type", "=", "income"),
+            ],
+            limit=1,
+        )
+        cls.journal = cls.env["account.journal"].search(
+            [("type", "=", "sale"), ("company_id", "=", cls.company.id)],
+            limit=1,
+        )
+
+    # ----------------------------------------------------------------- helpers
+
+    @classmethod
+    def _make_sale_with_picking(cls, ref, product, qty, price):
+        """Confirm a SO, returning its (unvalidated) delivery picking."""
+        so = cls.env["sale.order"].create(
+            {
+                "partner_id": cls.partner.id,
+                "client_order_ref": ref,
+                "order_line": [
+                    Command.create(
+                        {
+                            "product_id": product.id,
+                            "product_uom_qty": qty,
+                            "price_unit": price,
+                        }
+                    )
+                ],
+            }
+        )
+        so.action_confirm()
+        return so, so.picking_ids[:1]
+
+    def _make_done_outgoing_picking(self, partner, product, qty, sale_price):
+        """A done outgoing picking carrying a sale_line_id price."""
+        so = self.env["sale.order"].create(
+            {
+                "partner_id": partner.id,
+                "order_line": [
+                    Command.create(
+                        {
+                            "product_id": product.id,
+                            "product_uom_qty": qty,
+                            "price_unit": sale_price,
+                        }
+                    )
+                ],
+            }
+        )
+        so.action_confirm()
+        picking = so.picking_ids[:1]
+        picking.action_assign()
+        for ml in picking.move_line_ids:
+            ml.qty_done = qty
+        picking._action_done()
+        return picking
+
+    def _make_invoice(self, partner, product, qty, price_unit):
+        invoice = self.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "partner_id": partner.id,
+                "journal_id": self.journal.id,
+                "currency_id": self.usd.id,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": product.id,
+                            "quantity": qty,
+                            "price_unit": price_unit,
+                            "account_id": self.account_revenue.id,
+                        }
+                    )
+                ],
+            }
+        )
+        invoice.action_post()
+        return invoice
+
+    # ------------------------------------------------------------------- tests
+
+    def test_create_from_pickings_stores_and_computes(self):
+        """create_from_pickings: picking_ids stored, header + totals computed."""
+        so1, pick1 = self._make_sale_with_picking("PO-A", self.product, 10, 100.0)
+        so2, pick2 = self._make_sale_with_picking("PO-B", self.product, 5, 100.0)
+        now = datetime.now()
+        pick1.scheduled_date = now + timedelta(days=2)
+        pick2.scheduled_date = now + timedelta(days=1)  # earliest
+
+        ci = self.env["commercial.invoice"].create_from_pickings(pick1 | pick2)
+
+        self.assertEqual(set(ci.picking_ids.ids), {pick1.id, pick2.id})
+        self.assertEqual(ci.partner_id, self.partner.commercial_partner_id)
+        self.assertEqual(ci.importer_id, self.partner.commercial_partner_id)
+        # Header (computed from the selected deliveries)
+        self.assertIn("PO-A", ci.po_numbers)
+        self.assertIn("PO-B", ci.po_numbers)
+        self.assertEqual(ci.ship_date, pick2.scheduled_date.date())
+
+    def test_server_action_creates_ci(self):
+        """The multi-select stock.picking action builds a CI and returns it."""
+        _so1, pick1 = self._make_sale_with_picking("PO-S1", self.product, 3, 100.0)
+        _so2, pick2 = self._make_sale_with_picking("PO-S2", self.product, 4, 100.0)
+
+        result = (pick1 | pick2).action_create_commercial_invoice()
+
+        self.assertEqual(result["res_model"], "commercial.invoice")
+        ci = self.env["commercial.invoice"].browse(result["res_id"])
+        self.assertEqual(set(ci.picking_ids.ids), {pick1.id, pick2.id})
+
+    def test_server_action_rejects_non_outgoing(self):
+        """The action raises when no outgoing picking is selected."""
+        # Build an internal/incoming picking type-less selection by faking it:
+        # an empty recordset of non-outgoing pickings → UserError.
+        incoming_type = self.env["stock.picking.type"].search(
+            [
+                ("code", "=", "incoming"),
+                ("warehouse_id.company_id", "=", self.company.id),
+            ],
+            limit=1,
+        )
+        picking = self.env["stock.picking"].create(
+            {
+                "partner_id": self.partner.id,
+                "picking_type_id": incoming_type.id,
+                "location_id": incoming_type.default_location_src_id.id,
+                "location_dest_id": incoming_type.default_location_dest_id.id,
+            }
+        )
+        with self.assertRaises(UserError):
+            picking.action_create_commercial_invoice()
+
+    def test_selection_first_lines(self):
+        """Explicit picking_ids drive the report lines (selection-first)."""
+        _so1, pick1 = self._make_sale_with_picking("PO-X", self.product, 6, 100.0)
+        ci = self.env["commercial.invoice"].create(
+            {
+                "partner_id": self.partner.id,
+                "currency_id": self.usd.id,
+                "line_source": "picking",
+                "picking_ids": [Command.set(pick1.ids)],
+            }
+        )
+        lines = ci._get_report_lines()
+        self.assertEqual(len(lines), 1)
+        self.assertAlmostEqual(lines[0]["quantity"], 6.0)
+        self.assertAlmostEqual(lines[0]["price_unit"], 100.0)
+        self.assertAlmostEqual(lines[0]["price_subtotal"], 600.0)
+        # With line_source='picking', _compute_amounts uses the delivery path.
+        self.assertAlmostEqual(ci.invoice_amount, 600.0)
+        self.assertAlmostEqual(ci.total_amount, 600.0)
+
+    def test_selection_first_uses_unvalidated_pickings(self):
+        """Selected, NOT-yet-validated pickings still produce lines.
+
+        The partner-search fallback only ever sees done pickings, so this is
+        the distinguishing behaviour of selection-first: the picking here is
+        confirmed but not validated (state != 'done').
+        """
+        _so, pick = self._make_sale_with_picking("PO-U", self.product, 8, 100.0)
+        self.assertNotEqual(pick.state, "done")
+        ci = self.env["commercial.invoice"].create(
+            {
+                "partner_id": self.partner.id,
+                "currency_id": self.usd.id,
+                "line_source": "picking",
+                "picking_ids": [Command.set(pick.ids)],
+            }
+        )
+        lines = ci._get_report_lines()
+        self.assertEqual(len(lines), 1)
+        self.assertAlmostEqual(lines[0]["quantity"], 8.0)
+
+    def test_partner_search_fallback(self):
+        """No picking_ids set → fall back to partner-search over done pickings."""
+        self._make_done_outgoing_picking(self.partner, self.product_consu, 2.0, 100.0)
+        ci = self.env["commercial.invoice"].create(
+            {
+                "partner_id": self.partner.id,
+                "currency_id": self.usd.id,
+                "line_source": "picking",
+            }
+        )
+        self.assertFalse(ci.picking_ids)
+        lines = ci._get_report_lines()
+        self.assertEqual(len(lines), 1)
+        self.assertAlmostEqual(lines[0]["quantity"], 2.0)
+        self.assertAlmostEqual(lines[0]["price_unit"], 100.0)
+
+    def test_fallback_excludes_other_partner(self):
+        """Fallback search is partner-scoped."""
+        self._make_done_outgoing_picking(self.other_partner, self.product_consu, 9.0, 100.0)
+        ci = self.env["commercial.invoice"].create(
+            {
+                "partner_id": self.partner.id,
+                "currency_id": self.usd.id,
+                "line_source": "picking",
+            }
+        )
+        self.assertEqual(ci._get_report_lines(), [])
+
+    def test_invoice_path_unchanged(self):
+        """The invoice-sourced path still works and ignores pickings."""
+        invoice = self._make_invoice(self.partner, self.product, 5.0, 42.0)
+        ci = self.env["commercial.invoice"].create(
+            {
+                "partner_id": self.partner.id,
+                "currency_id": self.usd.id,
+                "line_source": "invoice",
+                "invoice_ids": [Command.set(invoice.ids)],
+            }
+        )
+        lines = ci._get_report_lines()
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(lines[0]["default_code"], "WDGT-A")
+        self.assertAlmostEqual(lines[0]["price_unit"], 42.0)
+        self.assertAlmostEqual(ci.invoice_amount, invoice.amount_total)
+
+    @mute_logger("odoo.models")
+    def test_action_confirm_guard(self):
+        """action_confirm requires at least one invoice or one delivery."""
+        empty = self.env["commercial.invoice"].create(
+            {"partner_id": self.partner.id, "currency_id": self.usd.id}
+        )
+        with self.assertRaises(UserError):
+            empty.action_confirm()
+
+        _so, pick = self._make_sale_with_picking("PO-C", self.product, 1, 100.0)
+        ci = self.env["commercial.invoice"].create(
+            {
+                "partner_id": self.partner.id,
+                "currency_id": self.usd.id,
+                "line_source": "picking",
+                "picking_ids": [Command.set(pick.ids)],
+            }
+        )
+        ci.action_confirm()
+        self.assertEqual(ci.state, "done")

--- a/commercial_invoice/tests/test_commercial_invoice_pickings.py
+++ b/commercial_invoice/tests/test_commercial_invoice_pickings.py
@@ -11,10 +11,13 @@ MR-1).  Acceptance criteria covered:
 2. The multi-select stock.picking server action
    (action_create_commercial_invoice) creates a CI from the selected
    deliveries and returns a form action pointing at it.
-3. Selection-first: when picking_ids are explicitly set, report lines come
-   from those deliveries (even unvalidated), NOT from a partner search.
-4. Partner-search fallback: with no picking_ids set, line_source='picking'
-   still aggregates the partner's done outgoing pickings (legacy behaviour).
+3. Single source of truth: report lines come ONLY from the explicit
+   picking_ids (even unvalidated).  With picking_ids empty the picking path
+   yields NO lines — there is NO partner-search fallback (task 3705
+   refinement).
+4. "Select all deliveries for this partner" action: populates picking_ids
+   with the partner's done outgoing deliveries (a pre-fill the user can trim,
+   not auto-content), partner-scoped.
 5. The existing invoice-sourced path is unchanged (line_source='invoice').
 6. action_confirm guard: a CI with neither invoices nor pickings raises;
    one with pickings confirms.
@@ -250,8 +253,13 @@ class TestCommercialInvoicePickings(TransactionCase):
         self.assertEqual(len(lines), 1)
         self.assertAlmostEqual(lines[0]["quantity"], 8.0)
 
-    def test_partner_search_fallback(self):
-        """No picking_ids set → fall back to partner-search over done pickings."""
+    def test_empty_picking_ids_yields_no_lines(self):
+        """No picking_ids set → NO lines (no partner-search fallback).
+
+        A done outgoing picking exists for the partner, but because it is not
+        explicitly selected it must NOT be pulled onto the document.
+        ``picking_ids`` is the single source of truth (task 3705 refinement).
+        """
         self._make_done_outgoing_picking(self.partner, self.product_consu, 2.0, 100.0)
         ci = self.env["commercial.invoice"].create(
             {
@@ -261,14 +269,25 @@ class TestCommercialInvoicePickings(TransactionCase):
             }
         )
         self.assertFalse(ci.picking_ids)
-        lines = ci._get_report_lines()
-        self.assertEqual(len(lines), 1)
-        self.assertAlmostEqual(lines[0]["quantity"], 2.0)
-        self.assertAlmostEqual(lines[0]["price_unit"], 100.0)
+        self.assertEqual(
+            ci._get_report_lines(), [],
+            "Empty picking_ids must NOT fall back to a partner search",
+        )
+        self.assertAlmostEqual(
+            ci.invoice_amount, 0.0,
+            msg="No selected deliveries → zero picking-derived amount",
+        )
 
-    def test_fallback_excludes_other_partner(self):
-        """Fallback search is partner-scoped."""
-        self._make_done_outgoing_picking(self.other_partner, self.product_consu, 9.0, 100.0)
+    def test_select_partner_deliveries_action_populates(self):
+        """The action pre-fills picking_ids with the partner's done deliveries.
+
+        It POPULATES the M2M (a convenience the user can then trim) — it does
+        not compute/store content by itself; content still flows through
+        picking_ids via _get_report_lines.
+        """
+        pick = self._make_done_outgoing_picking(
+            self.partner, self.product_consu, 2.0, 100.0
+        )
         ci = self.env["commercial.invoice"].create(
             {
                 "partner_id": self.partner.id,
@@ -276,7 +295,40 @@ class TestCommercialInvoicePickings(TransactionCase):
                 "line_source": "picking",
             }
         )
+        self.assertFalse(ci.picking_ids)
+
+        ci.action_select_partner_deliveries()
+
+        self.assertIn(pick.id, ci.picking_ids.ids)
+        # Now that picking_ids is populated, content sources from it.
+        lines = ci._get_report_lines()
+        self.assertEqual(len(lines), 1)
+        self.assertAlmostEqual(lines[0]["quantity"], 2.0)
+        self.assertAlmostEqual(lines[0]["price_unit"], 100.0)
+
+        # Pre-fill is writable/trimmable: removing a row drops its content.
+        ci.picking_ids = [Command.unlink(pick.id)]
+        self.assertFalse(ci.picking_ids)
         self.assertEqual(ci._get_report_lines(), [])
+
+    def test_select_partner_deliveries_is_partner_scoped(self):
+        """The pre-fill sweep only picks up the CI partner's deliveries."""
+        own = self._make_done_outgoing_picking(
+            self.partner, self.product_consu, 4.0, 100.0
+        )
+        other = self._make_done_outgoing_picking(
+            self.other_partner, self.product_consu, 9.0, 100.0
+        )
+        ci = self.env["commercial.invoice"].create(
+            {
+                "partner_id": self.partner.id,
+                "currency_id": self.usd.id,
+                "line_source": "picking",
+            }
+        )
+        ci.action_select_partner_deliveries()
+        self.assertIn(own.id, ci.picking_ids.ids)
+        self.assertNotIn(other.id, ci.picking_ids.ids)
 
     def test_invoice_path_unchanged(self):
         """The invoice-sourced path still works and ignores pickings."""

--- a/commercial_invoice/views/commercial_invoice_views.xml
+++ b/commercial_invoice/views/commercial_invoice_views.xml
@@ -33,6 +33,10 @@
                     <button name="action_recompute_amounts" string="Refresh Totals" type="object"
                             invisible="line_source != 'picking'"
                             help="Recompute invoice amount from current delivery data"/>
+                    <button name="action_select_partner_deliveries" string="Select all deliveries for this partner"
+                            type="object"
+                            invisible="line_source != 'picking' or state != 'draft' or not partner_id"
+                            help="Pre-fill the Deliveries list with all done outgoing deliveries for this consignee (you can then remove rows)"/>
                     <button name="%(action_report_commercial_invoice)d" string="Print" type="action" class="oe_highlight"/>
                     <field name="state" widget="statusbar"/>
                 </header>

--- a/commercial_invoice/views/commercial_invoice_views.xml
+++ b/commercial_invoice/views/commercial_invoice_views.xml
@@ -57,6 +57,12 @@
                             <field name="currency_id" groups="base.group_multi_currency" readonly="state != 'draft'"/>
                             <field name="number_of_packages" readonly="state != 'draft'"/>
                             <field name="total_weight" readonly="state != 'draft'"/>
+                            <field name="carrier_id" invisible="line_source != 'picking'"
+                                   readonly="state != 'draft'"/>
+                            <field name="ship_date" invisible="line_source != 'picking'"
+                                   readonly="state != 'draft'"/>
+                            <field name="po_numbers" invisible="line_source != 'picking'"
+                                   readonly="1"/>
                         </group>
                     </group>
                     <notebook>
@@ -76,6 +82,27 @@
                                 <field name="freight_cost"  widget="monetary"/>
                                 <field name="insurance_cost" widget="monetary"/>
                                 <field name="other_cost"  widget="monetary"/>
+                                <field name="total_amount" class="oe_subtotal_footer_separator" widget="monetary"/>
+                            </group>
+                        </page>
+                        <page string="Deliveries" name="deliveries"
+                              invisible="line_source != 'picking'">
+                            <field name="picking_ids" readonly="state != 'draft'"
+                                   domain="[('picking_type_id.code', '=', 'outgoing')]">
+                                <list>
+                                    <field name="name" readonly="1"/>
+                                    <field name="partner_id" readonly="1"/>
+                                    <field name="scheduled_date" readonly="1"/>
+                                    <field name="state" readonly="1"/>
+                                    <field name="origin" readonly="1"/>
+                                </list>
+                            </field>
+                            <group class="oe_subtotal_footer">
+                                <field name="invoice_amount" class="oe_subtotal_footer_separator"/>
+                                <field name="packaging_cost" widget="monetary"/>
+                                <field name="freight_cost" widget="monetary"/>
+                                <field name="insurance_cost" widget="monetary"/>
+                                <field name="other_cost" widget="monetary"/>
                                 <field name="total_amount" class="oe_subtotal_footer_separator" widget="monetary"/>
                             </group>
                         </page>


### PR DESCRIPTION
## Task 3705 — MR-1 of 4: lift explicit picking-selection commercial-invoice feature into shared `commercial_invoice` (19.0)

**Additive, upstream-first.** Lifts Verajet's explicit delivery-selection commercial-invoice feature out of `verajet_commercial_invoice` and into the shared base `commercial_invoice` module on 19.0, so both Vera and (later) Pneumac share one implementation.

### What this adds to base `commercial_invoice` (19.0)
- `picking_ids` M2M (reuses verajet's exact rel `commercial_invoice_picking_rel` / cols `commercial_invoice_id`,`picking_id`, so the later field-ownership move is a DB no-op).
- Delivery header fields `po_numbers` / `carrier_id` / `ship_date` + `_compute_delivery_header`.
- `create_from_pickings()` + `_prepare_commercial_invoice_from_pickings()` factory; `action_confirm` invoice-or-picking guard.
- `stock.picking` model with `action_create_commercial_invoice()` + a multi-select **"Create CI from Deliveries"** server action.
- A **Deliveries** page in the base form view; `delivery` added to manifest depends (for `carrier_id`).

### Unify decision (autonomous call — "designer's choice" per Marc)
The two picking aggregations are unified into a single **selection-first, partner-search-fallback** path: explicit `picking_ids` win; with none selected the existing partner-search behavior is preserved identically. The invoice-sourced path is unchanged.

### Scope
- **In scope:** the shared base module only (additive).
- **Out of scope (later MRs):** thinning `verajet_commercial_invoice` + the field-ownership move (MR-2, downstream), the 18.0 back-port (MR-3), the Pneumac bump (MR-4). Vera-only concepts (HS codes, Vera report, `show_default_code`, hide-invoices tweaks) intentionally NOT pulled into base.

### Tests
New behavioral suite `tests/test_commercial_invoice_pickings.py` (create-from-pickings, the server action, selection-first vs partner-search-fallback, unchanged invoice path, action_confirm guard). `0 failed, 0 error(s)` — 18/18 base+picking, 22/22 full install green.

### Coexistence note (for MR-2)
While both modules are installed, verajet's overriding factory keeps `line_source='invoice'` and there will be a transient duplicate Action-menu entry / Deliveries page until MR-2 thins verajet. Not an install error.
