### PR TITLE
fix(fsm_visit_confirmation): align portal task route to 19.0 plural /my/tasks/<id>

### DIFF
--- a/fsm_visit_confirmation/__manifest__.py
+++ b/fsm_visit_confirmation/__manifest__.py
@@ -19,7 +19,7 @@
 #
 {
     "name": "FSM Visit Confirmation",
-    "version": "19.0.0.2.0",
+    "version": "19.0.0.2.1",
     "summary": "Enable client feedback workflow for field service tasks",
     "description": """
         This module enhances the field service management workflow by leveraging Odoo's

--- a/fsm_visit_confirmation/controllers/main.py
+++ b/fsm_visit_confirmation/controllers/main.py
@@ -15,9 +15,14 @@ _logger = logging.getLogger(__name__)
 class CustomerPortalExtended(CustomerPortal):
     """Extend the customer portal controller to handle FSM visit confirmations."""
 
-    @http.route("/my/task/<int:task_id>", type="http", auth="public", website=True)
+    @http.route("/my/tasks/<int:task_id>", type="http", auth="public", website=True)
     def portal_my_task(self, task_id, access_token=None, **kw):
-        """Override to allow access with token for public users."""
+        """Override to allow access with token for public users.
+
+        19.0: the base project portal route is ``/my/tasks/<id>`` (plural).
+        This override must use the same path or it replaces the base route
+        and the standard portal task page 404s for every task. (In 18.0 the
+        base route was singular ``/my/task/<id>``.)"""
         try:
             task = request.env["project.task"].browse(task_id)
             task.check_access_rights("read")
@@ -89,7 +94,7 @@ class CustomerPortalExtended(CustomerPortal):
                 )
 
                 # Always redirect to the task portal page with success message
-                redirect_url = "/my/task/%s?%s" % (
+                redirect_url = "/my/tasks/%s?%s" % (
                     task.id,
                     keep_query(
                         "access_token",
@@ -105,7 +110,7 @@ class CustomerPortalExtended(CustomerPortal):
                 )
 
         # For change requests, redirect to the task portal page with change request form
-        redirect_url = "/my/task/%s?%s" % (
+        redirect_url = "/my/tasks/%s?%s" % (
             task.id,
             keep_query(
                 "access_token",
@@ -151,7 +156,7 @@ class CustomerPortalExtended(CustomerPortal):
             )
 
             # Always redirect to the task portal page with success message
-            redirect_url = "/my/task/%s?%s" % (
+            redirect_url = "/my/tasks/%s?%s" % (
                 task.id,
                 keep_query(
                     access_token=kwargs.get("access_token"),

--- a/fsm_visit_confirmation/tests/test_fsm_visit_confirmation.py
+++ b/fsm_visit_confirmation/tests/test_fsm_visit_confirmation.py
@@ -126,6 +126,25 @@ class TestFSMVisitConfirmation(HttpCase):
             messages, "A message with 'approved' should be posted on the task"
         )
 
+    def test_confirmation_redirect_uses_plural_tasks_route(self):
+        """Regression: the post-confirmation redirect must target the 19.0
+        plural portal route ``/my/tasks/<id>`` and never the 18.0 singular
+        ``/my/task/<id>``. The override's own route was realigned to the plural
+        path so it no longer shadows the base project portal task page."""
+        from odoo.addons.fsm_visit_confirmation.controllers.main import (
+            CustomerPortalExtended,
+        )
+        from odoo.addons.http_routing.tests.common import MockRequest
+
+        controller = CustomerPortalExtended()
+        with MockRequest(self.env):
+            response = controller.fsm_confirmation_action(
+                "approve", access_token=self.token
+            )
+        location = response.headers.get("Location", "")
+        self.assertIn("/my/tasks/%s" % self.task.id, location)
+        self.assertNotIn("/my/task/%s" % self.task.id, location)
+
     def test_02_email_sent_on_stage_change(self):
         """Test that email is sent when task moves to approved stage"""
         # Create email template with auto_delete=False so we can inspect the mail


### PR DESCRIPTION
## Problem

In Odoo 19.0 the base `project` portal route for a single task changed from the 18.0 **singular** `/my/task/<id>` to the **plural** `/my/tasks/<id>` (`project/controllers/portal.py:535`).

`fsm_visit_confirmation`'s `CustomerPortalExtended.portal_my_task` override (migrated in #161) kept the **singular** route. Because the override shares the method name `portal_my_task`, its `@http.route` *replaces* the base route — so in production the standard 19.0 portal task page `/my/tasks/<id>` 404s **for every task** (not just FSM ones), and the override only answers the now-orphaned singular URL.

This was surfaced while adding test coverage (the `website=True` route was unreachable in a test DB without the `website` module).

## Fix

- Realign the override's `@http.route` to `/my/tasks/<int:task_id>` (matches the 19.0 base; base is already `auth="public"`).
- Update the three post-confirmation redirects (`approve` / `change` / `submit_change`) from `/my/task/%s` to `/my/tasks/%s`.
- Customer entry points (`/my/fsm_confirmation/approve|change|submit_change`, and the confirmation email links) are **unchanged** — only the landing/redirect path is corrected.
- Add a regression test asserting the approve redirect targets `/my/tasks/<id>` and never `/my/task/<id>`.
- Bump version `19.0.0.2.0` → `19.0.0.2.1`.

## Validation

`0 failed, 0 error(s) of 10 tests` (`fsm_visit_confirmation`, fresh 19.0 DB with enterprise). New regression test executes and passes.

> ⚠️ Recommend an end-to-end functional check of the customer confirmation flow (email → approve/change → landing page) on staging before merge, since the website/portal rendering can't be fully exercised in the test DB.

Separate from #191 (tests-only); touches business code only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)