### PR TITLE
fix(odoo_herd): load template config_options in wizard and sync scale-to-0

### DIFF
--- a/odoo_herd/models/k8s_odoo_instance.py
+++ b/odoo_herd/models/k8s_odoo_instance.py
@@ -679,8 +679,9 @@ class K8sOdooInstance(models.Model):
         if self.image:
             patch["spec"]["image"] = self.image
 
-        # Replicas
-        if self.replicas:
+        # Replicas — 0 is a valid desired state (stops the instance), so a
+        # truthiness test would silently drop a scale-to-0 sync.
+        if self.replicas is not None and self.replicas >= 0:
             patch["spec"]["replicas"] = self.replicas
 
         # Resources

--- a/odoo_herd/tests/test_create_instance_wizard.py
+++ b/odoo_herd/tests/test_create_instance_wizard.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import patch
 from typing import Any, cast
 
@@ -111,6 +112,38 @@ class TestCreateInstanceWizard(TransactionCase):
         wiz = self._make_wizard(config_options="{bad json")
         spec = wiz._build_instance_spec(["a.example.com"])
         self.assertNotIn("configOptions", spec)
+
+    def test_onchange_template_loads_config_options(self):
+        """Selecting a template in the wizard must copy its config_options.
+
+        Regression: the onchange skipped config_options, so the enterprise
+        addons_path never reached the CR and wizard-created instances booted
+        without /mnt/enterprise-addons — breaking SCSS/asset compilation on
+        Enterprise databases.
+        """
+        env: Any = self.env
+        template = cast(
+            Any,
+            env["k8s.odoo.instance.template"].create(
+                {
+                    "name": "enterprise",
+                    "image": "odoo:19.0",
+                    "cluster_issuer": "lets-encrypt",
+                    "filestore_size": "10Gi",
+                    "filestore_storage_class": "standard",
+                    "config_options": (
+                        '{"addons_path": "/mnt/extra-addons,/mnt/enterprise-addons",'
+                        ' "workers": "5"}'
+                    ),
+                }
+            ),
+        )
+        wiz = self._make_wizard(config_options="{}")
+        wiz.template_id = template.id
+        wiz._onchange_template_id()
+
+        self.assertIn("/mnt/enterprise-addons", wiz.config_options)
+        self.assertEqual(json.loads(wiz.config_options)["workers"], "5")
 
     def test_validate_initialization_mode_enforces_restore_fields(self):
         wiz = self._make_wizard(initialization_mode="restore")

--- a/odoo_herd/tests/test_deployment_strategy.py
+++ b/odoo_herd/tests/test_deployment_strategy.py
@@ -45,6 +45,23 @@ class TestDeploymentStrategy(TransactionCase):
             ),
         )
 
+    def test_patch_data_includes_scale_to_zero(self):
+        """replicas=0 must be synced (scale-to-0 / stop the instance).
+
+        Regression: a truthiness guard dropped replicas when it was 0, so
+        scaling an instance down to 0 from the form did nothing.
+        """
+        self.instance.replicas = 0
+        patch_data = self.instance._build_patch_data()
+        self.assertIn("replicas", patch_data["spec"])
+        self.assertEqual(patch_data["spec"]["replicas"], 0)
+
+    def test_patch_data_includes_positive_replicas(self):
+        """Non-zero replicas still sync as before."""
+        self.instance.replicas = 3
+        patch_data = self.instance._build_patch_data()
+        self.assertEqual(patch_data["spec"]["replicas"], 3)
+
     def test_deployment_strategy_recreate_patch(self):
         """Test patch data generation for Recreate strategy"""
         self.instance.deployment_strategy_type = "Recreate"

--- a/odoo_herd/wizards/k8s_create_instance_wizard.py
+++ b/odoo_herd/wizards/k8s_create_instance_wizard.py
@@ -163,7 +163,7 @@ class K8sCreateInstanceWizard(models.TransientModel):
         if self.template_id:
             template_values = self.template_id.get_template_values()
             for field, value in template_values.items():
-                if field != "config_options" and hasattr(self, field):
+                if hasattr(self, field):
                     setattr(self, field, value)
 
     def action_create_instance(self):

--- a/odoo_herd/wizards/k8s_create_instance_wizard_views.xml
+++ b/odoo_herd/wizards/k8s_create_instance_wizard_views.xml
@@ -165,9 +165,8 @@
                         </page>
                         
                         <page string="Odoo Configuration" name="odoo_config">
-                            <group string="Additional Config Options (JSON)">
-                                <field name="config_options" widget="ace" options="{'mode': 'javascript'}" nolabel="1"/>
-                            </group>
+                            <separator string="Additional Config Options (JSON)"/>
+                            <field name="config_options" widget="ace" options="{'mode': 'javascript'}" nolabel="1"/>
                         </page>
                         
                         <page string="Health Probes" name="health_probes">


### PR DESCRIPTION
## Summary

Three related fixes to the `odoo_herd` instance creation wizard and instance form, all surfaced while debugging why a wizard-provisioned instance booted without the enterprise `addons_path` (broken SCSS / unstyled UI on an Enterprise database).

1. **Template `onchange` dropped `config_options`** — `_onchange_template_id` applied every template field *except* `config_options` (`if field != "config_options"`). Selecting a template in the wizard therefore loaded everything but the additional config params, so the instance CR was created with empty `configOptions` and lost `/mnt/enterprise-addons` from its `addons_path`. `default_get` already propagated it; the onchange is now consistent.

2. **`config_options` field truncated in the wizard** — the ace editor sat inside a `<group>`, which clamped it to the label-column width so only the line-number gutter showed. Moved it out to a `<separator>` + full-width field.

3. **Scale-to-0 sync did nothing** — `_build_patch_data` guarded replicas with `if self.replicas:`, a falsy-zero check that silently dropped `replicas == 0`. "Sync to cluster" could never scale an instance down to 0. Now `replicas is not None and replicas >= 0`.

## Tests

- `test_onchange_template_loads_config_options` — selecting a template populates `config_options`.
- `test_patch_data_includes_scale_to_zero` / `test_patch_data_includes_positive_replicas` — `_build_patch_data` includes `replicas` for both 0 and positive values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)