### PR TITLE
[3705] commercial_invoice: back-port delivery source to 18.0 (MR-3/4)

### DIFF
--- a/commercial_invoice/__manifest__.py
+++ b/commercial_invoice/__manifest__.py
@@ -1,12 +1,15 @@
 {
     'name': 'Commercial Invoice',
-    'version': '18.0.1.1.1',
+    'version': '18.0.1.2.0',
     'category': 'Accounting',
     'summary': 'Generate commercial invoices for cross-border shipments',
     'description': """
         Generate commercial invoices for cross-border shipments between Canada and the USA.
         Features:
         - Group multiple invoices into a single commercial invoice
+        - Build a commercial invoice from explicitly selected customer
+          deliveries (picking_ids is the single source of truth); a
+          "Select all deliveries for this partner" action pre-fills the list
         - Track additional costs (packaging, freight, insurance)
         - Print bilingual commercial invoice reports
     """,
@@ -16,15 +19,18 @@
     'depends': [
         'account',
         'stock_delivery',
+        'delivery',
         'mail',
     ],
     'data': [
         'security/ir.model.access.csv',
         'data/commercial_invoice_sequence.xml',
+        'data/stock_picking_actions.xml',
         'report/commercial_invoice_report.xml',
         'report/report_templates.xml',
         'views/account_move_views.xml',
         'views/commercial_invoice_views.xml',
+        'views/res_config_settings_views.xml',
     ],
     'installable': True,
     'application': False,

--- a/commercial_invoice/data/stock_picking_actions.xml
+++ b/commercial_invoice/data/stock_picking_actions.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Multi-select server action on stock.picking: build a commercial
+         invoice from the selected customer deliveries. Ported from
+         verajet_commercial_invoice (task 3705 MR-1). -->
+    <record id="action_picking_create_commercial_invoice" model="ir.actions.server">
+        <field name="name">Create CI from Deliveries</field>
+        <field name="model_id" ref="stock.model_stock_picking"/>
+        <field name="binding_model_id" ref="stock.model_stock_picking"/>
+        <field name="binding_view_types">list,form</field>
+        <field name="state">code</field>
+        <field name="code">action = records.action_create_commercial_invoice()</field>
+    </record>
+</odoo>

--- a/commercial_invoice/migrations/18.0.1.2.0/post-migrate.py
+++ b/commercial_invoice/migrations/18.0.1.2.0/post-migrate.py
@@ -1,0 +1,19 @@
+# License: LGPL-3
+# Author: Bemade Inc. (Marc Durepos <marc@bemade.org>)
+"""Post-migration: backfill line_source='invoice' on existing rows.
+
+Odoo normally backfills the default value for a new required Selection field
+on upgrade, but this explicit UPDATE guarantees correctness even if the ORM
+skips the backfill (e.g. when the column already exists with NULLs from a
+partial upgrade).
+"""
+
+
+def migrate(cr, version):
+    cr.execute(
+        """
+        UPDATE commercial_invoice
+        SET line_source = 'invoice'
+        WHERE line_source IS NULL
+        """
+    )

--- a/commercial_invoice/models/__init__.py
+++ b/commercial_invoice/models/__init__.py
@@ -1,2 +1,4 @@
-from . import commercial_invoice
 from . import account_move
+from . import commercial_invoice
+from . import stock_picking
+from . import res_config_settings

--- a/commercial_invoice/models/commercial_invoice.py
+++ b/commercial_invoice/models/commercial_invoice.py
@@ -1,4 +1,6 @@
-from odoo import api, fields, models, _
+from collections import Counter, OrderedDict
+
+from odoo import Command, api, fields, models, _
 from odoo.exceptions import UserError
 
 
@@ -19,6 +21,16 @@ class CommercialInvoice(models.Model):
         string="Status",
         default="draft",
         tracking=True,
+    )
+    line_source = fields.Selection(
+        [("invoice", "Invoices"), ("picking", "Deliveries")],
+        string="Line Source",
+        required=True,
+        default="invoice",
+        tracking=True,
+        help="Whether this commercial invoice sources its content from linked "
+        "Invoices or from explicitly selected Deliveries. With 'Deliveries' the "
+        "content comes solely from the Deliveries field (picking_ids).",
     )
 
     # Related parties
@@ -47,6 +59,49 @@ class CommercialInvoice(models.Model):
     )
     payment_term_id = fields.Many2one("account.payment.term", string="Payment Terms")
     incoterm_id = fields.Many2one("account.incoterms", string="Incoterms")
+
+    # Delivery (stock.picking) source — explicit picking selection.
+    #
+    # NOTE (field-ownership intent, task 3705 MR-1): picking_ids is REUSING the
+    # exact relation/column names that ``verajet_commercial_invoice`` already
+    # uses for its own ``picking_ids`` M2M
+    # (rel ``commercial_invoice_picking_rel``, columns
+    # ``commercial_invoice_id`` / ``picking_id``).  This is deliberate so that
+    # a later move of field ownership from the Vera overlay down into this base
+    # module is a no-op at the database level (same table/columns) rather than
+    # a delete+recreate.  Verajet's own ``picking_ids`` declaration is removed
+    # in the downstream MR-2; until then both declare the same relation, which
+    # the ORM collapses onto one table.
+    picking_ids = fields.Many2many(
+        "stock.picking",
+        "commercial_invoice_picking_rel",
+        "commercial_invoice_id",
+        "picking_id",
+        string="Deliveries",
+        domain="[('picking_type_id.code', '=', 'outgoing')]",
+    )
+    po_numbers = fields.Char(
+        string="PO Numbers",
+        compute="_compute_delivery_header",
+        compute_sudo=True,
+        store=True,
+        readonly=False,
+    )
+    carrier_id = fields.Many2one(
+        "delivery.carrier",
+        string="Carrier",
+        compute="_compute_delivery_header",
+        compute_sudo=True,
+        store=True,
+        readonly=False,
+    )
+    ship_date = fields.Date(
+        string="Ship Date",
+        compute="_compute_delivery_header",
+        compute_sudo=True,
+        store=True,
+        readonly=False,
+    )
 
     # Shipping details
     number_of_packages = fields.Integer(string="Number of Packages")
@@ -83,12 +138,144 @@ class CommercialInvoice(models.Model):
                 )
         return super().create(vals_list)
 
+    def _get_report_lines(self):
+        """Return a uniform list of dicts for QWeb report line iteration.
+
+        Each dict has the shape::
+
+            {
+                'name': str,
+                'default_code': str,
+                'hs_code': str,
+                'quantity': float,
+                'uom': res.uom record or False,
+                'price_unit': float,
+                'price_subtotal': float,
+                'country_of_origin': str,
+            }
+
+        When ``line_source == 'invoice'`` the data comes from
+        ``account.move.line`` records linked through ``invoice_ids``.
+
+        When ``line_source == 'picking'`` the data comes from the
+        ``stock.move`` records of the explicitly selected ``picking_ids``.
+        Moves are aggregated by (product_id, price_unit) so different unit
+        prices for the same product produce separate rows.  ``picking_ids`` is
+        the *single source of truth*: with no deliveries selected the picking
+        path yields no lines (task 3705 refinement — no partner-search
+        fallback; see :meth:`action_select_partner_deliveries`).
+        """
+        self.ensure_one()
+        if self.line_source == "picking":
+            return self._get_report_lines_from_pickings()
+        return self._get_report_lines_from_invoices()
+
+    def _get_report_lines_from_invoices(self):
+        """Build report lines from linked account.move.line records."""
+        lines = []
+        for line in self.invoice_ids.mapped("invoice_line_ids").filtered("product_id"):
+            lines.append(
+                {
+                    "name": line.product_id.name,
+                    "default_code": line.product_id.default_code or "",
+                    "hs_code": line.product_id.hs_code or "",
+                    "quantity": line.quantity,
+                    "uom": line.product_uom_id,
+                    "price_unit": line.price_unit,
+                    "price_subtotal": line.price_subtotal,
+                    "country_of_origin": line.product_id.country_of_origin.name or "",
+                }
+            )
+        return lines
+
+    def _partner_outgoing_pickings_domain(self):
+        """Domain for the CI partner's done outgoing deliveries.
+
+        Used by :meth:`action_select_partner_deliveries` to PRE-FILL
+        ``picking_ids`` (a convenience sweep the user can then trim).  It is
+        NOT a content/sourcing path — report lines come only from the explicit
+        ``picking_ids`` selection (task 3705 refinement).
+        """
+        self.ensure_one()
+        commercial_partner = self.partner_id.commercial_partner_id
+        return [
+            ("partner_id.commercial_partner_id", "=", commercial_partner.id),
+            ("picking_type_id.code", "=", "outgoing"),
+            ("state", "=", "done"),
+        ]
+
+    def _get_report_lines_from_pickings(self):
+        """Build report lines from the explicitly selected ``picking_ids``.
+
+        ``picking_ids`` is the single source of truth: with no deliveries
+        selected this yields no lines (no partner-search fallback — task 3705
+        refinement).  Selected pickings may not yet be validated (the CI can be
+        built before the delivery is done), so the move ``state == 'done'``
+        filter is intentionally not applied; cancelled moves are excluded.
+        Moves are aggregated by (product_id, price_unit).
+        """
+        pickings = self.picking_ids
+        if not pickings:
+            return []
+        moves = pickings.mapped("move_ids").filtered(
+            lambda m: m.product_id and m.state != "cancel"
+        )
+
+        # Aggregate by (product_id, price_unit derived from sale_line_id)
+        aggregated = {}
+        for move in moves:
+            price_unit = (
+                move.sale_line_id.price_unit if move.sale_line_id else 0.0
+            )
+            key = (move.product_id.id, price_unit)
+            if key not in aggregated:
+                aggregated[key] = {
+                    "product": move.product_id,
+                    "price_unit": price_unit,
+                    "quantity": 0.0,
+                    "uom": move.product_uom,
+                }
+            # Selected pickings may not yet be validated, so use the demanded
+            # quantity, which is set before validation.
+            aggregated[key]["quantity"] += move.product_uom_qty
+
+        lines = []
+        for (product_id, price_unit), data in aggregated.items():
+            product = data["product"]
+            qty = data["quantity"]
+            lines.append(
+                {
+                    "name": product.name,
+                    "default_code": product.default_code or "",
+                    "hs_code": product.hs_code or "",
+                    "quantity": qty,
+                    "uom": data["uom"],
+                    "price_unit": price_unit,
+                    "price_subtotal": qty * price_unit,
+                    "country_of_origin": product.country_of_origin.name or "",
+                }
+            )
+        return lines
+
     @api.depends(
-        "invoice_ids", "packaging_cost", "freight_cost", "insurance_cost", "other_cost"
+        "invoice_ids",
+        "invoice_ids.amount_total",
+        "line_source",
+        "partner_id",
+        "picking_ids",
+        "packaging_cost",
+        "freight_cost",
+        "insurance_cost",
+        "other_cost",
     )
     def _compute_amounts(self):
         for record in self:
-            record.invoice_amount = sum(record.invoice_ids.mapped("amount_total"))
+            if record.line_source == "picking":
+                record.invoice_amount = sum(
+                    row["price_subtotal"] for row in record._get_report_lines()
+                )
+            else:
+                record.invoice_amount = sum(record.invoice_ids.mapped("amount_total"))
             record.total_amount = (
                 record.invoice_amount
                 + record.packaging_cost
@@ -97,7 +284,91 @@ class CommercialInvoice(models.Model):
                 + record.other_cost
             )
 
+    @api.depends(
+        "picking_ids",
+        "picking_ids.sale_id",
+        "picking_ids.sale_id.client_order_ref",
+        "picking_ids.carrier_id",
+        "picking_ids.scheduled_date",
+        "picking_ids.date_done",
+    )
+    def _compute_delivery_header(self):
+        """Aggregate header fields from the selected deliveries.
+
+        Ported from ``verajet_commercial_invoice`` (task 3705 MR-1): PO
+        numbers, carrier and ship date are derived from ``picking_ids`` so a
+        delivery-sourced commercial invoice carries the shipment header that a
+        customs document needs.
+        """
+        for record in self:
+            pickings = record.picking_ids
+            # PO numbers: unique, keep insertion order, prefer client_order_ref,
+            # fall back to SO name when ref missing, then picking origin.
+            refs = OrderedDict()
+            for pick in pickings:
+                so = pick.sale_id
+                ref = (so.client_order_ref or so.name) if so else pick.origin
+                if ref:
+                    refs[ref] = True
+            record.po_numbers = ", ".join(refs.keys()) if refs else False
+
+            # Carrier: most common across pickings; ties broken by first seen.
+            carriers = [p.carrier_id for p in pickings if p.carrier_id]
+            if carriers:
+                counter = Counter(c.id for c in carriers)
+                most_common_id, _count = counter.most_common(1)[0]
+                record.carrier_id = most_common_id
+            else:
+                record.carrier_id = False
+
+            # Ship date: earliest of date_done (if validated) else scheduled_date.
+            candidates = []
+            for pick in pickings:
+                dt = pick.date_done or pick.scheduled_date
+                if dt:
+                    candidates.append(dt)
+            record.ship_date = min(candidates).date() if candidates else False
+
+    def action_recompute_amounts(self):
+        """Manually trigger amount recomputation.
+
+        When ``line_source='picking'`` the ORM cannot automatically detect
+        changes to ``stock.move.quantity`` (no persisted relation exists).
+        Users must click this button to refresh totals after delivery changes.
+        """
+        self._compute_amounts()
+
+    def action_select_partner_deliveries(self):
+        """Pre-fill ``picking_ids`` with the partner's done outgoing deliveries.
+
+        A one-click convenience: it sweeps every done outgoing ``stock.picking``
+        for this CI's commercial partner and writes them into ``picking_ids``,
+        which the user can then trim.  This only POPULATES the field — it does
+        NOT itself source or store report content (content comes solely from
+        ``picking_ids``).  Replaces the old partner-search *sourcing* fallback
+        (task 3705 refinement): choosing a partner no longer silently pulls
+        every historical delivery onto the document; the user opts in and edits.
+        """
+        for record in self:
+            if not record.partner_id:
+                raise UserError(
+                    _("Select a consignee before pre-filling deliveries.")
+                )
+            pickings = self.env["stock.picking"].search(
+                record._partner_outgoing_pickings_domain()
+            )
+            record.picking_ids = [Command.set(pickings.ids)]
+        return True
+
     def action_confirm(self):
+        for record in self:
+            if not record.invoice_ids and not record.picking_ids:
+                raise UserError(
+                    _(
+                        "A commercial invoice must have at least one invoice "
+                        "or one delivery linked."
+                    )
+                )
         self.write({"state": "done"})
 
     def action_draft(self):
@@ -156,4 +427,57 @@ class CommercialInvoice(models.Model):
     def create_from_invoices(self, invoices):
         """Create a commercial invoice from a set of invoices."""
         vals = self._prepare_commercial_invoice_from_invoices(invoices)
+        return self.create(vals)
+
+    @api.model
+    def _prepare_commercial_invoice_from_pickings(self, pickings):
+        """Prepare commercial invoice values from a set of deliveries.
+
+        Ported from ``verajet_commercial_invoice`` (task 3705 MR-1).  Sets
+        ``line_source='picking'`` so the report/totals use the delivery path,
+        and stores the explicit ``picking_ids`` so the selection-first
+        aggregation applies.
+        """
+        if not pickings:
+            raise UserError(_("No deliveries selected."))
+
+        companies = pickings.mapped("company_id")
+        if len(companies) > 1:
+            raise UserError(_("Selected deliveries are from different companies."))
+
+        # Shipping = partner on picking (consignee); importer = commercial partner.
+        shipping_partners = pickings.mapped("partner_id.commercial_partner_id")
+        consignee = shipping_partners[0] if len(shipping_partners) == 1 else False
+
+        # Align currency with the SO; fall back to USD (cross-border default).
+        sale_orders = pickings.mapped("sale_id")
+        currency = False
+        if sale_orders:
+            currencies = sale_orders.mapped("currency_id")
+            if len(currencies) == 1:
+                currency = currencies[0].id
+        if not currency:
+            currency = self.env.ref("base.USD").id
+
+        incoterms = sale_orders.mapped("incoterm")
+        payment_terms = sale_orders.mapped("payment_term_id")
+
+        vals = {
+            "line_source": "picking",
+            "picking_ids": [Command.set(pickings.ids)],
+            "company_id": companies[:1].id,
+            "currency_id": currency,
+            "partner_id": consignee.id if consignee else False,
+            "importer_id": consignee.id if consignee else False,
+            "incoterm_id": incoterms[0].id if len(incoterms) == 1 else False,
+            "payment_term_id": (
+                payment_terms[0].id if len(payment_terms) == 1 else False
+            ),
+        }
+        return vals
+
+    @api.model
+    def create_from_pickings(self, pickings):
+        """Create a commercial invoice from a set of deliveries."""
+        vals = self._prepare_commercial_invoice_from_pickings(pickings)
         return self.create(vals)

--- a/commercial_invoice/models/res_config_settings.py
+++ b/commercial_invoice/models/res_config_settings.py
@@ -1,0 +1,13 @@
+# License: LGPL-3
+# Author: Bemade Inc. (Marc Durepos <marc@bemade.org>)
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    commercial_invoice_show_default_code = fields.Boolean(
+        string="Show Internal Reference on Commercial Invoice",
+        config_parameter="commercial_invoice.show_default_code",
+        default=True,
+    )

--- a/commercial_invoice/models/stock_picking.py
+++ b/commercial_invoice/models/stock_picking.py
@@ -1,0 +1,29 @@
+# License: LGPL-3
+# Author: Bemade Inc. (Marc Durepos <marc@bemade.org>)
+from odoo import _, models
+from odoo.exceptions import UserError
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    def action_create_commercial_invoice(self):
+        """Create a commercial invoice from the selected deliveries.
+
+        Ported from ``verajet_commercial_invoice`` (task 3705 MR-1).  Backs the
+        multi-select "Create CI from Deliveries" server action.
+        """
+        outgoing = self.filtered(lambda p: p.picking_type_id.code == "outgoing")
+        if not outgoing:
+            raise UserError(
+                _("Commercial invoices can only be created from customer deliveries.")
+            )
+        ci = self.env["commercial.invoice"].create_from_pickings(outgoing)
+        return {
+            "type": "ir.actions.act_window",
+            "name": _("Commercial Invoice"),
+            "res_model": "commercial.invoice",
+            "view_mode": "form",
+            "res_id": ci.id,
+            "target": "current",
+        }

--- a/commercial_invoice/report/report_templates.xml
+++ b/commercial_invoice/report/report_templates.xml
@@ -83,9 +83,9 @@
                         <td width="50%">
                             <strong>Country of Origin / Pays d'origine:</strong>
                             <br/>
-                            <t t-set="all_lines" t-value="o.invoice_ids.mapped('invoice_line_ids')"/>
-                            <t t-set="origins" t-value="all_lines.mapped('product_id.country_of_origin.name')"/>
-                            <span t-out="', '.join([x for x in origins if x])"/>
+                            <t t-set="report_lines" t-value="o._get_report_lines()"/>
+                            <t t-set="origins" t-value="list(dict.fromkeys([l['country_of_origin'] for l in report_lines if l['country_of_origin']]))"/>
+                            <span t-out="', '.join(origins)"/>
                         </td>
                         <td width="50%" rowspan="2">
                             <strong>Importer of Record / Importateur attitré:</strong>
@@ -127,131 +127,130 @@ Valeur totale</th>
                         </tr>
                     </thead>
                     <tbody>
-                        <t t-set="all_lines" t-value="o.invoice_ids.mapped('invoice_line_ids').filtered('product_id')"/>
-                        <tr t-foreach="all_lines" t-as="line">
-                            <td name="line_name">
-                                <span t-field="line.product_id.display_name"/>
-                            </td>
-                            <td>
-                                <span t-field="line.product_id.hs_code"/>
-                            </td>
-                            <td>
-                                <span t-field="line.quantity"/>
-                                <span t-field="line.product_uom_id" groups="uom.group_uom"/>
-                            </td>
-                            <td>
-                                <span t-field="line.price_unit" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
-                            </td>
-                            <td>
-                                <span t-field="line.price_subtotal" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
-                            </td>
-                            <td>
-                                <span t-field="line.product_id.country_of_origin.name"/>
-                            </td>
-                        </tr>
+                        <t t-set="show_code" t-value="o.env['ir.config_parameter'].sudo().get_param('commercial_invoice.show_default_code', 'True') == 'True'"/>
+                        <t t-if="report_lines">
+                            <tr t-foreach="report_lines" t-as="line">
+                                <td name="line_name">
+                                    <span t-if="show_code and line['default_code'] and line['default_code'] != line['name']" t-out="'[%s]' % line['default_code']"/>
+                                    <span t-out="line['name']"/>
+                                </td>
+                                <td>
+                                    <span t-out="line['hs_code']"/>
+                                </td>
+                                <td>
+                                    <span t-out="'%.2f' % line['quantity']"/>
+                                    <t t-if="line['uom']">
+                                        <span t-out="line['uom'].name" groups="uom.group_uom"/>
+                                    </t>
+                                </td>
+                                <td>
+                                    <span t-out="o.currency_id.symbol"/> <span t-out="'%.2f' % line['price_unit']"/>
+                                </td>
+                                <td>
+                                    <span t-out="o.currency_id.symbol"/> <span t-out="'%.2f' % line['price_subtotal']"/>
+                                </td>
+                                <td>
+                                    <span t-out="line['country_of_origin']"/>
+                                </td>
+                            </tr>
+                        </t>
+                        <t t-else="">
+                            <tr>
+                                <td colspan="6" class="text-center text-muted">
+                                    No deliveries linked to this selection / Aucune livraison liée à cette sélection
+                                </td>
+                            </tr>
+                        </t>
                     </tbody>
                 </table>
 
-                <!-- Costs and Totals -->
-                <div class="row">
-                    <div class="col-7">
-                        <!-- Declaration -->
-                        <p class="small">
-                            These commodities, technology or software were exported from Canada in accordance with the Export
-                            Administration Regulations. Diversion contrary to Canadian law prohibited.<br/>
-                            It is hereby certified that this invoice shows the actual price of the goods described, that no other invoice has
-                            been issued and that all particulars are true and correct.<br/>
-                            ----------------------------------------------------------------------------                    <br/>
-                            Ces marchandises, technologies ou logiciels ont été exportés du Canada conformément aux règlements
-                            administratifs sur l'exportation des Etats-Unis. Tout agissement contraire à la loi Canadienne est strictement
-                            interdit.<br/>
-                            Je certifie par la présente que les prix indiqués sur cette facture sont exacts, qu'aucune autre facture
-                            commerciale n'a été produite et que tous les renseignements fournis sont véridiques.
-                </p>
-                <!-- Signature -->
-                <div class="mt-4">
-                    <div>Signature: _______________________</div>
-                    <div>Title / Titre: _______________________</div>
-                    <div>Date: _______________________</div>
+                <!-- Declaration, Costs, and Totals -->
+                <div style="page-break-inside: avoid;">
+                    <div class="row">
+                        <div class="col-7">
+                            <!-- Declaration -->
+                            <p class="small">
+                                These commodities, technology or software were exported from Canada in accordance with the Export
+                                Administration Regulations. Diversion contrary to Canadian law prohibited.<br/>
+                                It is hereby certified that this invoice shows the actual price of the goods described, that no other invoice has
+                                been issued and that all particulars are true and correct.<br/>
+                                ----------------------------------------------------------------------------<br/>
+                                Ces marchandises, technologies ou logiciels ont été exportés du Canada conformément aux règlements
+                                administratifs sur l'exportation des Etats-Unis. Tout agissement contraire à la loi Canadienne est strictement
+                                interdit.<br/>
+                                Je certifie par la présente que les prix indiqués sur cette facture sont exacts, qu'aucune autre facture
+                                commerciale n'a été produite et que tous les renseignements fournis sont véridiques.
+                            </p>
+                            <!-- Signature -->
+                            <div class="mt-4">
+                                <div>Signature: _______________________</div>
+                                <div>Title / Titre: _______________________</div>
+                                <div>Date: _______________________</div>
+                            </div>
+                        </div>
+                        <div class="col-5">
+                            <table class="table table-sm table-bordered">
+                                <tr>
+                                    <td><strong>Packaging / Emballage:</strong></td>
+                                    <td class="text-end">
+                                        <span t-field="o.packaging_cost" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td><strong>Freight / Fret:</strong></td>
+                                    <td class="text-end">
+                                        <span t-field="o.freight_cost" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td><strong>Insurance / Assurance:</strong></td>
+                                    <td class="text-end">
+                                        <span t-field="o.insurance_cost" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td><strong>Other / Autre:</strong></td>
+                                    <td class="text-end">
+                                        <span t-field="o.other_cost" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
+                                    </td>
+                                </tr>
+                                <tr class="border-black">
+                                    <td><strong>Total Invoice Value / Valeur totale de la facture:</strong></td>
+                                    <td class="text-end">
+                                        <strong t-field="o.total_amount" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
+                                    </td>
+                                </tr>
+                            </table>
+                        </div>
+                    </div>
+
+                    <!-- Footer Info -->
+                    <table class="table table-sm table-bordered mt-4">
+                        <tr>
+                            <td width="33%">
+                                <strong>Customs Broker / Courtier en douane:</strong><br/>
+                                <span t-field="o.customs_broker_id.name"/>
+                            </td>
+                            <td width="33%">
+                                <strong>Number of Packages / Nombre de colis:</strong><br/>
+                                <span t-field="o.number_of_packages"/>
+                            </td>
+                            <td width="33%">
+                                <strong>Total Weight / Poids total:</strong><br/>
+                                <span t-field="o.total_weight"/> kg
+                            </td>
+                        </tr>
+                        <tr>
+                            <td colspan="3">
+                                <strong>Incoterms:</strong>
+                                <t t-if="o.incoterm_id">
+                                    <span t-field="o.incoterm_id.code"/> - <span t-field="o.incoterm_id.name"/>
+                                </t>
+                            </td>
+                        </tr>
+                    </table>
                 </div>
             </div>
-            <div class="col-5">
-                <table class="table table-sm table-bordered">
-                    <tr>
-                        <td>
-                            <strong>Packaging / Emballage:</strong>
-                        </td>
-                        <td class="text-right">
-                            <span t-field="o.packaging_cost" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>
-                            <strong>Freight / Fret:</strong>
-                        </td>
-                        <td class="text-right">
-                            <span t-field="o.freight_cost" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>
-                            <strong>Insurance / Assurance:</strong>
-                        </td>
-                        <td class="text-right">
-                            <span t-field="o.insurance_cost" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>
-                            <strong>Other / Autre:</strong>
-                        </td>
-                        <td class="text-right">
-                            <span t-field="o.other_cost" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
-                        </td>
-                    </tr>
-                    <tr class="border-black">
-                        <td>
-                            <strong>Total Invoice Value / Valeur totale de la facture:</strong>
-                        </td>
-                        <td class="text-right">
-                            <strong t-field="o.total_amount" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
-                        </td>
-                    </tr>
-                </table>
-            </div>
-        </div>
-
-        <!-- Footer Info -->
-        <table class="table table-sm table-bordered mt-4">
-            <tr>
-                <td width="33%">
-                    <strong>Customs Broker / Courtier en douane:</strong>
-                    <br/>
-                    <span t-field="o.customs_broker_id.name"/>
-                </td>
-                <td width="33%">
-                    <strong>Number of Packages / Nombre de colis:</strong>
-                    <br/>
-                    <span t-field="o.number_of_packages"/>
-                </td>
-                <td width="33%">
-                    <strong>Total Weight / Poids total:</strong>
-                    <br/>
-                    <span t-field="o.total_weight"/>
- kg
-                </td>
-            </tr>
-            <tr>
-                <td colspan="3">
-                    <strong>Incoterms:</strong>
-                    <t t-if="o.incoterm_id">
-                        <span t-field="o.incoterm_id.code"/>
- -                        <span t-field="o.incoterm_id.name"/>
-                    </t>
-                </td>
-            </tr>
-        </table>
-    </div>
-</t>
+        </t>
 </template>
 </odoo>

--- a/commercial_invoice/tests/__init__.py
+++ b/commercial_invoice/tests/__init__.py
@@ -1,0 +1,2 @@
+from . import test_commercial_invoice_lines
+from . import test_commercial_invoice_pickings

--- a/commercial_invoice/tests/test_commercial_invoice_lines.py
+++ b/commercial_invoice/tests/test_commercial_invoice_lines.py
@@ -34,8 +34,11 @@ NOTE (task 3705 refinement): picking-source content comes SOLELY from the
 explicit picking_ids selection — there is no partner-search fallback.  These
 tests therefore set picking_ids explicitly.
 
-18.0 adaptation: stock.move.line uses `quantity` (not `qty_done`) for the
-done quantity field.
+18.0 adaptations:
+- stock.move.line uses `quantity` (not `qty_done`) for the done quantity field.
+- stock.move.name is required (no default) in 18.0; must be supplied explicitly.
+- ml.picked must be set True in test helpers; Odoo 18's _action_done() only
+  processes moves where picked=True (new field, absent in pre-18 Odoo).
 """
 
 from odoo import Command
@@ -151,7 +154,11 @@ class TestCommercialInvoiceLines(TransactionCase):
         A fake sale.order.line is created to set sale_line_id so that
         price_unit can be validated independently of the move's own price_unit.
 
-        18.0 adaptation: use ml.quantity (not ml.qty_done) for the done qty.
+        18.0 adaptations:
+        - use ml.quantity (not ml.qty_done) for the done qty.
+        - stock.move.name is required in 18.0 (no default); provide product name.
+        - ml.picked must be set True explicitly (new field in 18.0; required for
+          _action_done() to include the move in moves_todo).
         """
         picking = self.env["stock.picking"].create(
             {
@@ -164,6 +171,7 @@ class TestCommercialInvoiceLines(TransactionCase):
                         0,
                         0,
                         {
+                            "name": product.name,
                             "product_id": product.id,
                             "product_uom": product.uom_id.id,
                             "product_uom_qty": qty,
@@ -200,6 +208,7 @@ class TestCommercialInvoiceLines(TransactionCase):
         picking.action_assign()
         for ml in picking.move_line_ids:
             ml.quantity = qty
+            ml.picked = True  # 18.0: must be set explicitly; _action_done filters on picked
         picking._action_done()
         return picking
 
@@ -359,7 +368,8 @@ class TestCommercialInvoiceLines(TransactionCase):
         The partner-sweep pre-fill action sweeps outgoing deliveries only, so
         an incoming picking for the same partner must NOT be pre-filled.
 
-        18.0 adaptation: use ml.quantity (not ml.qty_done) for the done qty.
+        18.0 adaptations: use ml.quantity (not ml.qty_done) for the done qty;
+        stock.move.name is required; ml.picked must be set True explicitly.
         """
         location_supplier = self.picking_type_in.default_location_src_id
         location_input = self.picking_type_in.default_location_dest_id
@@ -376,6 +386,7 @@ class TestCommercialInvoiceLines(TransactionCase):
                         0,
                         0,
                         {
+                            "name": self.product_a.name,
                             "product_id": self.product_a.id,
                             "product_uom": self.product_a.uom_id.id,
                             "product_uom_qty": 10.0,
@@ -389,6 +400,7 @@ class TestCommercialInvoiceLines(TransactionCase):
         incoming.action_assign()
         for ml in incoming.move_line_ids:
             ml.quantity = 10.0
+            ml.picked = True  # 18.0: explicit picked required
         incoming._action_done()
 
         ci = self._make_ci(self.partner, line_source="picking")

--- a/commercial_invoice/tests/test_commercial_invoice_lines.py
+++ b/commercial_invoice/tests/test_commercial_invoice_lines.py
@@ -1,0 +1,399 @@
+# License: LGPL-3
+# Author: Bemade Inc. (Marc Durepos <marc@bemade.org>)
+"""Tests for commercial.invoice line-source switching.
+
+Acceptance criteria (from task-3516 requirements):
+
+1. line_source='invoice' (default) — _get_report_lines() returns one dict per
+   invoice line, values matching account.move.line.  Rendered HTML contains
+   the product code and price_subtotal.
+
+2. line_source='picking' — _get_report_lines() yields rows with
+   quantities/prices from move.sale_line_id.price_unit, sourced from the
+   explicitly selected picking_ids.
+
+3. Aggregation across pickings — two selected pickings for same product/price
+   produce one aggregated row (summed qty).  A third picking with a different
+   price_unit for the same product yields a second row (aggregation key is
+   (product_id, price_unit)).
+
+4. Empty deliveries — picking-source CI with no picking_ids → [] from
+   _get_report_lines(); rendered HTML contains the "No deliveries linked"
+   note.
+
+5. Unit price origin — each row's price_unit equals move.sale_line_id.price_unit,
+   NOT the product's list price or move.price_unit.
+
+6. _compute_amounts for picking source — invoice_amount == sum of helper rows'
+   price_subtotal; total_amount == invoice_amount + addons.
+
+7. Backwards-compat smoke — existing CI (line_source='invoice') renders HTML
+   with the expected product code; _get_report_lines() matches invoice lines.
+
+NOTE (task 3705 refinement): picking-source content comes SOLELY from the
+explicit picking_ids selection — there is no partner-search fallback.  These
+tests therefore set picking_ids explicitly.
+
+18.0 adaptation: stock.move.line uses `quantity` (not `qty_done`) for the
+done quantity field.
+"""
+
+from odoo import Command
+from odoo.tests.common import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install", "commercial_invoice")
+class TestCommercialInvoiceLines(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # --- base objects ---
+        cls.usd = cls.env.ref("base.USD")
+        cls.company = cls.env.company
+        cls.canada = cls.env.ref("base.ca")
+        cls.usa = cls.env.ref("base.us")
+
+        # Partners
+        cls.partner = cls.env["res.partner"].create(
+            {"name": "Test Consignee", "country_id": cls.usa.id}
+        )
+        cls.other_partner = cls.env["res.partner"].create(
+            {"name": "Other Partner", "country_id": cls.usa.id}
+        )
+
+        # Products
+        cls.product_a = cls.env["product.product"].create(
+            {
+                "name": "Widget A",
+                "default_code": "WDGT-A",
+                "type": "consu",
+                "lst_price": 100.0,
+            }
+        )
+        cls.product_b = cls.env["product.product"].create(
+            {
+                "name": "Widget B",
+                "default_code": "WDGT-B",
+                "type": "consu",
+                "lst_price": 200.0,
+            }
+        )
+
+        # Account setup for invoice tests
+        cls.account_revenue = cls.env["account.account"].search(
+            [
+                ("company_ids", "in", [cls.company.id]),
+                ("account_type", "=", "income"),
+            ],
+            limit=1,
+        )
+        cls.journal = cls.env["account.journal"].search(
+            [("type", "=", "sale"), ("company_id", "=", cls.company.id)], limit=1
+        )
+
+        # Outgoing picking type
+        cls.picking_type_out = cls.env["stock.picking.type"].search(
+            [
+                ("code", "=", "outgoing"),
+                ("warehouse_id.company_id", "=", cls.company.id),
+            ],
+            limit=1,
+        )
+        cls.picking_type_in = cls.env["stock.picking.type"].search(
+            [
+                ("code", "=", "incoming"),
+                ("warehouse_id.company_id", "=", cls.company.id),
+            ],
+            limit=1,
+        )
+        cls.picking_type_internal = cls.env["stock.picking.type"].search(
+            [
+                ("code", "=", "internal"),
+                ("warehouse_id.company_id", "=", cls.company.id),
+            ],
+            limit=1,
+        )
+        cls.location_output = cls.picking_type_out.default_location_src_id
+        cls.location_customer = cls.picking_type_out.default_location_dest_id
+
+    # ------------------------------------------------------------------ helpers
+
+    def _make_invoice(self, partner, product, qty, price_unit):
+        """Create and post a customer invoice with one line."""
+        invoice = self.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "partner_id": partner.id,
+                "journal_id": self.journal.id,
+                "currency_id": self.usd.id,
+                "invoice_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": product.id,
+                            "quantity": qty,
+                            "price_unit": price_unit,
+                            "account_id": self.account_revenue.id,
+                        },
+                    )
+                ],
+            }
+        )
+        invoice.action_post()
+        return invoice
+
+    def _make_done_outgoing_picking(self, partner, product, qty, sale_price):
+        """Create a done outgoing picking with one move.
+
+        A fake sale.order.line is created to set sale_line_id so that
+        price_unit can be validated independently of the move's own price_unit.
+
+        18.0 adaptation: use ml.quantity (not ml.qty_done) for the done qty.
+        """
+        picking = self.env["stock.picking"].create(
+            {
+                "partner_id": partner.id,
+                "picking_type_id": self.picking_type_out.id,
+                "location_id": self.location_output.id,
+                "location_dest_id": self.location_customer.id,
+                "move_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": product.id,
+                            "product_uom": product.uom_id.id,
+                            "product_uom_qty": qty,
+                            "location_id": self.location_output.id,
+                            "location_dest_id": self.location_customer.id,
+                            "price_unit": 999.0,  # intentionally wrong; test uses sale_line
+                        },
+                    )
+                ],
+            }
+        )
+        # Create a minimal sale.order.line to carry the expected price_unit
+        sale_order = self.env["sale.order"].create(
+            {
+                "partner_id": partner.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": product.id,
+                            "product_uom_qty": qty,
+                            "price_unit": sale_price,
+                        },
+                    )
+                ],
+            }
+        )
+        sale_order.action_confirm()
+        sale_line = sale_order.order_line[0]
+        picking.move_ids.write({"sale_line_id": sale_line.id})
+
+        # Validate the picking (mark as done)
+        picking.action_assign()
+        for ml in picking.move_line_ids:
+            ml.quantity = qty
+        picking._action_done()
+        return picking
+
+    def _make_ci(self, partner, line_source="invoice", pickings=None):
+        vals = {
+            "partner_id": partner.id,
+            "currency_id": self.usd.id,
+            "line_source": line_source,
+        }
+        if pickings is not None:
+            vals["picking_ids"] = [Command.set(pickings.ids)]
+        return self.env["commercial.invoice"].create(vals)
+
+    # ------------------------------------------------------------------ tests
+
+    def test_01_invoice_source_report_lines(self):
+        """line_source='invoice': _get_report_lines() mirrors invoice lines."""
+        invoice = self._make_invoice(self.partner, self.product_a, 5.0, 42.0)
+        ci = self._make_ci(self.partner)
+        ci.invoice_ids = invoice
+
+        lines = ci._get_report_lines()
+        self.assertEqual(len(lines), 1, "Expected one report line from invoice")
+        row = lines[0]
+        self.assertEqual(row["name"], self.product_a.name)
+        self.assertEqual(row["default_code"], "WDGT-A")
+        self.assertAlmostEqual(row["quantity"], 5.0)
+        self.assertAlmostEqual(row["price_unit"], 42.0)
+        self.assertAlmostEqual(row["price_subtotal"], 5.0 * 42.0)
+
+    def test_02_picking_source_report_lines(self):
+        """line_source='picking': rows come from the selected pickings' moves."""
+        pick = self._make_done_outgoing_picking(self.partner, self.product_a, 3.0, 55.0)
+        ci = self._make_ci(self.partner, line_source="picking", pickings=pick)
+
+        lines = ci._get_report_lines()
+        self.assertEqual(len(lines), 1)
+        row = lines[0]
+        self.assertEqual(row["name"], self.product_a.name)
+        self.assertAlmostEqual(row["quantity"], 3.0)
+        self.assertAlmostEqual(row["price_unit"], 55.0)
+        self.assertAlmostEqual(row["price_subtotal"], 3.0 * 55.0)
+
+    def test_03_aggregation_across_pickings(self):
+        """Two pickings same product+price → one aggregated row; third with
+        different price → second row.
+
+        Aggregation key is (product_id, price_unit).  Two rows with the same
+        product but different prices are intentionally kept separate rather
+        than weighted-averaged, because the requirements do not specify how to
+        combine different prices.
+        """
+        # Two pickings: same product_a, same price 50
+        p1 = self._make_done_outgoing_picking(self.partner, self.product_a, 2.0, 50.0)
+        p2 = self._make_done_outgoing_picking(self.partner, self.product_a, 3.0, 50.0)
+        # Third picking: same product_a, different price 60
+        p3 = self._make_done_outgoing_picking(self.partner, self.product_a, 1.0, 60.0)
+
+        ci = self._make_ci(
+            self.partner, line_source="picking", pickings=p1 | p2 | p3
+        )
+        lines = ci._get_report_lines()
+
+        # Group by price_unit to check aggregation
+        by_price = {row["price_unit"]: row for row in lines}
+        self.assertIn(50.0, by_price, "Expected a row for price 50")
+        self.assertIn(60.0, by_price, "Expected a row for price 60")
+        self.assertAlmostEqual(by_price[50.0]["quantity"], 5.0, msg="2+3 should aggregate")
+        self.assertAlmostEqual(by_price[60.0]["quantity"], 1.0)
+
+    def test_04_empty_deliveries(self):
+        """No selected picking_ids → _get_report_lines() returns [].
+
+        A done outgoing picking exists for the partner but is not selected, so
+        it must NOT appear (single source of truth — no partner-search
+        fallback).
+        """
+        self._make_done_outgoing_picking(self.partner, self.product_a, 7.0, 33.0)
+        ci = self._make_ci(self.partner, line_source="picking")
+        self.assertFalse(ci.picking_ids)
+        lines = ci._get_report_lines()
+        self.assertEqual(lines, [])
+
+    def test_05_unit_price_from_sale_line(self):
+        """price_unit on each row must equal move.sale_line_id.price_unit,
+        not the product's list price (999.0 in the helper) or move.price_unit.
+        """
+        pick = self._make_done_outgoing_picking(self.partner, self.product_a, 4.0, 77.0)
+        ci = self._make_ci(self.partner, line_source="picking", pickings=pick)
+        lines = ci._get_report_lines()
+
+        self.assertEqual(len(lines), 1)
+        self.assertAlmostEqual(lines[0]["price_unit"], 77.0,
+                               msg="price_unit must come from sale_line_id, not move.price_unit")
+
+    def test_06_compute_amounts_picking_source(self):
+        """_compute_amounts sums picking lines into invoice_amount; total_amount
+        adds addon costs.
+        """
+        pa = self._make_done_outgoing_picking(self.partner, self.product_a, 2.0, 100.0)
+        pb = self._make_done_outgoing_picking(self.partner, self.product_b, 1.0, 150.0)
+
+        ci = self.env["commercial.invoice"].create(
+            {
+                "partner_id": self.partner.id,
+                "currency_id": self.usd.id,
+                "line_source": "picking",
+                "picking_ids": [Command.set((pa | pb).ids)],
+                "packaging_cost": 10.0,
+                "freight_cost": 20.0,
+                "insurance_cost": 5.0,
+                "other_cost": 0.0,
+            }
+        )
+
+        expected_invoice_amount = 2.0 * 100.0 + 1.0 * 150.0  # 350
+        expected_total = expected_invoice_amount + 10.0 + 20.0 + 5.0  # 385
+
+        self.assertAlmostEqual(ci.invoice_amount, expected_invoice_amount)
+        self.assertAlmostEqual(ci.total_amount, expected_total)
+
+    def test_07_backwards_compat_smoke(self):
+        """Existing CI with line_source='invoice' still reports correctly."""
+        invoice = self._make_invoice(self.partner, self.product_a, 1.0, 88.0)
+        ci = self._make_ci(self.partner)
+        self.assertEqual(ci.line_source, "invoice",
+                         "Default line_source must be 'invoice'")
+        ci.invoice_ids = invoice
+
+        lines = ci._get_report_lines()
+        self.assertEqual(len(lines), 1)
+        self.assertAlmostEqual(lines[0]["price_unit"], 88.0)
+        self.assertAlmostEqual(lines[0]["quantity"], 1.0)
+        # invoice_amount should equal the invoice total
+        self.assertAlmostEqual(ci.invoice_amount, invoice.amount_total)
+
+    def test_08_select_partner_deliveries_scope(self):
+        """The partner-sweep pre-fill action is partner-scoped.
+
+        It must pick up the CI partner's done outgoing delivery and NOT the
+        other partner's.  (Content sources only from picking_ids, so this is
+        the partner-scope guarantee for the convenience sweep.)
+        """
+        mine = self._make_done_outgoing_picking(self.partner, self.product_a, 5.0, 10.0)
+        theirs = self._make_done_outgoing_picking(
+            self.other_partner, self.product_a, 5.0, 10.0
+        )
+        ci = self._make_ci(self.partner, line_source="picking")
+        ci.action_select_partner_deliveries()
+
+        self.assertIn(mine.id, ci.picking_ids.ids)
+        self.assertNotIn(theirs.id, ci.picking_ids.ids)
+
+    def test_09_non_outgoing_picking_ignored(self):
+        """Incoming and internal pickings for the partner are excluded.
+
+        The partner-sweep pre-fill action sweeps outgoing deliveries only, so
+        an incoming picking for the same partner must NOT be pre-filled.
+
+        18.0 adaptation: use ml.quantity (not ml.qty_done) for the done qty.
+        """
+        location_supplier = self.picking_type_in.default_location_src_id
+        location_input = self.picking_type_in.default_location_dest_id
+
+        # Incoming picking (receipt)
+        incoming = self.env["stock.picking"].create(
+            {
+                "partner_id": self.partner.id,
+                "picking_type_id": self.picking_type_in.id,
+                "location_id": location_supplier.id,
+                "location_dest_id": location_input.id,
+                "move_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product_a.id,
+                            "product_uom": self.product_a.uom_id.id,
+                            "product_uom_qty": 10.0,
+                            "location_id": location_supplier.id,
+                            "location_dest_id": location_input.id,
+                        },
+                    )
+                ],
+            }
+        )
+        incoming.action_assign()
+        for ml in incoming.move_line_ids:
+            ml.quantity = 10.0
+        incoming._action_done()
+
+        ci = self._make_ci(self.partner, line_source="picking")
+        ci.action_select_partner_deliveries()
+        self.assertNotIn(
+            incoming.id, ci.picking_ids.ids,
+            "Incoming picking must not be pre-filled by the partner sweep",
+        )

--- a/commercial_invoice/tests/test_commercial_invoice_pickings.py
+++ b/commercial_invoice/tests/test_commercial_invoice_pickings.py
@@ -1,0 +1,375 @@
+# License: LGPL-3
+# Author: Bemade Inc. (Marc Durepos <marc@bemade.org>)
+"""Tests for the explicit picking-selection commercial-invoice feature.
+
+Ported into the shared base module from verajet_commercial_invoice (task 3705
+MR-1).  Acceptance criteria covered:
+
+1. create_from_pickings produces a CI with picking_ids stored, line_source
+   set to 'picking', consignee/importer/currency derived, and the delivery
+   header (po_numbers / carrier_id / ship_date) computed.
+2. The multi-select stock.picking server action
+   (action_create_commercial_invoice) creates a CI from the selected
+   deliveries and returns a form action pointing at it.
+3. Single source of truth: report lines come ONLY from the explicit
+   picking_ids (even unvalidated).  With picking_ids empty the picking path
+   yields NO lines — there is NO partner-search fallback (task 3705
+   refinement).
+4. "Select all deliveries for this partner" action: populates picking_ids
+   with the partner's done outgoing deliveries (a pre-fill the user can trim,
+   not auto-content), partner-scoped.
+5. The existing invoice-sourced path is unchanged (line_source='invoice').
+6. action_confirm guard: a CI with neither invoices nor pickings raises;
+   one with pickings confirms.
+
+18.0 adaptation: stock.move.line uses `quantity` (not `qty_done`) for the
+done quantity field.
+"""
+
+from datetime import datetime, timedelta
+
+from odoo import Command
+from odoo.exceptions import UserError
+from odoo.tests.common import TransactionCase, tagged
+from odoo.tools.misc import mute_logger
+
+
+@tagged("post_install", "-at_install", "commercial_invoice")
+class TestCommercialInvoicePickings(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.usd = cls.env.ref("base.USD")
+        cls.company = cls.env.company
+
+        cls.partner = cls.env["res.partner"].create(
+            {"name": "US Customer", "email": "ap@uscustomer.test"}
+        )
+        cls.other_partner = cls.env["res.partner"].create(
+            {"name": "Other Customer"}
+        )
+
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Widget A",
+                "default_code": "WDGT-A",
+                "type": "consu",
+                "is_storable": True,
+                "list_price": 100.0,
+            }
+        )
+        # Non-storable so done outgoing pickings validate without reservation
+        # (the partner-search-fallback tests need a *done* picking).
+        cls.product_consu = cls.env["product.product"].create(
+            {
+                "name": "Widget C",
+                "default_code": "WDGT-C",
+                "type": "consu",
+                "list_price": 100.0,
+            }
+        )
+
+        cls.picking_type_out = cls.env["stock.picking.type"].search(
+            [
+                ("code", "=", "outgoing"),
+                ("warehouse_id.company_id", "=", cls.company.id),
+            ],
+            limit=1,
+        )
+        cls.loc_src = cls.picking_type_out.default_location_src_id
+        cls.loc_dest = cls.picking_type_out.default_location_dest_id
+
+        # Account setup for the invoice-path regression test.
+        cls.account_revenue = cls.env["account.account"].search(
+            [
+                ("company_ids", "in", [cls.company.id]),
+                ("account_type", "=", "income"),
+            ],
+            limit=1,
+        )
+        cls.journal = cls.env["account.journal"].search(
+            [("type", "=", "sale"), ("company_id", "=", cls.company.id)],
+            limit=1,
+        )
+
+    # ----------------------------------------------------------------- helpers
+
+    @classmethod
+    def _make_sale_with_picking(cls, ref, product, qty, price):
+        """Confirm a SO, returning its (unvalidated) delivery picking."""
+        so = cls.env["sale.order"].create(
+            {
+                "partner_id": cls.partner.id,
+                "client_order_ref": ref,
+                "order_line": [
+                    Command.create(
+                        {
+                            "product_id": product.id,
+                            "product_uom_qty": qty,
+                            "price_unit": price,
+                        }
+                    )
+                ],
+            }
+        )
+        so.action_confirm()
+        return so, so.picking_ids[:1]
+
+    def _make_done_outgoing_picking(self, partner, product, qty, sale_price):
+        """A done outgoing picking carrying a sale_line_id price.
+
+        18.0 adaptation: use ml.quantity (not ml.qty_done) for the done qty.
+        """
+        so = self.env["sale.order"].create(
+            {
+                "partner_id": partner.id,
+                "order_line": [
+                    Command.create(
+                        {
+                            "product_id": product.id,
+                            "product_uom_qty": qty,
+                            "price_unit": sale_price,
+                        }
+                    )
+                ],
+            }
+        )
+        so.action_confirm()
+        picking = so.picking_ids[:1]
+        picking.action_assign()
+        for ml in picking.move_line_ids:
+            ml.quantity = qty
+        picking._action_done()
+        return picking
+
+    def _make_invoice(self, partner, product, qty, price_unit):
+        invoice = self.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "partner_id": partner.id,
+                "journal_id": self.journal.id,
+                "currency_id": self.usd.id,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": product.id,
+                            "quantity": qty,
+                            "price_unit": price_unit,
+                            "account_id": self.account_revenue.id,
+                        }
+                    )
+                ],
+            }
+        )
+        invoice.action_post()
+        return invoice
+
+    # ------------------------------------------------------------------- tests
+
+    def test_create_from_pickings_stores_and_computes(self):
+        """create_from_pickings: picking_ids stored, header + totals computed."""
+        so1, pick1 = self._make_sale_with_picking("PO-A", self.product, 10, 100.0)
+        so2, pick2 = self._make_sale_with_picking("PO-B", self.product, 5, 100.0)
+        now = datetime.now()
+        pick1.scheduled_date = now + timedelta(days=2)
+        pick2.scheduled_date = now + timedelta(days=1)  # earliest
+
+        ci = self.env["commercial.invoice"].create_from_pickings(pick1 | pick2)
+
+        self.assertEqual(set(ci.picking_ids.ids), {pick1.id, pick2.id})
+        self.assertEqual(ci.partner_id, self.partner.commercial_partner_id)
+        self.assertEqual(ci.importer_id, self.partner.commercial_partner_id)
+        # Header (computed from the selected deliveries)
+        self.assertIn("PO-A", ci.po_numbers)
+        self.assertIn("PO-B", ci.po_numbers)
+        self.assertEqual(ci.ship_date, pick2.scheduled_date.date())
+
+    def test_server_action_creates_ci(self):
+        """The multi-select stock.picking action builds a CI and returns it."""
+        _so1, pick1 = self._make_sale_with_picking("PO-S1", self.product, 3, 100.0)
+        _so2, pick2 = self._make_sale_with_picking("PO-S2", self.product, 4, 100.0)
+
+        result = (pick1 | pick2).action_create_commercial_invoice()
+
+        self.assertEqual(result["res_model"], "commercial.invoice")
+        ci = self.env["commercial.invoice"].browse(result["res_id"])
+        self.assertEqual(set(ci.picking_ids.ids), {pick1.id, pick2.id})
+
+    def test_server_action_rejects_non_outgoing(self):
+        """The action raises when no outgoing picking is selected."""
+        # Build an internal/incoming picking type-less selection by faking it:
+        # an empty recordset of non-outgoing pickings → UserError.
+        incoming_type = self.env["stock.picking.type"].search(
+            [
+                ("code", "=", "incoming"),
+                ("warehouse_id.company_id", "=", self.company.id),
+            ],
+            limit=1,
+        )
+        picking = self.env["stock.picking"].create(
+            {
+                "partner_id": self.partner.id,
+                "picking_type_id": incoming_type.id,
+                "location_id": incoming_type.default_location_src_id.id,
+                "location_dest_id": incoming_type.default_location_dest_id.id,
+            }
+        )
+        with self.assertRaises(UserError):
+            picking.action_create_commercial_invoice()
+
+    def test_selection_first_lines(self):
+        """Explicit picking_ids drive the report lines (selection-first)."""
+        _so1, pick1 = self._make_sale_with_picking("PO-X", self.product, 6, 100.0)
+        ci = self.env["commercial.invoice"].create(
+            {
+                "partner_id": self.partner.id,
+                "currency_id": self.usd.id,
+                "line_source": "picking",
+                "picking_ids": [Command.set(pick1.ids)],
+            }
+        )
+        lines = ci._get_report_lines()
+        self.assertEqual(len(lines), 1)
+        self.assertAlmostEqual(lines[0]["quantity"], 6.0)
+        self.assertAlmostEqual(lines[0]["price_unit"], 100.0)
+        self.assertAlmostEqual(lines[0]["price_subtotal"], 600.0)
+        # With line_source='picking', _compute_amounts uses the delivery path.
+        self.assertAlmostEqual(ci.invoice_amount, 600.0)
+        self.assertAlmostEqual(ci.total_amount, 600.0)
+
+    def test_selection_first_uses_unvalidated_pickings(self):
+        """Selected, NOT-yet-validated pickings still produce lines.
+
+        The partner-search fallback only ever sees done pickings, so this is
+        the distinguishing behaviour of selection-first: the picking here is
+        confirmed but not validated (state != 'done').
+        """
+        _so, pick = self._make_sale_with_picking("PO-U", self.product, 8, 100.0)
+        self.assertNotEqual(pick.state, "done")
+        ci = self.env["commercial.invoice"].create(
+            {
+                "partner_id": self.partner.id,
+                "currency_id": self.usd.id,
+                "line_source": "picking",
+                "picking_ids": [Command.set(pick.ids)],
+            }
+        )
+        lines = ci._get_report_lines()
+        self.assertEqual(len(lines), 1)
+        self.assertAlmostEqual(lines[0]["quantity"], 8.0)
+
+    def test_empty_picking_ids_yields_no_lines(self):
+        """No picking_ids set → NO lines (no partner-search fallback).
+
+        A done outgoing picking exists for the partner, but because it is not
+        explicitly selected it must NOT be pulled onto the document.
+        ``picking_ids`` is the single source of truth (task 3705 refinement).
+        """
+        self._make_done_outgoing_picking(self.partner, self.product_consu, 2.0, 100.0)
+        ci = self.env["commercial.invoice"].create(
+            {
+                "partner_id": self.partner.id,
+                "currency_id": self.usd.id,
+                "line_source": "picking",
+            }
+        )
+        self.assertFalse(ci.picking_ids)
+        self.assertEqual(
+            ci._get_report_lines(), [],
+            "Empty picking_ids must NOT fall back to a partner search",
+        )
+        self.assertAlmostEqual(
+            ci.invoice_amount, 0.0,
+            msg="No selected deliveries → zero picking-derived amount",
+        )
+
+    def test_select_partner_deliveries_action_populates(self):
+        """The action pre-fills picking_ids with the partner's done deliveries.
+
+        It POPULATES the M2M (a convenience the user can then trim) — it does
+        not compute/store content by itself; content still flows through
+        picking_ids via _get_report_lines.
+        """
+        pick = self._make_done_outgoing_picking(
+            self.partner, self.product_consu, 2.0, 100.0
+        )
+        ci = self.env["commercial.invoice"].create(
+            {
+                "partner_id": self.partner.id,
+                "currency_id": self.usd.id,
+                "line_source": "picking",
+            }
+        )
+        self.assertFalse(ci.picking_ids)
+
+        ci.action_select_partner_deliveries()
+
+        self.assertIn(pick.id, ci.picking_ids.ids)
+        # Now that picking_ids is populated, content sources from it.
+        lines = ci._get_report_lines()
+        self.assertEqual(len(lines), 1)
+        self.assertAlmostEqual(lines[0]["quantity"], 2.0)
+        self.assertAlmostEqual(lines[0]["price_unit"], 100.0)
+
+        # Pre-fill is writable/trimmable: removing a row drops its content.
+        ci.picking_ids = [Command.unlink(pick.id)]
+        self.assertFalse(ci.picking_ids)
+        self.assertEqual(ci._get_report_lines(), [])
+
+    def test_select_partner_deliveries_is_partner_scoped(self):
+        """The pre-fill sweep only picks up the CI partner's deliveries."""
+        own = self._make_done_outgoing_picking(
+            self.partner, self.product_consu, 4.0, 100.0
+        )
+        other = self._make_done_outgoing_picking(
+            self.other_partner, self.product_consu, 9.0, 100.0
+        )
+        ci = self.env["commercial.invoice"].create(
+            {
+                "partner_id": self.partner.id,
+                "currency_id": self.usd.id,
+                "line_source": "picking",
+            }
+        )
+        ci.action_select_partner_deliveries()
+        self.assertIn(own.id, ci.picking_ids.ids)
+        self.assertNotIn(other.id, ci.picking_ids.ids)
+
+    def test_invoice_path_unchanged(self):
+        """The invoice-sourced path still works and ignores pickings."""
+        invoice = self._make_invoice(self.partner, self.product, 5.0, 42.0)
+        ci = self.env["commercial.invoice"].create(
+            {
+                "partner_id": self.partner.id,
+                "currency_id": self.usd.id,
+                "line_source": "invoice",
+                "invoice_ids": [Command.set(invoice.ids)],
+            }
+        )
+        lines = ci._get_report_lines()
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(lines[0]["default_code"], "WDGT-A")
+        self.assertAlmostEqual(lines[0]["price_unit"], 42.0)
+        self.assertAlmostEqual(ci.invoice_amount, invoice.amount_total)
+
+    @mute_logger("odoo.models")
+    def test_action_confirm_guard(self):
+        """action_confirm requires at least one invoice or one delivery."""
+        empty = self.env["commercial.invoice"].create(
+            {"partner_id": self.partner.id, "currency_id": self.usd.id}
+        )
+        with self.assertRaises(UserError):
+            empty.action_confirm()
+
+        _so, pick = self._make_sale_with_picking("PO-C", self.product, 1, 100.0)
+        ci = self.env["commercial.invoice"].create(
+            {
+                "partner_id": self.partner.id,
+                "currency_id": self.usd.id,
+                "line_source": "picking",
+                "picking_ids": [Command.set(pick.ids)],
+            }
+        )
+        ci.action_confirm()
+        self.assertEqual(ci.state, "done")

--- a/commercial_invoice/tests/test_commercial_invoice_pickings.py
+++ b/commercial_invoice/tests/test_commercial_invoice_pickings.py
@@ -22,8 +22,10 @@ MR-1).  Acceptance criteria covered:
 6. action_confirm guard: a CI with neither invoices nor pickings raises;
    one with pickings confirms.
 
-18.0 adaptation: stock.move.line uses `quantity` (not `qty_done`) for the
-done quantity field.
+18.0 adaptations:
+- stock.move.line uses `quantity` (not `qty_done`) for the done quantity field.
+- ml.picked must be set True in test helpers; Odoo 18's _action_done() only
+  processes moves where picked=True (new field, absent in pre-18 Odoo).
 """
 
 from datetime import datetime, timedelta
@@ -119,7 +121,10 @@ class TestCommercialInvoicePickings(TransactionCase):
     def _make_done_outgoing_picking(self, partner, product, qty, sale_price):
         """A done outgoing picking carrying a sale_line_id price.
 
-        18.0 adaptation: use ml.quantity (not ml.qty_done) for the done qty.
+        18.0 adaptations:
+        - use ml.quantity (not ml.qty_done) for the done qty.
+        - ml.picked must be set True explicitly; Odoo 18's _action_done() only
+          processes moves where picked=True (new field, absent in pre-18 Odoo).
         """
         so = self.env["sale.order"].create(
             {
@@ -140,6 +145,7 @@ class TestCommercialInvoicePickings(TransactionCase):
         picking.action_assign()
         for ml in picking.move_line_ids:
             ml.quantity = qty
+            ml.picked = True  # 18.0: explicit picked required for _action_done
         picking._action_done()
         return picking
 

--- a/commercial_invoice/views/account_move_views.xml
+++ b/commercial_invoice/views/account_move_views.xml
@@ -12,4 +12,13 @@
             </xpath>
         </field>
     </record>
+
+    <record id="action_create_commercial_invoice_server" model="ir.actions.server">
+        <field name="name">Create Commercial Invoice</field>
+        <field name="model_id" ref="account.model_account_move"/>
+        <field name="binding_model_id" ref="account.model_account_move"/>
+        <field name="binding_view_types">form,list</field>
+        <field name="state">code</field>
+        <field name="code">action = records.action_create_commercial_invoice()</field>
+    </record>
 </odoo>

--- a/commercial_invoice/views/commercial_invoice_views.xml
+++ b/commercial_invoice/views/commercial_invoice_views.xml
@@ -30,6 +30,13 @@
                             invisible="state == 'draft'"/>
                     <button name="action_cancel" string="Cancel" type="object"
                             invisible="state == 'cancelled'"/>
+                    <button name="action_recompute_amounts" string="Refresh Totals" type="object"
+                            invisible="line_source != 'picking'"
+                            help="Recompute invoice amount from current delivery data"/>
+                    <button name="action_select_partner_deliveries" string="Select all deliveries for this partner"
+                            type="object"
+                            invisible="line_source != 'picking' or state != 'draft' or not partner_id"
+                            help="Pre-fill the Deliveries list with all done outgoing deliveries for this consignee (you can then remove rows)"/>
                     <button name="%(action_report_commercial_invoice)d" string="Print" type="action" class="oe_highlight"/>
                     <field name="state" widget="statusbar"/>
                 </header>
@@ -49,14 +56,22 @@
                         </group>
                         <group>
                             <field name="date" readonly="state != 'draft'"/>
+                            <field name="line_source" readonly="state != 'draft'"/>
                             <field name="company_id" groups="base.group_multi_company" readonly="state != 'draft'"/>
                             <field name="currency_id" groups="base.group_multi_currency" readonly="state != 'draft'"/>
                             <field name="number_of_packages" readonly="state != 'draft'"/>
                             <field name="total_weight" readonly="state != 'draft'"/>
+                            <field name="carrier_id" invisible="line_source != 'picking'"
+                                   readonly="state != 'draft'"/>
+                            <field name="ship_date" invisible="line_source != 'picking'"
+                                   readonly="state != 'draft'"/>
+                            <field name="po_numbers" invisible="line_source != 'picking'"
+                                   readonly="1"/>
                         </group>
                     </group>
                     <notebook>
-                        <page string="Invoices" name="invoices">
+                        <page string="Invoices" name="invoices"
+                              invisible="line_source == 'picking'">
                             <field name="invoice_ids" readonly="state != 'draft'">
                                 <list>
                                     <field name="name" readonly="1"/>
@@ -67,10 +82,31 @@
                             </field>
                             <group class="oe_subtotal_footer">
                                 <field name="invoice_amount" class="oe_subtotal_footer_separator"/>
-                                <field name="packaging_cost"  widget="monetary"/>
-                                <field name="freight_cost"  widget="monetary"/>
+                                <field name="packaging_cost" widget="monetary"/>
+                                <field name="freight_cost" widget="monetary"/>
                                 <field name="insurance_cost" widget="monetary"/>
-                                <field name="other_cost"  widget="monetary"/>
+                                <field name="other_cost" widget="monetary"/>
+                                <field name="total_amount" class="oe_subtotal_footer_separator" widget="monetary"/>
+                            </group>
+                        </page>
+                        <page string="Deliveries" name="deliveries"
+                              invisible="line_source != 'picking'">
+                            <field name="picking_ids" readonly="state != 'draft'"
+                                   domain="[('picking_type_id.code', '=', 'outgoing')]">
+                                <list>
+                                    <field name="name" readonly="1"/>
+                                    <field name="partner_id" readonly="1"/>
+                                    <field name="scheduled_date" readonly="1"/>
+                                    <field name="state" readonly="1"/>
+                                    <field name="origin" readonly="1"/>
+                                </list>
+                            </field>
+                            <group class="oe_subtotal_footer">
+                                <field name="invoice_amount" class="oe_subtotal_footer_separator"/>
+                                <field name="packaging_cost" widget="monetary"/>
+                                <field name="freight_cost" widget="monetary"/>
+                                <field name="insurance_cost" widget="monetary"/>
+                                <field name="other_cost" widget="monetary"/>
                                 <field name="total_amount" class="oe_subtotal_footer_separator" widget="monetary"/>
                             </group>
                         </page>
@@ -92,11 +128,9 @@
                 <field name="invoice_ids"/>
                 <filter string="Draft" name="draft" domain="[('state','=','draft')]"/>
                 <filter string="Done" name="done" domain="[('state','=','done')]"/>
-                <group expand="0" string="Group By">
-                    <filter string="Status" name="status" context="{'group_by':'state'}"/>
-                    <filter string="Partner" name="partner" context="{'group_by':'partner_id'}"/>
-                    <filter string="Date" name="date" context="{'group_by':'date'}"/>
-                </group>
+                <filter string="Status" name="status" context="{'group_by':'state'}"/>
+                <filter string="Partner" name="partner" context="{'group_by':'partner_id'}"/>
+                <filter string="Date" name="date" context="{'group_by':'date'}"/>
             </search>
         </field>
     </record>

--- a/commercial_invoice/views/res_config_settings_views.xml
+++ b/commercial_invoice/views/res_config_settings_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="res_config_settings_view_form_commercial_invoice" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.commercial.invoice</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="account.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//block[@id='invoicing_settings']" position="inside">
+                <setting
+                    string="Internal Reference on Commercial Invoice"
+                    help="Show internal reference (default code) on printed commercial invoices">
+                    <field name="commercial_invoice_show_default_code"/>
+                </setting>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Task 3705 — MR-3 of 4 (bemade-addons 18.0 back-port)

Back-ports the `commercial_invoice` **delivery-source** feature to `18.0`, bringing the 18.0 module to parity with the merged 19.0 feature (#183, commit `7449f7f4`). 18.0's `commercial_invoice` was invoice-only — it had neither the partner-search delivery source nor the explicit picking-selection feature; this MR ports the whole surface.

### What's ported (all production code byte-identical to 19.0)
- `line_source` Selection (Invoices/Deliveries), `picking_ids` M2M, computed delivery header (`po_numbers`/`carrier_id`/`ship_date`), `_get_report_lines*`, `create_from_pickings`, `action_select_partner_deliveries`, `action_confirm` invoice-or-picking guard, `action_recompute_amounts`.
- NEW `models/stock_picking.py` (`action_create_commercial_invoice`) + `data/stock_picking_actions.xml` (multi-select "Create CI from Deliveries" server action).
- NEW `models/res_config_settings.py` + view (`commercial_invoice.show_default_code`).
- Report rewrite to `_get_report_lines()`-driven rows with the "No deliveries linked / Aucune livraison liée" fallback.
- `__manifest__.py` → `18.0.1.2.0`, adds `delivery` to depends.
- `migrations/18.0.1.2.0/post-migrate.py` — backfills `line_source='invoice'` on existing rows (new required field).

### 19→18 adaptations (the only diff vs 19.0 — 171 lines)
- Test helpers: `stock.move.line.qty_done` → `quantity`; `stock.move.name` now required; explicit `ml.picked=True` so `_action_done` validates consumable moves on 18.0.
- Version string + migration folder rename; two LGPL-3 headers; one whitespace normalization.

### Tests
`commercial_invoice` suite (ported 9 + 10 tests) on an Odoo 18 stack → **19 passed, 0 failed, 0 errors**.

### Sequence
MR-1 (bemade-addons 19.0 #183, **merged**) → MR-2 (verajet thin+bump !54, **merged**) → **MR-3 (this)** → on merge: MR-4 (Pneumac `.repos/bemade-addons` bump + enable button). UI/PDF smoke runs at MR-4 Pneumac staging UAT.

Pipeline artifacts: https://git.bemade.org/bemade/tasks/-/tree/main/task-3705-bemade-addons-18-backport
