### PR TITLE
test: raise coverage on five 19.0 addons

### DIFF
--- a/bemade_helpdesk_one_ticket_per_email/tests/test_module.py
+++ b/bemade_helpdesk_one_ticket_per_email/tests/test_module.py
@@ -1,3 +1,7 @@
+from unittest.mock import patch
+
+from odoo.addons.mail.models.mail_thread import MailThread as CoreMailThread
+from odoo.exceptions import UserError
 from odoo.tests import TransactionCase, tagged
 
 
@@ -22,7 +26,76 @@ class TestHelpdeskOneTicketPerEmail(TransactionCase):
         """Test mail.thread has expected fields"""
         self.assertTrue(hasattr(self.MailThread, "message_ids"))
 
-    def test_thread_message_tracking(self):
-        """Test message tracking in mail.thread"""
-        # Basic test that thread model works
-        self.assertTrue(True)
+    # ------------------------------------------------------------------
+    # _message_route_process override
+    # ------------------------------------------------------------------
+    def _route(self, model, thread_id=False):
+        """Build a route tuple as expected by _message_route_process:
+        (model, thread_id, custom_values, user_id, alias)."""
+        return (model, thread_id, {}, False, False)
+
+    def test_no_helpdesk_routes_passthrough(self):
+        """Without helpdesk routes, the override forwards routes unchanged.
+
+        Passing an empty route list lets the core implementation loop zero
+        times and return False, so no helpdesk model is required.
+        """
+        result = self.MailThread._message_route_process(None, {}, [])
+        self.assertFalse(result)
+
+    def test_non_helpdesk_routes_not_filtered(self):
+        """Routes that are not helpdesk routes are forwarded untouched."""
+        routes = [self._route("res.partner"), self._route("crm.lead")]
+        with patch.object(
+            CoreMailThread,
+            "_message_route_process",
+            return_value="forwarded",
+        ) as mock_super:
+            result = self.MailThread._message_route_process(None, {}, routes)
+        self.assertEqual(result, "forwarded")
+        mock_super.assert_called_once()
+        # super() binds self, so positional args are (message, message_dict, routes)
+        forwarded_routes = mock_super.call_args.args[2]
+        self.assertEqual(forwarded_routes, routes)
+
+    def test_multiple_helpdesk_routes_keep_first(self):
+        """When several helpdesk routes are present, only the first is kept."""
+        ticket_route = self._route("helpdesk.ticket", thread_id=1)
+        team_route = self._route("helpdesk.team")
+        routes = [ticket_route, team_route]
+        with patch.object(
+            CoreMailThread,
+            "_message_route_process",
+            return_value="done",
+        ) as mock_super:
+            result = self.MailThread._message_route_process(None, {}, routes)
+        self.assertEqual(result, "done")
+        mock_super.assert_called_once()
+        forwarded_routes = mock_super.call_args.args[2]
+        self.assertEqual(forwarded_routes, [ticket_route])
+
+    def test_mixed_routes_keep_first_helpdesk(self):
+        """Mixed routes are reduced to the first helpdesk route only."""
+        non_helpdesk = self._route("res.partner")
+        team_route = self._route("helpdesk.team")
+        ticket_route = self._route("helpdesk.ticket")
+        routes = [non_helpdesk, team_route, ticket_route]
+        with patch.object(
+            CoreMailThread,
+            "_message_route_process",
+            return_value=True,
+        ) as mock_super:
+            self.MailThread._message_route_process(None, {}, routes)
+        forwarded_routes = mock_super.call_args.args[2]
+        self.assertEqual(forwarded_routes, [team_route])
+
+    def test_exception_wrapped_in_user_error(self):
+        """Any error raised by the super call is wrapped into a UserError."""
+        routes = [self._route("helpdesk.ticket")]
+        with patch.object(
+            CoreMailThread,
+            "_message_route_process",
+            side_effect=ValueError("boom"),
+        ):
+            with self.assertRaises(UserError):
+                self.MailThread._message_route_process(None, {}, routes)

--- a/bemade_quotation_alternative/tests/__init__.py
+++ b/bemade_quotation_alternative/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_migration_odoo18
+from . import test_duplication_extra

--- a/bemade_quotation_alternative/tests/test_duplication_extra.py
+++ b/bemade_quotation_alternative/tests/test_duplication_extra.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+
+import importlib
+
+from odoo.tests.common import TransactionCase
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestDuplicationExtra(TransactionCase):
+    """Couverture additionnelle : action modèle, branches du compute et
+    smoke test du script de validation autonome."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner = cls.env["res.partner"].create(
+            {"name": "Extra Customer", "email": "extra@example.com"}
+        )
+        cls.product = cls.env["product.product"].create(
+            {"name": "Extra Product", "type": "consu", "list_price": 100.0}
+        )
+        cls.order = cls.env["sale.order"].create(
+            {
+                "partner_id": cls.partner.id,
+                "name": "SOEXTRA",
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": cls.product.id,
+                            "product_uom_qty": 1,
+                            "price_unit": 100.0,
+                        },
+                    )
+                ],
+            }
+        )
+
+    def test_action_duplicate_order_returns_wizard_action(self):
+        """models/sale_order.py action_duplicate_order : ouvre le wizard avec
+        le bon contexte par défaut."""
+        action = self.order.action_duplicate_order()
+
+        self.assertEqual(action["type"], "ir.actions.act_window")
+        self.assertEqual(action["res_model"], "sale.order.duplication.wizard")
+        self.assertEqual(
+            action["context"]["default_original_order_id"], self.order.id
+        )
+
+    def test_action_duplicate_order_requires_single_record(self):
+        """ensure_one() doit lever sur un recordset multiple."""
+        order2 = self.env["sale.order"].create(
+            {"partner_id": self.partner.id, "name": "SOEXTRA2"}
+        )
+        multi = self.order | order2
+        with self.assertRaises(ValueError):
+            multi.action_duplicate_order()
+
+    def test_new_quot_empty_when_no_original(self):
+        """_compute_new_quot : branche 'pas de commande originale' -> nom vide."""
+        wizard = self.env["sale.order.duplication.wizard"].new({})
+        self.assertEqual(wizard.new_quot, "")
+
+    def test_new_quot_without_dash_in_name(self):
+        """_compute_new_quot : nom de base sans tiret -> base = nom complet."""
+        order = self.env["sale.order"].create(
+            {"partner_id": self.partner.id, "name": "PLAINNAME"}
+        )
+        wizard = self.env["sale.order.duplication.wizard"].create(
+            {"original_order_id": order.id}
+        )
+        self.assertEqual(wizard.new_quot, "PLAINNAME-REV1")
+
+    def test_new_quot_with_dash_strips_suffix(self):
+        """_compute_new_quot : nom avec tiret -> on garde seulement la partie
+        avant le premier tiret comme base."""
+        order = self.env["sale.order"].create(
+            {"partner_id": self.partner.id, "name": "BASE-2026"}
+        )
+        wizard = self.env["sale.order.duplication.wizard"].create(
+            {"original_order_id": order.id}
+        )
+        self.assertEqual(wizard.new_quot, "BASE-REV1")
+
+    def test_migration_validation_smoke(self):
+        """Smoke test du script autonome migration_validation.py : il n'est pas
+        importé par le module mais reste du code Python valide. On exécute ses
+        fonctions de vérification pour s'assurer qu'elles ne lèvent pas."""
+        module = importlib.import_module(
+            "odoo.addons.bemade_quotation_alternative.migration_validation"
+        )
+
+        # Chaque fonction lit de vrais fichiers du module et renvoie un bool.
+        self.assertIsInstance(module.check_manifest(), bool)
+        self.assertIsInstance(module.check_xml_views(), bool)
+        self.assertIsInstance(module.check_python_syntax(), bool)
+        self.assertIsInstance(module.check_security(), bool)
+
+        # main() orchestre les quatre vérifications et renvoie un code de sortie.
+        self.assertIn(module.main(), (0, 1))

--- a/bemade_search_supplier_code/tests/test_module.py
+++ b/bemade_search_supplier_code/tests/test_module.py
@@ -53,3 +53,95 @@ class TestSearchSupplierCode(TransactionCase):
         })
 
         self.assertIsNotNone(product.id)
+
+    def test_compute_supplier_codes_single(self):
+        """Compute concatenates the supplier code of a single seller."""
+        supplier = self.Supplier.create({
+            "name": "ACME", "supplier_rank": 1,
+        })
+        product = self.Product.create({
+            "name": "Coded Product", "type": "consu",
+        })
+        self.SupplierInfo.create({
+            "partner_id": supplier.id,
+            "product_id": product.id,
+            "product_tmpl_id": product.product_tmpl_id.id,
+            "product_code": "ACME-001",
+        })
+        # Ensure the seller is attached to the variant the compute reads.
+        self.assertIn(
+            product.id, self.SupplierInfo.search(
+                [("product_id", "=", product.id)]).mapped("product_id.id"),
+        )
+        product.invalidate_recordset(["supplier_codes"])
+        self.assertEqual(product.supplier_codes, "ACME-001")
+
+    def test_compute_supplier_codes_multiple_and_false(self):
+        """Compute joins multiple codes and drops False (non-str) codes."""
+        supplier1 = self.Supplier.create({"name": "S1", "supplier_rank": 1})
+        supplier2 = self.Supplier.create({"name": "S2", "supplier_rank": 1})
+        supplier3 = self.Supplier.create({"name": "S3", "supplier_rank": 1})
+        product = self.Product.create({
+            "name": "Multi Coded", "type": "consu",
+        })
+        tmpl = product.product_tmpl_id.id
+        self.SupplierInfo.create({
+            "partner_id": supplier1.id, "product_id": product.id,
+            "product_tmpl_id": tmpl, "product_code": "AAA",
+        })
+        self.SupplierInfo.create({
+            "partner_id": supplier2.id, "product_id": product.id,
+            "product_tmpl_id": tmpl, "product_code": "BBB",
+        })
+        # A seller without a product_code -> product_code is False (non-str),
+        # exercising the isinstance(x, str) filter branch.
+        self.SupplierInfo.create({
+            "partner_id": supplier3.id, "product_id": product.id,
+            "product_tmpl_id": tmpl,
+        })
+        product.invalidate_recordset(["supplier_codes"])
+        codes = product.supplier_codes
+        self.assertIn("AAA", codes)
+        self.assertIn("BBB", codes)
+        # The False code must not appear (e.g. no "False" / no empty token).
+        self.assertNotIn("False", codes)
+        self.assertEqual(
+            sorted(c.strip() for c in codes.split(",")), ["AAA", "BBB"],
+        )
+
+    def test_search_supplier_codes_match(self):
+        """Searching supplier_codes returns the product with that code."""
+        supplier = self.Supplier.create({"name": "SrchSup", "supplier_rank": 1})
+        product = self.Product.create({
+            "name": "Searchable", "type": "consu",
+        })
+        self.SupplierInfo.create({
+            "partner_id": supplier.id, "product_id": product.id,
+            "product_tmpl_id": product.product_tmpl_id.id,
+            "product_code": "UNIQUE-CODE-XYZ",
+        })
+        found = self.Product.search([("supplier_codes", "=", "UNIQUE-CODE-XYZ")])
+        self.assertIn(product, found)
+
+    def test_search_supplier_codes_like(self):
+        """Search supports operators other than equality (ilike)."""
+        supplier = self.Supplier.create({"name": "LikeSup", "supplier_rank": 1})
+        product = self.Product.create({
+            "name": "Likeable", "type": "consu",
+        })
+        self.SupplierInfo.create({
+            "partner_id": supplier.id, "product_id": product.id,
+            "product_tmpl_id": product.product_tmpl_id.id,
+            "product_code": "PREFIX-12345",
+        })
+        found = self.Product.search([("supplier_codes", "ilike", "prefix-12")])
+        self.assertIn(product, found)
+
+    def test_search_supplier_codes_empty_value(self):
+        """Empty search value short-circuits to an empty domain (no filtering)."""
+        # Directly exercise the `if not value: return []` branch: a falsy value
+        # must yield an empty (match-all) domain leaf.
+        domain = self.Product._search_supplier_codes("=", False)
+        self.assertEqual(domain, [])
+        # Through the ORM: searching on a falsy value must not raise.
+        self.Product.search([("supplier_codes", "=", False)])

--- a/fsm_visit_confirmation/tests/test_fsm_visit_confirmation.py
+++ b/fsm_visit_confirmation/tests/test_fsm_visit_confirmation.py
@@ -1,6 +1,8 @@
 import odoo.tests
 import logging
+import werkzeug
 from datetime import datetime, timedelta
+from unittest.mock import patch
 from odoo import http
 from odoo.tests import tagged
 from odoo.tests.common import HttpCase
@@ -417,3 +419,195 @@ class TestFSMVisitConfirmation(HttpCase):
             new_mail.body_html,
             "Hardcoded fallback 'America/Toronto' must appear in the email body",
         )
+
+
+@tagged("post_install", "-at_install")
+class TestFSMVisitConfirmationController(HttpCase):
+    """Unit-level coverage of the CustomerPortalExtended controller helpers and
+    error/edge branches that are not exercised by the happy-path flow tests."""
+
+    def setUp(self):
+        super().setUp()
+        from odoo.addons.fsm_visit_confirmation.controllers.main import (
+            CustomerPortalExtended,
+        )
+
+        self.controller = CustomerPortalExtended()
+
+        stage_model = self.env["project.task.type"]
+        self.stage_new = stage_model.search([("name", "=", "New")], limit=1)
+        if not self.stage_new:
+            self.stage_new = stage_model.create({"name": "New", "sequence": 1})
+
+        self.project = self.env["project.project"].create(
+            {"name": "Ctrl Test Project", "active": True}
+        )
+        self.customer = self.env["res.partner"].create(
+            {
+                "name": "Ctrl Customer",
+                "email": "ctrl@example.com",
+                "lang": "en_US",
+            }
+        )
+        self.task = self.env["project.task"].create(
+            {
+                "name": "Ctrl Task",
+                "project_id": self.project.id,
+                "partner_id": self.customer.id,
+                "stage_id": self.stage_new.id,
+            }
+        )
+        self.token = self.task._portal_ensure_token()
+        self.task.invalidate_recordset()
+
+    def _mock_request(self):
+        from odoo.addons.http_routing.tests.common import MockRequest
+
+        return MockRequest(self.env)
+
+    # ------------------------------------------------------------------
+    # fsm_confirmation_action
+    # ------------------------------------------------------------------
+    def test_action_invalid_token_renders_error(self):
+        """Bad token -> no task -> _render_error_page (lines 69, 196-202)."""
+        with self._mock_request():
+            response = self.controller.fsm_confirmation_action(
+                "approve", access_token="does-not-exist"
+            )
+        self.assertTrue(hasattr(response, "status_code"))
+
+    def test_action_invalid_action_raises_bad_request(self):
+        """Unknown action with a valid token -> BadRequest (line 76)."""
+        with self._mock_request():
+            with self.assertRaises(werkzeug.exceptions.BadRequest):
+                self.controller.fsm_confirmation_action(
+                    "bogus", access_token=self.token
+                )
+
+    def test_action_approve_exception_renders_error(self):
+        """If message_post raises during approve, the except branch renders an
+        error page (lines 101-103)."""
+        task_cls = type(self.env["project.task"])
+        with self._mock_request():
+            with patch.object(
+                task_cls, "message_post", side_effect=ValueError("boom")
+            ):
+                response = self.controller.fsm_confirmation_action(
+                    "approve", access_token=self.token
+                )
+        self.assertTrue(hasattr(response, "status_code"))
+
+    # ------------------------------------------------------------------
+    # fsm_confirmation_submit_change
+    # ------------------------------------------------------------------
+    def test_submit_change_invalid_token_renders_error(self):
+        """No task on submit_change -> error page (line 134)."""
+        with self._mock_request():
+            response = self.controller.fsm_confirmation_submit_change(
+                access_token="does-not-exist", feedback="x"
+            )
+        self.assertTrue(hasattr(response, "status_code"))
+
+    def test_submit_change_no_feedback_renders_error(self):
+        """Valid token but empty feedback -> error page (line 138)."""
+        with self._mock_request():
+            response = self.controller.fsm_confirmation_submit_change(
+                access_token=self.token, feedback=""
+            )
+        self.assertTrue(hasattr(response, "status_code"))
+
+    def test_submit_change_exception_renders_error(self):
+        """If message_post raises during submit_change, the except branch renders
+        an error page (lines 163-165)."""
+        task_cls = type(self.env["project.task"])
+        with self._mock_request():
+            with patch.object(
+                task_cls, "message_post", side_effect=ValueError("boom")
+            ):
+                response = self.controller.fsm_confirmation_submit_change(
+                    access_token=self.token, feedback="please change"
+                )
+        self.assertTrue(hasattr(response, "status_code"))
+
+    # ------------------------------------------------------------------
+    # _get_task_by_token
+    # ------------------------------------------------------------------
+    def test_get_task_by_token_via_rating(self):
+        """When no task matches the token directly, fall back to a rating.rating
+        whose access_token matches and res_model is project.task (lines 182-192)."""
+        rating_token = "rating-token-abc"
+        self.env["rating.rating"].create(
+            {
+                "res_model_id": self.env["ir.model"]._get("project.task").id,
+                "res_id": self.task.id,
+                "access_token": rating_token,
+            }
+        )
+        with self._mock_request():
+            found = self.controller._get_task_by_token(rating_token)
+        self.assertEqual(found, self.task)
+
+    def test_get_task_by_token_unknown_returns_none(self):
+        """A token matching neither a task nor a rating returns None."""
+        with self._mock_request():
+            self.assertIsNone(self.controller._get_task_by_token("nope"))
+
+    # ------------------------------------------------------------------
+    # _get_portal_values / _get_lang
+    # ------------------------------------------------------------------
+    def test_get_portal_values_extra_kwargs(self):
+        """Extra status kwargs are copied into the values dict (line 228)."""
+        with self._mock_request():
+            values = self.controller._get_portal_values(
+                task=self.task, visit_confirmation_status="approved"
+            )
+        self.assertEqual(values["visit_confirmation_status"], "approved")
+
+    def test_get_lang_no_lang_returns_none(self):
+        """No task and no lang -> _get_lang returns None (line 253)."""
+        with self._mock_request():
+            self.assertIsNone(self.controller._get_lang(task=None, lang=None))
+
+    def test_get_lang_unknown_lang_returns_none(self):
+        """A lang code with no matching res.lang record returns None (line 270)."""
+        with self._mock_request():
+            self.assertIsNone(self.controller._get_lang(lang="zz_ZZ"))
+
+    def test_get_lang_from_task_partner(self):
+        """When no explicit lang is passed, _get_lang derives it from the task
+        partner's lang (covers the partner_id fallback branch in _get_lang)."""
+        with self._mock_request():
+            result = self.controller._get_lang(task=self.task)
+        self.assertEqual(result, "en_US")
+
+    # ------------------------------------------------------------------
+    # portal_my_task
+    # ------------------------------------------------------------------
+    def test_portal_my_task_invalid_token_renders_error(self):
+        """An invalid task id / token yields the error page rather than crashing
+        (covers the AccessError + no-task branch of portal_my_task, lines 27-35).
+
+        Called directly on the controller (not via url_open): the route is
+        ``website=True`` and is unreachable over HTTP in a test DB without the
+        ``website`` module, which this addon does not depend on. The call is run
+        as the *public* user so the access checks raise AccessError -> task=None
+        -> error page, exactly as a real anonymous portal hit would; running as
+        the test's admin user would bypass those checks. The error branch returns
+        before super() is reached, so a direct call exercises it fully.
+
+        The happy path (a valid token rendering the portal page through super())
+        is deliberately not unit-tested here: it requires the full website/HTTP
+        rendering stack, and the override's post-super qcontext merge is dead in
+        practice because super() returns an Odoo Response, which the override
+        short-circuits on. See the flow tests in TestFSMVisitConfirmation for
+        end-to-end confirmation coverage."""
+        public_user = self.env.ref("base.public_user")
+        public_controller_env = self.env(user=public_user)
+        from odoo.addons.http_routing.tests.common import MockRequest
+
+        with MockRequest(public_controller_env):
+            response = self.controller.portal_my_task(
+                999999, access_token="bad-token"
+            )
+        # _render_error_page returns a rendered Response (has a status_code).
+        self.assertTrue(hasattr(response, "status_code"))

--- a/product_supplierinfo_tracking/tests/test_product_supplierinfo_tracking.py
+++ b/product_supplierinfo_tracking/tests/test_product_supplierinfo_tracking.py
@@ -17,16 +17,12 @@ class TestProductSupplierinfoTracking(TransactionCase):
             }
         )
 
-        # Use first available product template and variant
-        self.product_template = self.env["product.template"].search([], limit=1)
-        if not self.product_template:
-            self.skipTest("No product template available for testing")
-
-        self.product_variant = (
-            self.product_template.product_variant_ids[0]
-            if self.product_template.product_variant_ids
-            else None
+        # Create a dedicated product (template + variant) so the suite runs on a
+        # fresh test DB without depending on demo data (19.0: type "consu").
+        self.product_template = self.env["product.template"].create(
+            {"name": "Tracked Test Product", "type": "consu"}
         )
+        self.product_variant = self.product_template.product_variant_ids[0]
 
         self.currency_usd = self.env.ref("base.USD")
         self.uom_unit = self.env.ref("uom.product_uom_unit")


### PR DESCRIPTION
Adds/extends unit tests for the five lowest-coverage 19.0 modules found by the coverage sweep. **Tests only — no functional code changed.**

Modules:
- `bemade_helpdesk_one_ticket_per_email` — `_message_route_process` error-wrapping branch
- `bemade_quotation_alternative` — new `test_duplication_extra` for the duplication path
- `bemade_search_supplier_code` — `_search_supplier_codes` operators + empty-value short-circuit
- `fsm_visit_confirmation` — portal controller helpers + `portal_my_task` no-task error branch (direct public-user call; the `website=True` route is unreachable over HTTP without the `website` module, not a dep here)
- `product_supplierinfo_tracking` — build a dedicated product in `setUp` so the previously-skipped suite runs (51% → 98%)

Validation: all five pass solo and in a combined 60-test run on a fresh 19.0 test DB (`0 failed, 0 error(s) of 60 tests`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)