### PR TITLE
fix(bemade_helpdesk_one_ticket_per_email): tests compatible with mass_mailing

### DIFF
--- a/bemade_helpdesk_one_ticket_per_email/__manifest__.py
+++ b/bemade_helpdesk_one_ticket_per_email/__manifest__.py
@@ -18,7 +18,7 @@
 #
 {
     "name": "Helpdesk One Ticket Per Email",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.0.1",
     "summary": "Restrict ticket creation to a single ticket per email received.",
     "category": "Helpdesk",
     "author": "Bemade Inc.",

--- a/bemade_helpdesk_one_ticket_per_email/tests/test_module.py
+++ b/bemade_helpdesk_one_ticket_per_email/tests/test_module.py
@@ -29,6 +29,12 @@ class TestHelpdeskOneTicketPerEmail(TransactionCase):
     # ------------------------------------------------------------------
     # _message_route_process override
     # ------------------------------------------------------------------
+    # Minimal yet realistic message_dict: real dicts from message_parse()
+    # always carry these keys, and other _message_route_process overrides in
+    # the MRO rely on them (e.g. mass_mailing reads message_dict['references']
+    # and crashes on an empty dict when installed alongside this module).
+    MSG_DICT = {"references": "", "in_reply_to": ""}
+
     def _route(self, model, thread_id=False):
         """Build a route tuple as expected by _message_route_process:
         (model, thread_id, custom_values, user_id, alias)."""
@@ -40,7 +46,7 @@ class TestHelpdeskOneTicketPerEmail(TransactionCase):
         Passing an empty route list lets the core implementation loop zero
         times and return False, so no helpdesk model is required.
         """
-        result = self.MailThread._message_route_process(None, {}, [])
+        result = self.MailThread._message_route_process(None, dict(self.MSG_DICT), [])
         self.assertFalse(result)
 
     def test_non_helpdesk_routes_not_filtered(self):
@@ -51,7 +57,7 @@ class TestHelpdeskOneTicketPerEmail(TransactionCase):
             "_message_route_process",
             return_value="forwarded",
         ) as mock_super:
-            result = self.MailThread._message_route_process(None, {}, routes)
+            result = self.MailThread._message_route_process(None, dict(self.MSG_DICT), routes)
         self.assertEqual(result, "forwarded")
         mock_super.assert_called_once()
         # super() binds self, so positional args are (message, message_dict, routes)
@@ -68,7 +74,7 @@ class TestHelpdeskOneTicketPerEmail(TransactionCase):
             "_message_route_process",
             return_value="done",
         ) as mock_super:
-            result = self.MailThread._message_route_process(None, {}, routes)
+            result = self.MailThread._message_route_process(None, dict(self.MSG_DICT), routes)
         self.assertEqual(result, "done")
         mock_super.assert_called_once()
         forwarded_routes = mock_super.call_args.args[2]
@@ -85,7 +91,7 @@ class TestHelpdeskOneTicketPerEmail(TransactionCase):
             "_message_route_process",
             return_value=True,
         ) as mock_super:
-            self.MailThread._message_route_process(None, {}, routes)
+            self.MailThread._message_route_process(None, dict(self.MSG_DICT), routes)
         forwarded_routes = mock_super.call_args.args[2]
         self.assertEqual(forwarded_routes, [team_route])
 
@@ -98,4 +104,4 @@ class TestHelpdeskOneTicketPerEmail(TransactionCase):
             side_effect=ValueError("boom"),
         ):
             with self.assertRaises(UserError):
-                self.MailThread._message_route_process(None, {}, routes)
+                self.MailThread._message_route_process(None, dict(self.MSG_DICT), routes)


### PR DESCRIPTION
The route-processing tests passed an **empty message_dict** (`{}`) to `_message_route_process`. Real dicts from `message_parse()` always carry `references`/`in_reply_to`, and other overrides in the MRO rely on them: with **mass_mailing** installed, `mass_mailing/models/mail_thread.py` reads `message_dict['references']` → `KeyError` before the mocked core method is reached → 3 tests error in any DB where both modules are installed (e.g. the DurPro CI single-DB run once `marketing_automation` joined the dependency set).

Fix: minimal realistic fixture (`MSG_DICT = {"references": "", "in_reply_to": ""}`) at every call site.

Validated locally: `0 failed, 0 error(s) of 8 tests` with `mass_mailing` + `bemade_alias_utm_tracking` + `mail_loop_prevention` installed alongside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)