### PR TITLE
[RELEASE] bemade_sports_clinic: 19.0 candidate batch (15 tasks + dev-review fixes)

### DIFF
--- a/bemade_sports_clinic/__manifest__.py
+++ b/bemade_sports_clinic/__manifest__.py
@@ -18,7 +18,7 @@
 #
 {
     'name': 'Sports Clinic Management',
-    'version': "19.0.1.1.9",
+    'version': "19.0.1.2.0",
     'summary': 'Comprehensive sports medicine clinic management with portal access and activity tracking.',
     'description': """
 Sports Clinic Management System

--- a/bemade_sports_clinic/controllers/access_control_mixin.py
+++ b/bemade_sports_clinic/controllers/access_control_mixin.py
@@ -168,9 +168,14 @@ class AccessControlMixin:
         return teams.sorted('name')
 
     def _get_organizations(self):
-        """Organizations (parent partners) of the accessible teams."""
+        """Organizations (parent partners) of the accessible teams.
+
+        sudo(): these are only rendered as filter labels (name/id) for teams
+        the user already staffs, and the res.partner record rules deny plain
+        portal users (e.g. staff role 'other') the read outright — /my/players
+        403'd at render (dev-review 2026-07-04 round 2)."""
         teams = self._get_accessible_teams()
-        organizations = teams.mapped('parent_id').filtered(lambda p: p)
+        organizations = teams.sudo().mapped('parent_id').filtered(lambda p: p)
         return organizations.sorted('name')
 
     def _get_all_teams(self):

--- a/bemade_sports_clinic/controllers/access_control_mixin.py
+++ b/bemade_sports_clinic/controllers/access_control_mixin.py
@@ -121,6 +121,30 @@ class AccessControlMixin:
         organizations = teams.mapped('parent_id').filtered(lambda p: p)
         return organizations.sorted('name')
 
+    def _get_all_teams(self):
+        """Every team, for the events-list filter dropdown (task 1226).
+
+        The dropdown lists *all* teams regardless of the user's assignment so a
+        coach can scope the list to any team. This widens only the *filter
+        options*, not record visibility: selecting a team they don't staff still
+        returns no events because the sports.event coach record rule keeps event
+        reads team-scoped, and the event/team/org detail routes have their own
+        gating (_check_access_to_event / _check_team_access).
+
+        sudo() is required because the sports.team record rules scope portal
+        users (coaches and therapists) to the teams they staff / share patients
+        with, so a non-sudo search([]) would return only their own teams and
+        defeat the purpose. Only names/ids are rendered from this set.
+        """
+        return http.request.env['sports.team'].sudo().search([], order='name')
+
+    def _get_all_organizations(self):
+        """Parent organizations of every team, for the events-list filter
+        dropdown (task 1226). See _get_all_teams for the sudo rationale."""
+        teams = self._get_all_teams()
+        organizations = teams.mapped('parent_id').filtered(lambda p: p)
+        return organizations.sorted('name')
+
     # ------------------------------------------------------------------
     # Post/Redirect/Get helpers for form-validation errors.
     # On a validation failure a submit handler stashes the message (and the

--- a/bemade_sports_clinic/controllers/access_control_mixin.py
+++ b/bemade_sports_clinic/controllers/access_control_mixin.py
@@ -66,8 +66,14 @@ class AccessControlMixin:
         utc_dt = local_dt.astimezone(pytz.UTC)
         return fields.Datetime.to_string(utc_dt)
 
-    def _prepare_events_domain(self, view_type='all'):
-        """Prepare domain for sports events based on user access."""
+    def _prepare_events_domain(self, view_type='all', include_cancelled=False):
+        """Prepare domain for sports events based on user access.
+
+        Cancelled events are excluded by default so the portal list and
+        calendar mirror the internal views (task 1235). Callers pass
+        include_cancelled=True (driven by an explicit ``show_cancelled``
+        toggle) to surface them again.
+        """
         user = http.request.env.user
         partner = user.partner_id
 
@@ -99,6 +105,12 @@ class AccessControlMixin:
                 ('timesheet_ids.user_id', 'in', shared_user_ids),
             ])
         # 'all' view uses base domain only
+
+        # Drop cancelled events from the default surfaces unless explicitly
+        # requested. Appended last; the implicit-AND combine is correct even
+        # for the missing_timesheets branch (which uses a '!' prefix operator).
+        if not include_cancelled:
+            base_domain.append(('state', '!=', 'cancelled'))
         return base_domain
 
     def _get_accessible_teams(self):

--- a/bemade_sports_clinic/controllers/access_control_mixin.py
+++ b/bemade_sports_clinic/controllers/access_control_mixin.py
@@ -20,7 +20,7 @@
 from odoo import http, _, fields
 from odoo.exceptions import UserError, AccessError, MissingError
 from odoo.http import request
-from datetime import datetime
+from datetime import datetime, time
 import pytz
 
 
@@ -100,6 +100,46 @@ class AccessControlMixin:
             ])
         # 'all' view uses base domain only
         return base_domain
+
+    def _date_bound_to_utc(self, date_str, end_of_day=False):
+        """Convert a YYYY-MM-DD date filter (interpreted in the user's tz)
+        into a naive-UTC datetime string for comparison against the
+        UTC-stored date_start. end_of_day pins to 23:59:59.999999."""
+        if not date_str:
+            return None
+        try:
+            d = fields.Date.from_string(date_str)
+        except Exception:
+            return None
+        user_tz = http.request.env.tz
+        t = time.max if end_of_day else time.min
+        local_dt = user_tz.localize(datetime.combine(d, t))
+        utc_dt = local_dt.astimezone(pytz.UTC)
+        return fields.Datetime.to_string(utc_dt)
+
+    def _apply_event_filters(self, domain, team_id=None, organization_id=None,
+                             assigned_user_id=None, date_from=None, date_to=None):
+        """Append the portal list-style filter leaves (team / organization /
+        assigned professional / date range) to an events domain.
+
+        Shared by the list view and the calendar JSON feed so both honor an
+        identical set of filters. Mutates and returns ``domain``.
+        """
+        if team_id:
+            domain.append(('team_ids', 'in', [int(team_id)]))
+        if organization_id:
+            domain.append(('partner_id', '=', int(organization_id)))
+        if assigned_user_id:
+            domain.append(('assigned_staff_ids', 'in', [int(assigned_user_id)]))
+        if date_from:
+            dt_utc = self._date_bound_to_utc(date_from, end_of_day=False)
+            if dt_utc:
+                domain.append(('date_start', '>=', dt_utc))
+        if date_to:
+            dt_utc = self._date_bound_to_utc(date_to, end_of_day=True)
+            if dt_utc:
+                domain.append(('date_start', '<=', dt_utc))
+        return domain
 
     def _get_accessible_teams(self):
         """Teams accessible to the current user (therapists: all; coaches: staffed)."""

--- a/bemade_sports_clinic/controllers/events_portal.py
+++ b/bemade_sports_clinic/controllers/events_portal.py
@@ -44,8 +44,9 @@ class EventsPortal(CustomerPortal, AccessControlMixin):
         return active_users.sorted('name')
 
     @http.route(['/my/events', '/my/events/page/<int:page>'], type='http', auth='user', website=True)
-    def view_events(self, page=1, view_type='all', team_id=None, organization_id=None, assigned_user_id=None, 
-                   date_from=None, date_to=None, sortby=None, group_by=None, search=None, no_default_dates=None, **kw):
+    def view_events(self, page=1, view_type='all', team_id=None, organization_id=None, assigned_user_id=None,
+                   date_from=None, date_to=None, sortby=None, group_by=None, search=None, no_default_dates=None,
+                   show_cancelled=None, **kw):
         """Main events view with filtering and pagination"""
         
         # Check access
@@ -85,9 +86,11 @@ class EventsPortal(CustomerPortal, AccessControlMixin):
                 except Exception:
                     date_to = datetime.today().strftime('%Y-%m-%d')
 
-        # Prepare base domain
-        domain = self._prepare_events_domain(view_type)
-        
+        # Prepare base domain. Cancelled events are hidden by default and only
+        # surfaced when the user opts in via the "Show cancelled" toggle.
+        include_cancelled = bool(show_cancelled)
+        domain = self._prepare_events_domain(view_type, include_cancelled=include_cancelled)
+
         # Apply additional filters
         if team_id:
             domain.append(('team_ids', 'in', [int(team_id)]))
@@ -157,7 +160,8 @@ class EventsPortal(CustomerPortal, AccessControlMixin):
             url='/my/events',
             url_args={'view_type': view_type, 'team_id': team_id, 'organization_id': organization_id,
                      'assigned_user_id': assigned_user_id, 'date_from': date_from,
-                     'date_to': date_to, 'sortby': sortby, 'group_by': group_by, 'search': search, 'no_default_dates': no_default_dates},
+                     'date_to': date_to, 'sortby': sortby, 'group_by': group_by, 'search': search,
+                     'no_default_dates': no_default_dates, 'show_cancelled': show_cancelled},
             total=event_count,
             page=page,
             step=self._items_per_page,
@@ -299,6 +303,7 @@ class EventsPortal(CustomerPortal, AccessControlMixin):
             'sortby': sortby,
             'group_by': group_by,
             'search': search,
+            'show_cancelled': bool(show_cancelled),
             'teams': teams,
             'organizations': organizations,
             'treatment_professionals': treatment_professionals,
@@ -345,7 +350,9 @@ class EventsPortal(CustomerPortal, AccessControlMixin):
         if not (is_therapist or is_coach or user.has_group('base.group_system')):
             return http.request.make_response('[]', headers=[('Content-Type', 'application/json')])
 
-        domain = self._prepare_events_domain('all')
+        # Cancelled events are hidden by default; show_cancelled=1 includes them.
+        include_cancelled = bool(kw.get('show_cancelled'))
+        domain = self._prepare_events_domain('all', include_cancelled=include_cancelled)
         # FullCalendar passes ISO datetimes (with or without tz). Normalize
         # to naive UTC so the comparison against Odoo's UTC-stored
         # date_start / date_end fields is correct regardless of the

--- a/bemade_sports_clinic/controllers/events_portal.py
+++ b/bemade_sports_clinic/controllers/events_portal.py
@@ -2,7 +2,7 @@ from odoo.addons.portal.controllers.portal import CustomerPortal, pager
 from odoo import http, _, fields
 from odoo.tools import html2plaintext
 from odoo.exceptions import UserError, AccessError
-from datetime import datetime, time, timedelta
+from datetime import datetime
 from .access_control_mixin import AccessControlMixin
 import logging
 import pytz
@@ -88,44 +88,17 @@ class EventsPortal(CustomerPortal, AccessControlMixin):
         # Prepare base domain
         domain = self._prepare_events_domain(view_type)
         
-        # Apply additional filters
-        if team_id:
-            domain.append(('team_ids', 'in', [int(team_id)]))
-        
-        if organization_id:
-            org_id = int(organization_id)
-            domain.append(('partner_id', '=', org_id))
-            # Debug: Log organization filter
-            import logging
-            _logger = logging.getLogger(__name__)
-            _logger.info(f"Organization filter applied: partner_id = {org_id}")
-        
-        if assigned_user_id:
-            domain.append(('assigned_staff_ids', 'in', [int(assigned_user_id)]))
-        
-        def _date_bound_to_utc(date_str, end_of_day=False):
-            if not date_str:
-                return None
-            try:
-                d = fields.Date.from_string(date_str)
-            except Exception:
-                return None
-            user_tz = http.request.env.tz
-            t = time.max if end_of_day else time.min
-            local_dt = user_tz.localize(datetime.combine(d, t))
-            utc_dt = local_dt.astimezone(pytz.UTC)
-            return fields.Datetime.to_string(utc_dt)
+        # Apply additional filters (team / organization / assigned / date
+        # range) via the shared helper so the calendar feed stays in sync.
+        self._apply_event_filters(
+            domain,
+            team_id=team_id,
+            organization_id=organization_id,
+            assigned_user_id=assigned_user_id,
+            date_from=date_from,
+            date_to=date_to,
+        )
 
-        if date_from:
-            dt_utc = _date_bound_to_utc(date_from, end_of_day=False)
-            if dt_utc:
-                domain.append(('date_start', '>=', dt_utc))
-
-        if date_to:
-            dt_utc = _date_bound_to_utc(date_to, end_of_day=True)
-            if dt_utc:
-                domain.append(('date_start', '<=', dt_utc))
-        
         if search:
             domain.extend([
                 '|', '|', '|',
@@ -312,11 +285,14 @@ class EventsPortal(CustomerPortal, AccessControlMixin):
         return http.request.render('bemade_sports_clinic.portal_events_list', values)
 
     @http.route(['/my/events/calendar'], type='http', auth='user', website=True)
-    def view_events_calendar(self, **kw):
+    def view_events_calendar(self, team_id=None, organization_id=None,
+                             assigned_user_id=None, date_from=None, date_to=None, **kw):
         """Calendar (month view) of accessible sports events for the user.
 
         Renders an HTML shell; FullCalendar in the template fetches events
-        via /my/events/calendar/data.
+        via /my/events/calendar/data. The same list-style filter controls
+        (team / organization / assigned professional / date range) are
+        rendered here; their current values seed the calendar's data fetch.
         """
         user = http.request.env.user
         is_therapist = user.has_group('bemade_sports_clinic.group_portal_treatment_professional') or \
@@ -326,10 +302,20 @@ class EventsPortal(CustomerPortal, AccessControlMixin):
             raise AccessError(_("You don't have access to events."))
         return http.request.render('bemade_sports_clinic.portal_events_calendar', {
             'page_name': 'events_calendar',
+            'teams': self._get_accessible_teams(),
+            'organizations': self._get_organizations(),
+            'treatment_professionals': self._get_treatment_professionals(),
+            'team_id': int(team_id) if team_id else None,
+            'organization_id': int(organization_id) if organization_id else None,
+            'assigned_user_id': int(assigned_user_id) if assigned_user_id else None,
+            'date_from': date_from,
+            'date_to': date_to,
         })
 
     @http.route(['/my/events/calendar/data'], type='http', auth='user', methods=['GET'], website=True)
-    def view_events_calendar_data(self, start=None, end=None, **kw):
+    def view_events_calendar_data(self, start=None, end=None, team_id=None,
+                                  organization_id=None, assigned_user_id=None,
+                                  date_from=None, date_to=None, **kw):
         """JSON feed for FullCalendar.
 
         Returns events the current user is allowed to see (record rules
@@ -346,6 +332,16 @@ class EventsPortal(CustomerPortal, AccessControlMixin):
             return http.request.make_response('[]', headers=[('Content-Type', 'application/json')])
 
         domain = self._prepare_events_domain('all')
+        # Apply the same list-style filters (team / organization / assigned /
+        # date range) the calendar's filter bar exposes.
+        self._apply_event_filters(
+            domain,
+            team_id=team_id,
+            organization_id=organization_id,
+            assigned_user_id=assigned_user_id,
+            date_from=date_from,
+            date_to=date_to,
+        )
         # FullCalendar passes ISO datetimes (with or without tz). Normalize
         # to naive UTC so the comparison against Odoo's UTC-stored
         # date_start / date_end fields is correct regardless of the
@@ -397,7 +393,13 @@ class EventsPortal(CustomerPortal, AccessControlMixin):
                     'teams': ev_sudo.team_ids.mapped('name'),
                     'assigned': ev_sudo.assigned_staff_ids.mapped('name'),
                     'event_type': ev.event_type or '',
-                    'state': ev.state,
+                    # 'Arrive by' time for therapists: emit explicit-UTC ISO so
+                    # the popover localizes it the same way as start/end.
+                    'therapist_start': (
+                        pytz.UTC.localize(ev_sudo.therapist_start).isoformat()
+                        if ev_sudo.therapist_start else None
+                    ),
+                    'venue': ev_sudo.venue_id.name or '',
                 },
             })
         return http.request.make_response(

--- a/bemade_sports_clinic/controllers/events_portal.py
+++ b/bemade_sports_clinic/controllers/events_portal.py
@@ -263,9 +263,12 @@ class EventsPortal(CustomerPortal, AccessControlMixin):
 
             grouped_events = list(grouped.values())
         
-        # Get filter options
-        teams = self._get_accessible_teams()
-        organizations = self._get_organizations()
+        # Get filter options. The team/org dropdowns list ALL teams/orgs (task
+        # 1226) so users can scope to any team; this only widens the *filter
+        # choices*, not record visibility — the result domain above and the
+        # sports.event record rules still keep coaches scoped to their teams.
+        teams = self._get_all_teams()
+        organizations = self._get_all_organizations()
         treatment_professionals = self._get_treatment_professionals()
         
         # Debug: Log filter options

--- a/bemade_sports_clinic/controllers/events_portal.py
+++ b/bemade_sports_clinic/controllers/events_portal.py
@@ -691,7 +691,9 @@ class EventsPortal(CustomerPortal, AccessControlMixin):
             )
 
         try:
-            event.with_context(portal_cancel_event=True).write({'state': 'cancelled'})
+            event.with_context(
+                portal_cancel_event=True, cancel_reason=reason,
+            ).write({'state': 'cancelled'})
             try:
                 event.message_post(body=_('Event cancelled via portal. Reason: %s') % reason)
             except Exception:

--- a/bemade_sports_clinic/controllers/events_portal.py
+++ b/bemade_sports_clinic/controllers/events_portal.py
@@ -310,14 +310,20 @@ class EventsPortal(CustomerPortal, AccessControlMixin):
             raise AccessError(_("You don't have access to events."))
         return http.request.render('bemade_sports_clinic.portal_events_calendar', {
             'page_name': 'events_calendar',
-            'teams': self._get_accessible_teams(),
-            'organizations': self._get_organizations(),
+            # Sudo-widened choices, matching the list view (task 1226): this
+            # widens only the filter OPTIONS — the feed's domain and record
+            # rules still scope actual event visibility.
+            'teams': self._get_all_teams(),
+            'organizations': self._get_all_organizations(),
             'treatment_professionals': self._get_treatment_professionals(),
             'team_id': int(team_id) if team_id else None,
             'organization_id': int(organization_id) if organization_id else None,
             'assigned_user_id': int(assigned_user_id) if assigned_user_id else None,
             'date_from': date_from,
             'date_to': date_to,
+            'view_type': kw.get('view_type') or 'all',
+            'show_cancelled': bool(kw.get('show_cancelled')),
+            'is_therapist': is_therapist,
         })
 
     @http.route(['/my/events/calendar/data'], type='http', auth='user', methods=['GET'], website=True)
@@ -341,7 +347,13 @@ class EventsPortal(CustomerPortal, AccessControlMixin):
 
         # Cancelled events are hidden by default; show_cancelled=1 includes them (task 1235).
         include_cancelled = bool(kw.get('show_cancelled'))
-        domain = self._prepare_events_domain('all', include_cancelled=include_cancelled)
+        # Honor the same quick filters as the list view (All / My /
+        # Unassigned / Missing Timesheets) via view_type (dev-review
+        # 2026-07-04). Unknown values fall back to 'all'.
+        view_type = kw.get('view_type')
+        if view_type not in ('all', 'my', 'unassigned', 'missing_timesheets'):
+            view_type = 'all'
+        domain = self._prepare_events_domain(view_type, include_cancelled=include_cancelled)
         # Apply the same list-style filters (team / organization / assigned /
         # date range) the calendar's filter bar exposes.
         self._apply_event_filters(
@@ -551,7 +563,14 @@ class EventsPortal(CustomerPortal, AccessControlMixin):
         # Timesheets are TP-only — coaches don't have read access to
         # sports.event.timesheet, so even iterating raises AccessError.
         # The template hides the tab and content when this is False.
-        can_view_timesheets = is_therapist or user.has_group('base.group_system')
+        # Confidentiality (dev-review 2026-07-04): a TP only sees the tab when
+        # assigned to this event, and then only their OWN rows; system admins
+        # keep the full view. Membership is read via event_sudo (m2m to
+        # res.users is group-restricted).
+        is_assigned = user.id in event_sudo.assigned_staff_ids.ids
+        show_all_timesheets = user.has_group('base.group_system')
+        can_view_timesheets = (is_therapist and is_assigned) or show_all_timesheets
+        can_add_timesheet = is_therapist and is_assigned
         values = {
             'event': event,
             'event_sudo': event_sudo,
@@ -565,6 +584,8 @@ class EventsPortal(CustomerPortal, AccessControlMixin):
             'page_name': 'event_detail',
             'can_edit': can_edit,
             'can_view_timesheets': can_view_timesheets,
+            'can_add_timesheet': can_add_timesheet,
+            'show_all_timesheets': show_all_timesheets,
             'return_url': return_url,
             'event_return_url': event_return_url,
             'timesheet_local_dt': local_dt_map,
@@ -835,14 +856,21 @@ class EventsPortal(CustomerPortal, AccessControlMixin):
                 update_vals['description'] = post['description']
             # Teams: accept team_ids (list or CSV) or legacy team_id
             team_ids_param = post.get('team_ids') or post.get('team_ids[]')
+            team_ids_list = None
             if team_ids_param is not None:
                 if isinstance(team_ids_param, list):
                     team_ids_list = [int(x) for x in team_ids_param if x]
                 else:
                     team_ids_list = [int(x.strip()) for x in str(team_ids_param).split(',') if x.strip()]
-                update_vals['team_ids'] = [(6, 0, team_ids_list)]
             elif 'team_id' in post and post['team_id']:
-                update_vals['team_ids'] = [(6, 0, [int(post['team_id'])])]
+                team_ids_list = [int(post['team_id'])]
+            # Only write team_ids when it actually changed: the form always
+            # re-posts the current teams, and writing an unchanged m2m still
+            # runs the sports.team record rules — a TP editing (e.g. adding a
+            # therapist to) an event that involves a team they can't read
+            # would trip a raw AccessError for a no-op (dev-review 2026-07-04).
+            if team_ids_list is not None and set(team_ids_list) != set(event.sudo().team_ids.ids):
+                update_vals['team_ids'] = [(6, 0, team_ids_list)]
             if 'venue_id' in post and post['venue_id']:
                 update_vals['venue_id'] = int(post['venue_id'])
             if 'event_type' in post:
@@ -904,7 +932,15 @@ class EventsPortal(CustomerPortal, AccessControlMixin):
                 event.sudo().write({'assigned_staff_ids': staff_command})
 
             return http.request.redirect(f'/my/event/{event_id}?success=1{return_qs}')
-            
+
+        except AccessError:
+            # Don't surface the ORM's verbose access blurb to portal users —
+            # log it and show a short actionable message instead.
+            _logger.warning("Portal save_event access refusal", exc_info=True)
+            error_msg = _("You don't have access to one of the selected teams "
+                          "or fields, so the change was not saved. Remove the "
+                          "restricted selection or ask an administrator.")
+            return http.request.redirect(f'/my/event/{event_id}/edit?error={urllib.parse.quote(error_msg)}{return_qs}')
         except Exception as e:
             # Clean error message to prevent redirect issues with newlines
             error_msg = str(e).replace('\n', ' ').replace('\r', ' ')

--- a/bemade_sports_clinic/controllers/task_management_portal.py
+++ b/bemade_sports_clinic/controllers/task_management_portal.py
@@ -251,34 +251,29 @@ class TaskManagementPortal(CustomerPortal, AccessControlMixin):
 
     @http.route(['/my/player/activities'], type='http', auth='user', website=True)
     def view_player_activities(self, player_id=None, team_id=None, **kw):
-        """Object-specific wrapper: activities for a single player.
+        """Back-compat redirect (task 1222).
 
-        Delegates to ``view_activities`` with ``model='sports.patient'`` and
-        a simplified, single-list view.
+        The player's activities (and its injuries') now live in an Activities
+        tab on the player detail page, so this standalone page is retired. We
+        keep the route and redirect to the player page's Activities tab anchor
+        so old links/bookmarks/breadcrumbs keep working. Access is still gated
+        via ``_check_access_to_patient`` (raises -> 403 for outsiders).
         """
         if not player_id:
             return request.redirect('/my/players')
 
         patient = self._check_access_to_patient(player_id)
 
-        # When a team_id is provided, validate explicit team context so that
-        # breadcrumbs can include the team in the trail. This mirrors
-        # team_context_id usage elsewhere but is scoped locally to activities.
-        validated_team_id = None
+        url = f'/my/player?player_id={patient.id}'
         if team_id:
             try:
                 team = self._check_team_access(team_id, check_staff=True)
                 if team:
-                    validated_team_id = team.id
+                    url += f'&team_id={team.id}'
             except UserError:
-                validated_team_id = None
+                pass
 
-        return self.view_activities(
-            model='sports.patient',
-            res_id=patient.id,
-            simplified=True,
-            team_id=validated_team_id,
-        )
+        return request.redirect(url + '#activities')
 
     @http.route(['/my/team/activities'], type='http', auth='user', website=True)
     def view_team_activities(self, team_id=None, **kw):

--- a/bemade_sports_clinic/controllers/team_management_portal.py
+++ b/bemade_sports_clinic/controllers/team_management_portal.py
@@ -208,25 +208,36 @@ class TeamManagementPortal(CustomerPortal, AccessControlMixin):
             # Activities tab (task 1223): team-LEVEL activities only. We strictly
             # scope to res_model='sports.team'/res_id=team.id so a team player's
             # (sports.patient) or injury's (sports.patient.injury) activities are
-            # NOT mixed into the team tab.
-            team_activities = request.env['mail.activity'].search([
-                ('res_model', '=', 'sports.team'),
-                ('res_id', '=', team.id),
-            ], order='date_deadline asc')
-
-            # Assignable users for the add-activity header / reassign modal:
-            # treatment professionals (and admins) may assign to any treatment
-            # professional; everyone else (e.g. coaches) may only self-assign.
-            portal_tp_group = request.env.ref('bemade_sports_clinic.group_portal_treatment_professional')
-            internal_tp_group = request.env.ref('bemade_sports_clinic.group_sports_clinic_treatment_professional')
-            if is_treatment_prof or is_admin:
-                assignable_users = request.env['res.users'].search([
-                    ('group_ids', 'in', [portal_tp_group.id, internal_tp_group.id])
-                ])
-            else:
-                assignable_users = request.env.user
-            default_activity_type = request.env.ref(
-                'mail.mail_activity_data_todo', raise_if_not_found=False)
+            # NOT mixed into the team tab. Only fetched for roles holding
+            # mail.activity ACLs (TP / coach / internal) — a staff member with
+            # role 'other' would 403 the whole page otherwise (dev-review
+            # 2026-07-04 round 2).
+            can_use_activities = (
+                is_treatment_prof or is_admin
+                or request.env.user.has_group('bemade_sports_clinic.group_portal_team_coach')
+                or request.env.user.has_group('base.group_user')
+            )
+            team_activities = request.env['mail.activity']
+            activity_types = request.env['mail.activity.type']
+            assignable_users = request.env.user
+            default_activity_type = None
+            if can_use_activities:
+                team_activities = request.env['mail.activity'].search([
+                    ('res_model', '=', 'sports.team'),
+                    ('res_id', '=', team.id),
+                ], order='date_deadline asc')
+                activity_types = request.env['mail.activity.type'].search([])
+                # Assignable users for the add-activity header / reassign modal:
+                # treatment professionals (and admins) may assign to any treatment
+                # professional; everyone else (e.g. coaches) may only self-assign.
+                portal_tp_group = request.env.ref('bemade_sports_clinic.group_portal_treatment_professional')
+                internal_tp_group = request.env.ref('bemade_sports_clinic.group_sports_clinic_treatment_professional')
+                if is_treatment_prof or is_admin:
+                    assignable_users = request.env['res.users'].search([
+                        ('group_ids', 'in', [portal_tp_group.id, internal_tp_group.id])
+                    ])
+                default_activity_type = request.env.ref(
+                    'mail.mail_activity_data_todo', raise_if_not_found=False)
 
             values = {
                 # Use my_teams so existing breadcrumbs logic renders
@@ -241,8 +252,9 @@ class TeamManagementPortal(CustomerPortal, AccessControlMixin):
                 'is_treatment_prof': is_treatment_prof or is_admin,
                 'is_team_staff': bool(is_team_staff),
                 # Activities tab context
+                'can_view_activities': can_use_activities,
                 'team_activities': team_activities,
-                'activity_types': request.env['mail.activity.type'].search([]),
+                'activity_types': activity_types,
                 'assignable_users': assignable_users,
                 'available_users': assignable_users,  # reassign modal in activity_list_table
                 'default_activity_type_id': default_activity_type.id if default_activity_type else False,

--- a/bemade_sports_clinic/controllers/team_management_portal.py
+++ b/bemade_sports_clinic/controllers/team_management_portal.py
@@ -893,6 +893,81 @@ class TeamManagementPortal(CustomerPortal, AccessControlMixin):
             }
             return request.redirect(f"/my/team/{team_id}")
 
+    @http.route(['/my/player/<int:player_id>/add_to_team'], type='http', auth='user', website=True, methods=['POST'], csrf=True)
+    def portal_add_player_to_team(self, player_id, **post):
+        """Link an out-of-reach player (surfaced by the broadened /my/players
+        search, task 1225) to one of the current user's staffed teams.
+
+        Security:
+        - Restricted to treatment professionals / admins, mirroring the other
+          direct add/link routes (coaches keep the request-based flow).
+        - The posted team_id is NEVER trusted: it must be a team the user
+          actually staffs (or the user is a system admin). Defense in depth, as
+          in the create/link flows.
+        - sudo() is required because the player may be hidden from the user's
+          per-record ir.rules until the team link exists; only then does
+          _check_access_to_patient grant the user full record access.
+        """
+        return_url = post.get('return_url') or '/my/players'
+        # Only ever redirect to a same-site, absolute path (reject scheme-relative
+        # '//host' and backslash tricks to avoid an open redirect).
+        if (not isinstance(return_url, str)
+                or not return_url.startswith('/')
+                or return_url.startswith('//')
+                or '\\' in return_url):
+            return_url = '/my/players'
+
+        user = request.env.user
+        is_system = user.has_group('base.group_system')
+        is_tp_admin = is_system or user.has_group(
+            'bemade_sports_clinic.group_portal_treatment_professional')
+        if not is_tp_admin:
+            request.session['notification'] = {
+                'type': 'danger',
+                'title': _('Access Denied'),
+                'message': _("You don't have permission to add players to a team."),
+                'sticky': False,
+            }
+            return request.redirect(return_url)
+
+        try:
+            team_id = int(post.get('team_id') or 0)
+        except (TypeError, ValueError):
+            team_id = 0
+
+        staff_team_ids = set(user.partner_id.team_staff_rel_ids.mapped('team_id.id'))
+        if not team_id or (not is_system and team_id not in staff_team_ids):
+            request.session['notification'] = {
+                'type': 'danger',
+                'title': _('Access Denied'),
+                'message': _('You can only add players to a team you staff.'),
+                'sticky': False,
+            }
+            return request.redirect(return_url)
+
+        # sudo: see docstring.
+        player = request.env['sports.patient'].sudo().browse(player_id).exists()
+        team = request.env['sports.team'].sudo().browse(team_id).exists()
+        if not player or not team:
+            request.session['notification'] = {
+                'type': 'danger',
+                'title': _('Error'),
+                'message': _('Player or team not found.'),
+                'sticky': False,
+            }
+            return request.redirect(return_url)
+
+        if team not in player.team_ids:
+            player.write({'team_ids': [fields.Command.link(team.id)]})
+
+        request.session['notification'] = {
+            'type': 'success',
+            'title': _('Player Added'),
+            'message': _('%s has been added to %s.') % (player.name, team.name),
+            'sticky': False,
+        }
+        return request.redirect(return_url)
+
     @http.route(['/my/team/<int:team_id>/player/create'], type='http', auth='user', website=True, methods=['POST'], csrf=True)
     def portal_create_player_submit(self, team_id, **post):
         """Create a brand new player and link to team from the Add/Link page.

--- a/bemade_sports_clinic/controllers/team_management_portal.py
+++ b/bemade_sports_clinic/controllers/team_management_portal.py
@@ -205,6 +205,29 @@ class TeamManagementPortal(CustomerPortal, AccessControlMixin):
                 lambda s: request.env.user.partner_id in s.user_ids.partner_id
             )
             
+            # Activities tab (task 1223): team-LEVEL activities only. We strictly
+            # scope to res_model='sports.team'/res_id=team.id so a team player's
+            # (sports.patient) or injury's (sports.patient.injury) activities are
+            # NOT mixed into the team tab.
+            team_activities = request.env['mail.activity'].search([
+                ('res_model', '=', 'sports.team'),
+                ('res_id', '=', team.id),
+            ], order='date_deadline asc')
+
+            # Assignable users for the add-activity header / reassign modal:
+            # treatment professionals (and admins) may assign to any treatment
+            # professional; everyone else (e.g. coaches) may only self-assign.
+            portal_tp_group = request.env.ref('bemade_sports_clinic.group_portal_treatment_professional')
+            internal_tp_group = request.env.ref('bemade_sports_clinic.group_sports_clinic_treatment_professional')
+            if is_treatment_prof or is_admin:
+                assignable_users = request.env['res.users'].search([
+                    ('group_ids', 'in', [portal_tp_group.id, internal_tp_group.id])
+                ])
+            else:
+                assignable_users = request.env.user
+            default_activity_type = request.env.ref(
+                'mail.mail_activity_data_todo', raise_if_not_found=False)
+
             values = {
                 # Use my_teams so existing breadcrumbs logic renders
                 # "Teams / <Team Name>" for team detail pages.
@@ -217,6 +240,14 @@ class TeamManagementPortal(CustomerPortal, AccessControlMixin):
                 'user': request.env.user,
                 'is_treatment_prof': is_treatment_prof or is_admin,
                 'is_team_staff': bool(is_team_staff),
+                # Activities tab context
+                'team_activities': team_activities,
+                'activity_types': request.env['mail.activity.type'].search([]),
+                'assignable_users': assignable_users,
+                'available_users': assignable_users,  # reassign modal in activity_list_table
+                'default_activity_type_id': default_activity_type.id if default_activity_type else False,
+                'default_user_id': request.env.user.id,
+                'today': date.today().strftime('%Y-%m-%d'),
             }
             
             # Add success/error messages if present in the URL

--- a/bemade_sports_clinic/controllers/team_staff_portal.py
+++ b/bemade_sports_clinic/controllers/team_staff_portal.py
@@ -11,19 +11,26 @@ from .access_control_mixin import AccessControlMixin
 class TeamStaffPortal(CustomerPortal, AccessControlMixin):
     def _prepare_home_portal_values(self, counters):
         rtn = super()._prepare_home_portal_values(counters)
+        user = http.request.env.user
         teams_domain = self._prepare_teams_domain()
         players_domain = self._prepare_players_domain(teams_domain)
-        activities_domain = self._prepare_activities_domain()
-        events_domain = self._prepare_events_domain()
         rtn['teams_count'] = http.request.env['sports.team'].search_count(teams_domain)
         rtn['players_count'] = http.request.env['sports.patient'].search_count(
             players_domain)
-        rtn['activities_count'] = http.request.env['mail.activity'].search_count(
-            activities_domain)
-        rtn['events_count'] = http.request.env['sports.event'].search_count(
-            events_domain)
+        # mail.activity and sports.event ACLs only cover internal users,
+        # portal coaches and portal TPs. Any other portal user (e.g. staff
+        # role 'other') would 403 right at login if we counted
+        # unconditionally (task 1222 dev-review fix, 2026-07-04).
+        if (user.has_group('bemade_sports_clinic.group_portal_treatment_professional')
+                or user.has_group('bemade_sports_clinic.group_portal_team_coach')
+                or user.has_group('base.group_user')):
+            activities_domain = self._prepare_activities_domain()
+            rtn['activities_count'] = http.request.env['mail.activity'].search_count(
+                activities_domain)
+            events_domain = self._prepare_events_domain()
+            rtn['events_count'] = http.request.env['sports.event'].search_count(
+                events_domain)
         # Timesheets count (therapists only)
-        user = http.request.env.user
         if user.has_group('bemade_sports_clinic.group_portal_treatment_professional') or user.has_group('base.group_system'):
             rtn['timesheets_count'] = http.request.env['sports.event.timesheet'].search_count([('user_id', '=', user.id)])
         return rtn

--- a/bemade_sports_clinic/controllers/team_staff_portal.py
+++ b/bemade_sports_clinic/controllers/team_staff_portal.py
@@ -1,4 +1,5 @@
 import urllib.parse
+from datetime import date
 
 from odoo.addons.portal.controllers.portal import CustomerPortal, pager
 from odoo import http, _
@@ -256,6 +257,59 @@ class TeamStaffPortal(CustomerPortal, AccessControlMixin):
             ('patient_id', '=', player.id)
         ], order='date desc, id desc')
 
+        # Activities tab (task 1222): the player's own activities AND the
+        # activities of the injuries the user is allowed to see, merged into one
+        # list. We scope injury activities to `injuries` (the role-filtered set
+        # computed above — TPs see all, coaches see active only), so an activity
+        # on an injury the user can't read never surfaces here. mail.activity
+        # record rules already gate broad access; constraining res_id to this
+        # player and its visible injuries keeps the listing team-scoped.
+        #
+        # IMPORTANT: only TPs and coaches hold ACLs on mail.activity[.type]
+        # (see security/ir.model.access.csv). view_player is reachable by any
+        # team staffer, including role='other' users who hold neither portal
+        # group, so the search/types lookups MUST be gated or they raise
+        # AccessError and 500 the whole player page. The Activities tab is
+        # likewise hidden from those users in the template.
+        can_use_activities = is_treatment_prof or user.has_group(
+            'bemade_sports_clinic.group_portal_team_coach')
+        player_activities = http.request.env['mail.activity']
+        activity_types = http.request.env['mail.activity.type']
+        default_activity_type = http.request.env['mail.activity.type']
+        assignable_users = http.request.env['res.users']
+        if can_use_activities:
+            player_activities = http.request.env['mail.activity'].search(
+                [
+                    '|',
+                    '&', ('res_model', '=', 'sports.patient'),
+                    ('res_id', '=', player.id),
+                    '&', ('res_model', '=', 'sports.patient.injury'),
+                    ('res_id', 'in', injuries.ids or [0]),
+                ],
+                order='date_deadline asc',
+            )
+
+            # Data for the inline add-activity header (mirrors
+            # create_activity_form for model='sports.patient').
+            activity_types = http.request.env['mail.activity.type'].search([])
+            default_activity_type = http.request.env.ref(
+                'mail.mail_activity_data_todo', raise_if_not_found=False)
+            if not default_activity_type:
+                default_activity_type = http.request.env['mail.activity.type'].search(
+                    [('category', '=', 'todo')], limit=1)
+            # Assignable users: TPs may assign to any treatment professional
+            # (portal or internal); coaches may only assign to themselves.
+            if is_treatment_prof:
+                portal_tp_group = http.request.env.ref(
+                    'bemade_sports_clinic.group_portal_treatment_professional')
+                internal_tp_group = http.request.env.ref(
+                    'bemade_sports_clinic.group_sports_clinic_treatment_professional')
+                assignable_users = http.request.env['res.users'].search([
+                    ('group_ids', 'in', [portal_tp_group.id, internal_tp_group.id])
+                ])
+            else:
+                assignable_users = user
+
         # Categories for patient document uploads
         categories = [
             ('medical', 'Medical'),
@@ -317,6 +371,7 @@ class TeamStaffPortal(CustomerPortal, AccessControlMixin):
         documents_tab_return = _tab_url('documents')
         notes_tab_return = _tab_url('notes')
         injuries_tab_return = _tab_url('injuries')
+        activities_tab_return = _tab_url('activities')
         contacts_tab_return_q = urllib.parse.quote(contacts_tab_return, safe='')
 
         add_contact_url = (
@@ -331,6 +386,11 @@ class TeamStaffPortal(CustomerPortal, AccessControlMixin):
                 'injuries': injuries,
                 'patient_documents': patient_documents,
                 'treatment_notes': treatment_notes,
+                'player_activities': player_activities,
+                'activity_types': activity_types,
+                'default_activity_type': default_activity_type,
+                'assignable_users': assignable_users,
+                'today': date.today().strftime('%Y-%m-%d'),
                 'categories': categories,
                 'team': team,
                 'page_name': 'my_player',
@@ -345,6 +405,7 @@ class TeamStaffPortal(CustomerPortal, AccessControlMixin):
                 'documents_tab_return': documents_tab_return,
                 'notes_tab_return': notes_tab_return,
                 'injuries_tab_return': injuries_tab_return,
+                'activities_tab_return': activities_tab_return,
                 'contacts_tab_return_q': contacts_tab_return_q,
                 'add_contact_url': add_contact_url,
             }

--- a/bemade_sports_clinic/controllers/team_staff_portal.py
+++ b/bemade_sports_clinic/controllers/team_staff_portal.py
@@ -122,13 +122,23 @@ class TeamStaffPortal(CustomerPortal, AccessControlMixin):
         - practice_status (exact)
         """
         Patients = http.request.env['sports.patient']
+        user = http.request.env.user
+        is_system = user.has_group('base.group_system')
+        is_tp_admin = is_system or user.has_group(
+            'bemade_sports_clinic.group_portal_treatment_professional')
+        # Teams the user actually staffs (drives both accessibility and the
+        # Add-to-Team target list). For a TP this is NOT "all teams": full
+        # patient-record access requires a staff relationship (see
+        # _check_access_to_patient), so the accessibility test must use the
+        # staffed teams, not _get_accessible_teams().
+        staff_teams = user.partner_id.team_staff_rel_ids.mapped('team_id')
+        staff_team_ids = set(staff_teams.ids)
 
         # Base domain by accessible teams
         teams_domain = self._prepare_teams_domain()
         base_players_domain = self._prepare_players_domain(teams_domain)
 
         # Additional filters
-        domain = list(base_players_domain)
         first_name = (kw.get('first_name') or '').strip()
         last_name = (kw.get('last_name') or '').strip()
         team_id = kw.get('team_id')
@@ -136,13 +146,24 @@ class TeamStaffPortal(CustomerPortal, AccessControlMixin):
         match_status = kw.get('match_status')
         practice_status = kw.get('practice_status')
 
+        # Task 1225 / 640: when a TP/admin searches by name, broaden beyond the
+        # user's own teams so out-of-team players are *findable* (to be added to
+        # a team the user staffs). The per-record ir.rules would hide those
+        # patients, so the identity-level lookup is done with sudo(); full
+        # record access stays team-gated by view_player. The default (no name
+        # search) listing and the home counter remain "your players" only.
+        name_search = bool(first_name or last_name)
+        broaden = is_tp_admin and name_search
+        Patients_search = Patients.sudo() if broaden else Patients
+
+        filters = []
         if first_name:
-            domain.append(('first_name', 'ilike', first_name))
+            filters.append(('first_name', 'ilike', first_name))
         if last_name:
-            domain.append(('last_name', 'ilike', last_name))
+            filters.append(('last_name', 'ilike', last_name))
         if team_id:
             try:
-                domain.append(('team_ids', 'in', [int(team_id)]))
+                filters.append(('team_ids', 'in', [int(team_id)]))
             except Exception:
                 pass
         if organization_id:
@@ -150,16 +171,18 @@ class TeamStaffPortal(CustomerPortal, AccessControlMixin):
                 org_id = int(organization_id)
                 # players whose any team has this parent organization
                 team_ids = http.request.env['sports.team'].search([('parent_id', '=', org_id)]).ids
-                domain.append(('team_ids', 'in', team_ids or [0]))
+                filters.append(('team_ids', 'in', team_ids or [0]))
             except Exception:
                 pass
         if match_status:
-            domain.append(('match_status', '=', match_status))
+            filters.append(('match_status', '=', match_status))
         if practice_status:
-            domain.append(('practice_status', '=', practice_status))
+            filters.append(('practice_status', '=', practice_status))
+
+        domain = ([] if broaden else list(base_players_domain)) + filters
 
         # Count and pagination
-        total = Patients.search_count(domain)
+        total = Patients_search.search_count(domain)
         pgr = pager(
             url='/my/players',
             total=total,
@@ -176,12 +199,29 @@ class TeamStaffPortal(CustomerPortal, AccessControlMixin):
         )
 
         # Query with ordering: last name, first name ASC
-        players = Patients.search(
+        players = Patients_search.search(
             domain,
             order='last_name asc, first_name asc',
             limit=self._items_per_page,
             offset=pgr['offset'],
         )
+
+        # Per-row accessibility (task 1225): a player is openable only if the
+        # user is a system admin or staffs one of the player's teams - exactly
+        # _check_access_to_patient's rule. Inaccessible players (surfaced by the
+        # broadened search) get an Add-to-Team action instead of a 403-bound
+        # View link.
+        if is_system:
+            accessible_ids = set(players.ids)
+        else:
+            accessible_ids = {
+                p.id for p in players
+                if staff_team_ids.intersection(p.team_ids.ids)
+            }
+        # Teams offered in the Add-to-Team control: only the user's own staffed
+        # teams, and only for users who may directly add (TP/admin). Linking to
+        # one of these grants the user access afterwards.
+        add_to_team_teams = staff_teams.sorted('name') if is_tp_admin else staff_teams.browse([])
 
         # Filter options
         teams = self._get_accessible_teams()
@@ -194,6 +234,8 @@ class TeamStaffPortal(CustomerPortal, AccessControlMixin):
             qcontext={
                 'players_count': total,
                 'players': players,
+                'accessible_ids': accessible_ids,
+                'add_to_team_teams': add_to_team_teams,
                 'pager': pgr,
                 'page_name': 'my_players',
                 # filters current values

--- a/bemade_sports_clinic/controllers/timesheets_portal.py
+++ b/bemade_sports_clinic/controllers/timesheets_portal.py
@@ -18,11 +18,10 @@ class TimesheetsPortal(CustomerPortal, AccessControlMixin):
         if 'event_timesheets_count' in counters:
             user = http.request.env.user
             if user.has_group('bemade_sports_clinic.group_portal_treatment_professional') or user.has_group('base.group_system'):
-                # Count timesheets owned by the current user OR by an internal user sharing the same partner,
-                # excluding timesheets whose event has been cancelled (task 990).
-                count_domain = ['&',
-                                ('event_id.state', '!=', 'cancelled'),
-                                '|', ('user_id', '=', user.id), ('user_id.partner_id', '=', user.partner_id.id)]
+                # Count timesheets owned by the current user OR by an internal user sharing
+                # the same partner. Timesheets on cancelled events stay included: a
+                # last-minute cancellation can still be payable/invoiceable.
+                count_domain = ['|', ('user_id', '=', user.id), ('user_id.partner_id', '=', user.partner_id.id)]
                 count = http.request.env['sports.event.timesheet'].search_count(count_domain)
                 vals['event_timesheets_count'] = count
                 _logger.debug(
@@ -36,9 +35,9 @@ class TimesheetsPortal(CustomerPortal, AccessControlMixin):
         if not (user.has_group('bemade_sports_clinic.group_portal_treatment_professional') or user.has_group('base.group_system')):
             # No access for non-therapists in portal
             return [('id', '=', 0)]
-        # Hard-exclude timesheets attached to cancelled events (task 990): they
-        # must never surface in the therapist portal list or counter.
-        domain = [('event_id.state', '!=', 'cancelled')]
+        # Timesheets on cancelled events stay listed: a last-minute cancellation
+        # can still be payable to the therapist / invoiceable to the customer.
+        domain = []
         if user_only:
             # Show records owned by the exact user or by an internal user sharing the same partner
             domain.extend(['|', ('user_id', '=', user.id), ('user_id.partner_id', '=', user.partner_id.id)])

--- a/bemade_sports_clinic/controllers/timesheets_portal.py
+++ b/bemade_sports_clinic/controllers/timesheets_portal.py
@@ -18,8 +18,11 @@ class TimesheetsPortal(CustomerPortal, AccessControlMixin):
         if 'event_timesheets_count' in counters:
             user = http.request.env.user
             if user.has_group('bemade_sports_clinic.group_portal_treatment_professional') or user.has_group('base.group_system'):
-                # Count timesheets owned by the current user OR by an internal user sharing the same partner
-                count_domain = ['|', ('user_id', '=', user.id), ('user_id.partner_id', '=', user.partner_id.id)]
+                # Count timesheets owned by the current user OR by an internal user sharing the same partner,
+                # excluding timesheets whose event has been cancelled (task 990).
+                count_domain = ['&',
+                                ('event_id.state', '!=', 'cancelled'),
+                                '|', ('user_id', '=', user.id), ('user_id.partner_id', '=', user.partner_id.id)]
                 count = http.request.env['sports.event.timesheet'].search_count(count_domain)
                 vals['event_timesheets_count'] = count
                 _logger.debug(
@@ -33,7 +36,9 @@ class TimesheetsPortal(CustomerPortal, AccessControlMixin):
         if not (user.has_group('bemade_sports_clinic.group_portal_treatment_professional') or user.has_group('base.group_system')):
             # No access for non-therapists in portal
             return [('id', '=', 0)]
-        domain = []
+        # Hard-exclude timesheets attached to cancelled events (task 990): they
+        # must never surface in the therapist portal list or counter.
+        domain = [('event_id.state', '!=', 'cancelled')]
         if user_only:
             # Show records owned by the exact user or by an internal user sharing the same partner
             domain.extend(['|', ('user_id', '=', user.id), ('user_id.partner_id', '=', user.partner_id.id)])

--- a/bemade_sports_clinic/controllers/timesheets_portal.py
+++ b/bemade_sports_clinic/controllers/timesheets_portal.py
@@ -200,3 +200,28 @@ class TimesheetsPortal(CustomerPortal, AccessControlMixin):
         target = return_url or '/my/sc/timesheets'
         separator = '&' if '?' in target else '?'
         return http.request.redirect(f'{target}{separator}updated=1')
+
+    @http.route(['/my/sc/timesheet/<int:ts_id>/delete'], type='http', auth='user', website=True, methods=['POST'], csrf=False)
+    def delete_timesheet(self, ts_id, **post):
+        user = http.request.env.user
+        if not (user.has_group('bemade_sports_clinic.group_portal_treatment_professional') or user.has_group('base.group_system')):
+            raise AccessError(_("You don't have permission to delete timesheets."))
+        ts = http.request.env['sports.event.timesheet'].browse(ts_id)
+        if not ts.exists() or ts.user_id.id != user.id:
+            raise AccessError(_("You can only delete your own timesheets."))
+        if ts.state == 'invoiced':
+            raise UserError(_('This timesheet is invoiced and cannot be deleted.'))
+        # Soft delete (archive); portal TPs have no unlink right.
+        ts.action_soft_delete()
+
+        return_url = post.get('return_url')
+        if return_url and isinstance(return_url, str) and '&amp;' in return_url:
+            return_url = return_url.replace('&amp;', '&')
+        if not return_url or return_url in ('None', 'none', 'null', 'NULL'):
+            return_url = None
+        if return_url and not str(return_url).startswith('/'):
+            return_url = None
+
+        target = return_url or '/my/sc/timesheets'
+        separator = '&' if '?' in target else '?'
+        return http.request.redirect(f'{target}{separator}deleted=1')

--- a/bemade_sports_clinic/data/sports_clinic_data.xml
+++ b/bemade_sports_clinic/data/sports_clinic_data.xml
@@ -92,5 +92,22 @@
                 </div>
             </field>
         </record>
+        <record id="mail_template_event_cancelled" model="mail.template">
+            <field name="name">Event Cancelled - Assigned Staff Notice</field>
+            <field name="model_id" ref="bemade_sports_clinic.model_sports_event"/>
+            <field name="subject">Event cancelled: {{ object.name }}</field>
+            <field name="body_html" type="html">
+                <p>The event you were assigned to has been cancelled.</p>
+                <ul>
+                    <li><strong>Event:</strong> <t t-out="object.name or ''"/></li>
+                    <li t-if="object.date_start"><strong>Date:</strong>
+                        <t t-out="format_datetime(object.date_start) or ''"/></li>
+                    <li t-if="object.team_ids"><strong>Team(s):</strong>
+                        <t t-out="', '.join(object.team_ids.mapped('name'))"/></li>
+                    <li t-if="ctx.get('cancel_reason')"><strong>Reason:</strong>
+                        <t t-out="ctx.get('cancel_reason')"/></li>
+                </ul>
+            </field>
+        </record>
     </data>
 </odoo>

--- a/bemade_sports_clinic/data/sports_clinic_data.xml
+++ b/bemade_sports_clinic/data/sports_clinic_data.xml
@@ -96,15 +96,21 @@
             <field name="name">Event Cancelled - Assigned Staff Notice</field>
             <field name="model_id" ref="bemade_sports_clinic.model_sports_event"/>
             <field name="subject">Event cancelled: {{ object.name }}</field>
+            <!-- Bilingual body (owner call, dev-review 2026-07-04 round 2):
+                 mail.template body_html is whole-value translated, so static
+                 per-language bodies would have to be maintained as full
+                 duplicates — a single FR/EN body is simpler and serves the
+                 mixed-language staff. The subject IS per-language (po). -->
             <field name="body_html" type="html">
-                <p>The event you were assigned to has been cancelled.</p>
+                <p>L'événement auquel vous étiez assigné a été annulé. /
+                   The event you were assigned to has been cancelled.</p>
                 <ul>
-                    <li><strong>Event:</strong> <t t-out="object.name or ''"/></li>
+                    <li><strong>Événement / Event:</strong> <t t-out="object.name or ''"/></li>
                     <li t-if="object.date_start"><strong>Date:</strong>
                         <t t-out="format_datetime(object.date_start) or ''"/></li>
-                    <li t-if="object.team_ids"><strong>Team(s):</strong>
+                    <li t-if="object.team_ids"><strong>Équipe(s) / Team(s):</strong>
                         <t t-out="', '.join(object.team_ids.mapped('name'))"/></li>
-                    <li t-if="ctx.get('cancel_reason')"><strong>Reason:</strong>
+                    <li t-if="ctx.get('cancel_reason')"><strong>Raison / Reason:</strong>
                         <t t-out="ctx.get('cancel_reason')"/></li>
                 </ul>
             </field>

--- a/bemade_sports_clinic/i18n/fr_CA.po
+++ b/bemade_sports_clinic/i18n/fr_CA.po
@@ -428,6 +428,11 @@ msgid "<i class=\"fa fa-link me-1\"/> Link to Team"
 msgstr "<i class=\"fa fa-link me-1\"/> Associer à l'équipe"
 
 #. module: bemade_sports_clinic
+#: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_patient_card
+msgid "<i class=\"fa fa-user-plus me-1\"/> Add to Team"
+msgstr "<i class=\"fa fa-user-plus me-1\"/> Associer à une équipe"
+
+#. module: bemade_sports_clinic
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_events_calendar
 msgid "<i class=\"fa fa-list\"/>&amp;nbsp;List view"
 msgstr "<i class=\"fa fa-list\"/>&amp;nbsp;Vue en liste"

--- a/bemade_sports_clinic/i18n/fr_CA.po
+++ b/bemade_sports_clinic/i18n/fr_CA.po
@@ -6874,3 +6874,68 @@ msgstr ""
 "⚠️ AVERTISSEMENT : Il s'agit de la seule équipe du joueur. Le retirer "
 "laissera le joueur sans équipe.\n"
 "\n"
+
+#. module: bemade_sports_clinic
+#: model:mail.template,subject:bemade_sports_clinic.mail_template_event_cancelled
+msgid "Event cancelled: {{ object.name }}"
+msgstr "Événement annulé : {{ object.name }}"
+
+#. module: bemade_sports_clinic
+#: model_terms:mail.template,body_html:bemade_sports_clinic.mail_template_event_cancelled
+msgid "The event you were assigned to has been cancelled."
+msgstr "L'événement auquel vous étiez assigné a été annulé."
+
+#. module: bemade_sports_clinic
+#: model_terms:mail.template,body_html:bemade_sports_clinic.mail_template_event_cancelled
+msgid "<strong>Event:</strong>"
+msgstr "<strong>Événement :</strong>"
+
+#. module: bemade_sports_clinic
+#: model_terms:mail.template,body_html:bemade_sports_clinic.mail_template_event_cancelled
+msgid "<strong>Date:</strong>"
+msgstr "<strong>Date :</strong>"
+
+#. module: bemade_sports_clinic
+#: model_terms:mail.template,body_html:bemade_sports_clinic.mail_template_event_cancelled
+msgid "<strong>Team(s):</strong>"
+msgstr "<strong>Équipe(s) :</strong>"
+
+#. module: bemade_sports_clinic
+#: model_terms:mail.template,body_html:bemade_sports_clinic.mail_template_event_cancelled
+msgid "<strong>Reason:</strong>"
+msgstr "<strong>Raison :</strong>"
+
+#. module: bemade_sports_clinic
+#: code:addons/bemade_sports_clinic/models/sports_event.py:0
+msgid "Event cancelled: %s"
+msgstr "Événement annulé : %s"
+
+#. module: bemade_sports_clinic
+#: code:addons/bemade_sports_clinic/models/sports_event.py:0
+msgid "Event deleted: %s"
+msgstr "Événement supprimé : %s"
+
+#. module: bemade_sports_clinic
+#: code:addons/bemade_sports_clinic/models/sports_event.py:0
+msgid "The event \"%s\" you were assigned to has been cancelled."
+msgstr "L'événement « %s » auquel vous étiez assigné a été annulé."
+
+#. module: bemade_sports_clinic
+#: code:addons/bemade_sports_clinic/models/sports_event.py:0
+msgid "The event \"%s\" you were assigned to has been deleted."
+msgstr "L'événement « %s » auquel vous étiez assigné a été supprimé."
+
+#. module: bemade_sports_clinic
+#: code:addons/bemade_sports_clinic/models/sports_event.py:0
+msgid "Date:"
+msgstr "Date :"
+
+#. module: bemade_sports_clinic
+#: code:addons/bemade_sports_clinic/models/sports_event.py:0
+msgid "Team(s):"
+msgstr "Équipe(s) :"
+
+#. module: bemade_sports_clinic
+#: code:addons/bemade_sports_clinic/models/sports_event.py:0
+msgid " Reason: %s"
+msgstr " Raison : %s"

--- a/bemade_sports_clinic/i18n/fr_CA.po
+++ b/bemade_sports_clinic/i18n/fr_CA.po
@@ -6880,30 +6880,10 @@ msgstr ""
 msgid "Event cancelled: {{ object.name }}"
 msgstr "Événement annulé : {{ object.name }}"
 
-#. module: bemade_sports_clinic
-#: model_terms:mail.template,body_html:bemade_sports_clinic.mail_template_event_cancelled
-msgid "The event you were assigned to has been cancelled."
-msgstr "L'événement auquel vous étiez assigné a été annulé."
 
-#. module: bemade_sports_clinic
-#: model_terms:mail.template,body_html:bemade_sports_clinic.mail_template_event_cancelled
-msgid "<strong>Event:</strong>"
-msgstr "<strong>Événement :</strong>"
 
-#. module: bemade_sports_clinic
-#: model_terms:mail.template,body_html:bemade_sports_clinic.mail_template_event_cancelled
-msgid "<strong>Date:</strong>"
-msgstr "<strong>Date :</strong>"
 
-#. module: bemade_sports_clinic
-#: model_terms:mail.template,body_html:bemade_sports_clinic.mail_template_event_cancelled
-msgid "<strong>Team(s):</strong>"
-msgstr "<strong>Équipe(s) :</strong>"
 
-#. module: bemade_sports_clinic
-#: model_terms:mail.template,body_html:bemade_sports_clinic.mail_template_event_cancelled
-msgid "<strong>Reason:</strong>"
-msgstr "<strong>Raison :</strong>"
 
 #. module: bemade_sports_clinic
 #: code:addons/bemade_sports_clinic/models/sports_event.py:0

--- a/bemade_sports_clinic/models/event_cancel_wizard.py
+++ b/bemade_sports_clinic/models/event_cancel_wizard.py
@@ -29,9 +29,12 @@ class SportsEventCancelWizard(models.TransientModel):
         if event.state in ('cancelled', 'invoiced'):
             raise UserError(_("This event cannot be cancelled."))
 
-        event.write({'state': 'cancelled'})
+        reason = self.reason.strip()
+        # cancel_reason flows into sports.event.write where the centralised
+        # assigned-staff cancellation notice is fired.
+        event.with_context(cancel_reason=reason).write({'state': 'cancelled'})
         try:
-            event.message_post(body=_('Event cancelled. Reason: %s') % (self.reason.strip(),))
+            event.message_post(body=_('Event cancelled. Reason: %s') % (reason,))
         except Exception:
             pass
 

--- a/bemade_sports_clinic/models/patient.py
+++ b/bemade_sports_clinic/models/patient.py
@@ -901,8 +901,16 @@ class Patient(models.Model):
         for patient in self:
             patient = patient.sudo()
             current_followers = patient.message_partner_ids
-            future_followers = patient.team_ids.mapped("staff_ids").filtered(
-                lambda s: not s.silent_notifications
+            # Read staff with active_test disabled so the eligibility check
+            # — not the ORM's active filtering — decides who is dropped. This
+            # keeps archived-but-not-unlinked staff (e.g. a contact archived
+            # or a user whose portal access was revoked) out of the follower
+            # set instead of silently re-subscribing them.
+            all_staff = patient.team_ids.with_context(
+                active_test=False
+            ).mapped("staff_ids")
+            future_followers = all_staff.filtered(
+                lambda s: s._is_follower_eligible()
             ).mapped("partner_id")
             removed_followers = current_followers - future_followers
 

--- a/bemade_sports_clinic/models/patient.py
+++ b/bemade_sports_clinic/models/patient.py
@@ -905,6 +905,14 @@ class Patient(models.Model):
                 lambda s: not s.silent_notifications
             ).mapped("partner_id")
             removed_followers = current_followers - future_followers
+            # Only subscribe genuinely-new partners. Subscribing the full
+            # ``future_followers`` set on every recompute relies on core's dedup; when
+            # the recompute fires more than once in a single flow (e.g. a team is
+            # assigned before the patient's first save, so create() and the team-side
+            # recompute both run) two inserts can race the mail.followers unique
+            # constraint and raise "a partner can't follow an object twice". Computing
+            # the net-new set up front keeps recompute_followers idempotent.
+            new_followers = future_followers - current_followers
 
             # Run follower subscribe/unsubscribe operations in a silent mail context
             silent_patient = patient.with_context(
@@ -922,9 +930,18 @@ class Patient(models.Model):
                 mail_notify_force_send=False,
             )
 
+            # Unsubscribe is driven by the patient's removed set (never per-injury):
+            # injuries may carry followers that are not team staff (e.g. assigned
+            # treatment professionals), and those must not be stripped here.
             if removed_followers:
                 silent_patient.message_unsubscribe(removed_followers.ids)
                 silent_injuries.message_unsubscribe(removed_followers.ids)
-            if future_followers:
-                silent_patient.message_subscribe(future_followers.ids)
-                silent_injuries.message_subscribe(future_followers.ids)
+            if new_followers:
+                silent_patient.message_subscribe(new_followers.ids)
+            # An individual injury may still be missing team-staff followers even when
+            # the patient itself is in sync (e.g. a freshly created injury), so add
+            # only the partners each injury is actually missing.
+            for injury in silent_injuries:
+                injury_new = future_followers - injury.message_partner_ids
+                if injury_new:
+                    injury.message_subscribe(injury_new.ids)

--- a/bemade_sports_clinic/models/patient_injury.py
+++ b/bemade_sports_clinic/models/patient_injury.py
@@ -479,6 +479,17 @@ class PatientInjury(models.Model):
             "context": self.env.context,
         }
 
+    def action_view_patient(self):
+        """Smart-button back-link from the injury form to its player."""
+        self.ensure_one()
+        return {
+            "type": "ir.actions.act_window",
+            "view_mode": "form",
+            "res_model": "sports.patient",
+            "res_id": self.patient_id.id,
+            "context": self.env.context,
+        }
+
     def _track_subtype(self, init_values):
         return self.env.ref("mail.mt_note")
 

--- a/bemade_sports_clinic/models/res_partner.py
+++ b/bemade_sports_clinic/models/res_partner.py
@@ -52,12 +52,19 @@ class Partner(models.Model):
         """When a staff contact (or their user) loses access through
         archiving, scrub the lingering side effects (task 399):
 
-        - recompute followers on every affected team's patients so the
-          archived person stops being a follower of patients/injuries,
         - drop the person from future events' assigned staff and unlink any
           auto-created event-coverage staff records,
-        - clean up stale treatment-professional assignments / mail activities
-          on the affected injuries.
+        - DELETE their team-membership (sports.team.staff) rows — archiving
+          used to only soft-hide them via the related partner ``active``
+          flag, so unarchiving the user silently restored their old team
+          access; a returning staff member must instead be explicitly
+          re-added to whatever team they now serve (dev-review 2026-07-04).
+          Rows are kept only while the partner still has another active
+          user account.
+        - recompute followers on every affected team's patients so the
+          archived person stops being a follower of patients/injuries, and
+          clean up stale treatment-professional assignments / mail
+          activities on the affected injuries.
 
         Keyed off the staff/user state rather than partner state alone, so a
         contact that legitimately stays active while its user is revoked is
@@ -70,11 +77,24 @@ class Partner(models.Model):
         if not staff:
             return
         patients = staff.mapped("team_id.patient_ids")
+        self._sports_clinic_purge_future_events()
+        # The future-event purge may already have unlinked orphaned
+        # auto-created coverage rows via the event sync — drop them from the
+        # set before touching their fields.
+        staff = staff.exists()
+        revoked = self.filtered(
+            lambda p: not p.active
+            or not p.sudo().with_context(active_test=False).user_ids.filtered("active")
+        )
+        doomed = staff.filtered(lambda s: s.partner_id in revoked)
+        if doomed:
+            # The staff unlink hook recomputes followers, cleans injury
+            # TPs/activities and reconciles portal groups.
+            doomed.unlink()
         if patients:
             patients.sudo().recompute_followers()
             patients.injury_ids.sudo()._cleanup_stale_treatment_professionals()
             patients.injury_ids.sudo()._cleanup_stale_mail_activities()
-        self._sports_clinic_purge_future_events()
 
     def _sports_clinic_purge_future_events(self):
         """Remove the archived partners' users from any not-yet-past event's

--- a/bemade_sports_clinic/models/res_partner.py
+++ b/bemade_sports_clinic/models/res_partner.py
@@ -1,4 +1,4 @@
-from odoo import models, fields, api, _
+from odoo import models, fields, api, _, Command
 from odoo.exceptions import UserError
 from odoo.exceptions import ValidationError
 
@@ -43,7 +43,58 @@ class Partner(models.Model):
             raise ValidationError(
                 _("To change a patient's name, change it from the patient form.")
             )
-        return super().write(vals)
+        res = super().write(vals)
+        if "active" in vals and not vals.get("active"):
+            self._sports_clinic_purge_archived_staff()
+        return res
+
+    def _sports_clinic_purge_archived_staff(self):
+        """When a staff contact (or their user) loses access through
+        archiving, scrub the lingering side effects (task 399):
+
+        - recompute followers on every affected team's patients so the
+          archived person stops being a follower of patients/injuries,
+        - drop the person from future events' assigned staff and unlink any
+          auto-created event-coverage staff records,
+        - clean up stale treatment-professional assignments / mail activities
+          on the affected injuries.
+
+        Keyed off the staff/user state rather than partner state alone, so a
+        contact that legitimately stays active while its user is revoked is
+        still purged.
+        """
+        Staff = self.env["sports.team.staff"].sudo().with_context(
+            active_test=False
+        )
+        staff = Staff.search([("partner_id", "in", self.ids)])
+        if not staff:
+            return
+        patients = staff.mapped("team_id.patient_ids")
+        if patients:
+            patients.sudo().recompute_followers()
+            patients.injury_ids.sudo()._cleanup_stale_treatment_professionals()
+            patients.injury_ids.sudo()._cleanup_stale_mail_activities()
+        self._sports_clinic_purge_future_events()
+
+    def _sports_clinic_purge_future_events(self):
+        """Remove the archived partners' users from any not-yet-past event's
+        assigned staff. Writing assigned_staff_ids triggers the event's
+        auto-staff sync, which unlinks orphaned auto-created staff records."""
+        users = self.with_context(active_test=False).user_ids
+        if not users:
+            return
+        now = fields.Datetime.now()
+        events = self.env["sports.event"].sudo().with_context(
+            active_test=False
+        ).search([
+            ("date_end", ">=", now),
+            ("assigned_staff_ids", "in", users.ids),
+        ])
+        events = events.filtered(lambda e: e._is_active_for_access())
+        for event in events:
+            event.write({
+                "assigned_staff_ids": [Command.unlink(u.id) for u in users],
+            })
 
     @api.depends("team_staff_rel_ids.team_id")
     def _compute_teams_served(self):

--- a/bemade_sports_clinic/models/res_users.py
+++ b/bemade_sports_clinic/models/res_users.py
@@ -39,7 +39,12 @@ class User(models.Model):
     def write(self, vals):
         """Override write to trigger treatment professional group assignment when portal access is granted."""
         # Process user updates for portal access changes
-        
+
+        # Archiving a user (portal-access revoke) must scrub the person from
+        # follower lists and future event assignments, even though their
+        # contact may legitimately stay active (task 399).
+        archiving = 'active' in vals and not vals.get('active')
+
         # Check if groups_id is being modified (portal access being granted/revoked)
         if 'group_ids' in vals:
             # Get the portal group reference
@@ -66,14 +71,20 @@ class User(models.Model):
                     ])
                     if staff_records:
                         staff_records._update_treatment_professional_group(user)
-            
+
+            if archiving:
+                self.mapped('partner_id')._sports_clinic_purge_archived_staff()
+
             return result
         else:
             # No group changes, use normal write
             pass
-        
+
         # If groups_id is not being modified, use normal write
-        return super().write(vals)
+        res = super().write(vals)
+        if archiving:
+            self.mapped('partner_id')._sports_clinic_purge_archived_staff()
+        return res
     
     @api.model_create_multi
     def create(self, vals_list):

--- a/bemade_sports_clinic/models/res_users.py
+++ b/bemade_sports_clinic/models/res_users.py
@@ -59,13 +59,13 @@ class User(models.Model):
                 # Check if portal access was granted
                 
                 if portal_group.id in new_groups and portal_group.id not in old_groups:
-                    # Portal access was just granted - trigger treatment professional group assignment
-                    # Portal access was just granted - trigger treatment professional group assignment
+                    # Portal access was just granted - reconcile ALL portal groups
+                    # (treatment professional *and* team coach) for this user.
                     staff_records = self.env['sports.team.staff'].search([
                         ('partner_id', '=', user.partner_id.id)
                     ])
                     if staff_records:
-                        staff_records._update_treatment_professional_group(user)
+                        staff_records._update_all_portal_groups(user)
             
             return result
         else:
@@ -92,12 +92,12 @@ class User(models.Model):
             # Check if user was created with portal access
             
             if portal_group.id in user.group_ids.ids:
-                # User was created with portal access - trigger treatment professional group assignment
-                # User was created with portal access - trigger treatment professional group assignment
+                # User was created with portal access - reconcile ALL portal groups
+                # (treatment professional *and* team coach) for this user.
                 staff_records = self.env['sports.team.staff'].search([
                     ('partner_id', '=', user.partner_id.id)
                 ])
                 if staff_records:
-                    staff_records._update_treatment_professional_group(user)
+                    staff_records._update_all_portal_groups(user)
         
         return users

--- a/bemade_sports_clinic/models/sports_event.py
+++ b/bemade_sports_clinic/models/sports_event.py
@@ -4,6 +4,7 @@ from markupsafe import Markup, escape
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
+from odoo.tools.misc import format_datetime
 
 _logger = logging.getLogger(__name__)
 
@@ -116,6 +117,11 @@ class SportsEvent(models.Model):
     )
     
     # Staff assignments
+    # active_test=False: archived (departed) staff must stay visible on PAST
+    # events for history — without it the ORM silently drops archived users
+    # from every read of this m2m (dev-review 2026-07-04). Future events are
+    # actively purged on archive; business logic that must ignore archived
+    # users filters on user.active explicitly.
     assigned_staff_ids = fields.Many2many(
         'res.users',
         'sports_event_staff_rel',
@@ -123,6 +129,7 @@ class SportsEvent(models.Model):
         'user_id',
         string='Assigned Staff',
         groups=_portal_groups,
+        context={'active_test': False},
         help='Treatment professionals assigned to this event'
     )
 
@@ -634,9 +641,15 @@ class SportsEvent(models.Model):
         # them about the deletion afterwards.
         deletion_notices = []
         for event in self:
-            partners = event.assigned_staff_ids.partner_id.filtered(lambda p: bool(p))
+            partners = event.assigned_staff_ids.filtered('active').partner_id.filtered(lambda p: bool(p))
             if partners:
-                deletion_notices.append((partners, event.display_name))
+                # Same details as the cancellation template: name, date, team(s).
+                deletion_notices.append((
+                    partners,
+                    event.display_name,
+                    event.date_start,
+                    ', '.join(event.team_ids.mapped('name')),
+                ))
 
         # Detach this event from any auto-staff records, deleting orphans.
         Staff = self.env['sports.team.staff'].sudo()
@@ -648,8 +661,9 @@ class SportsEvent(models.Model):
         orphan_auto.unlink()
         res = super().unlink()
 
-        for partners, label in deletion_notices:
-            self._notify_assigned_staff_deleted(partners, label)
+        for partners, label, date_start, team_names in deletion_notices:
+            self._notify_assigned_staff_deleted(
+                partners, label, date_start=date_start, team_names=team_names)
         return res
 
     def _is_active_for_access(self):
@@ -683,7 +697,8 @@ class SportsEvent(models.Model):
             desired = set()
             if event._is_active_for_access():
                 for team in event.team_ids:
-                    for user in event.assigned_staff_ids:
+                    # Never auto-create coverage staff for archived users.
+                    for user in event.assigned_staff_ids.filtered('active'):
                         if user.partner_id:
                             desired.add((team.id, user.partner_id.id))
             for team_id, partner_id in desired:
@@ -822,7 +837,9 @@ class SportsEvent(models.Model):
             event_sudo = event.sudo()
             # Read assignees under sudo: a portal user cancelling their own
             # event cannot necessarily read res.users records directly.
-            partners = event_sudo.assigned_staff_ids.partner_id.filtered(
+            # Archived staff stay on past events for history but must not be
+            # notified anymore.
+            partners = event_sudo.assigned_staff_ids.filtered('active').partner_id.filtered(
                 lambda p: bool(p)
             )
             if not partners:
@@ -848,7 +865,14 @@ class SportsEvent(models.Model):
             if not subject:
                 subject = _("Event cancelled: %s", event_sudo.display_name)
             try:
-                event_sudo.message_post(
+                # mail_notify_author: Odoo normally drops the message author
+                # from the recipients, so a canceller who is themselves an
+                # assignee (e.g. a portal TP cancelling their own event, or
+                # an internal user clicking the statusbar while assigned)
+                # would silently get NO notice — and with a single assignee,
+                # nobody would. Every assigned staff member must be alerted
+                # on every cancel path (dev-review 2026-07-04).
+                event_sudo.with_context(mail_notify_author=True).message_post(
                     body=body,
                     subject=subject,
                     partner_ids=partners.ids,
@@ -863,20 +887,33 @@ class SportsEvent(models.Model):
                     event.id,
                 )
 
-    def _notify_assigned_staff_deleted(self, partners, event_label):
+    def _notify_assigned_staff_deleted(self, partners, event_label,
+                                       date_start=None, team_names=None):
         """Alert assigned staff that an event was deleted. The event record
         is already gone by the time this runs, so we send an out-of-thread
-        notification (``message_notify``) rather than a chatter post."""
+        notification (``message_notify``) rather than a chatter post. Carries
+        the same details as the cancellation notice: name, date, team(s)."""
         partners = partners.filtered(lambda p: bool(p))
         if not partners:
             return
         author = self.env.user.partner_id
-        body = _(
+        details = [Markup("<p>%s</p>") % _(
             "The event \"%s\" you were assigned to has been deleted.",
             event_label,
-        )
+        )]
+        if date_start:
+            details.append(Markup("<p><strong>%s</strong> %s</p>") % (
+                _("Date:"), format_datetime(self.env, date_start)))
+        if team_names:
+            details.append(Markup("<p><strong>%s</strong> %s</p>") % (
+                _("Team(s):"), team_names))
+        body = Markup("").join(details)
         try:
-            self.env['mail.thread'].sudo().message_notify(
+            # mail_notify_author: keep the deleter notified too when they are
+            # an assignee, mirroring the cancellation notice behavior.
+            self.env['mail.thread'].sudo().with_context(
+                mail_notify_author=True,
+            ).message_notify(
                 partner_ids=partners.ids,
                 subject=_("Event deleted: %s", event_label),
                 body=body,
@@ -907,7 +944,9 @@ class SportsEvent(models.Model):
     def _get_missing_timesheet_user_ids(self):
         """Return res.users records for assigned staff who do not have a timesheet yet"""
         self.ensure_one()
-        assigned = self.assigned_staff_ids
+        # Archived staff stay listed on past events for history but should
+        # never be nagged about missing timesheets.
+        assigned = self.assigned_staff_ids.filtered('active')
         if not assigned:
             return self.env['res.users']
         # Soft-deleted timesheets don't count; their owner is "missing" again.

--- a/bemade_sports_clinic/models/sports_event.py
+++ b/bemade_sports_clinic/models/sports_event.py
@@ -1,5 +1,11 @@
-from odoo import api, fields, models
+import logging
+
+from markupsafe import Markup, escape
+
+from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
+
+_logger = logging.getLogger(__name__)
 
 
 class SportsEvent(models.Model):
@@ -548,6 +554,18 @@ class SportsEvent(models.Model):
             and not ('therapist_start' in vals or 'therapist_end' in vals)
             and not self.env.context.get('skip_event_time_sync')
         )
+        # Capture the events that are genuinely transitioning INTO the
+        # cancelled state (were not already cancelled). Every cancel path —
+        # internal statusbar (action_cancel), the cancel wizard and the
+        # portal controller — funnels through write({'state': 'cancelled'}),
+        # so notifying here covers all three exactly once and never double
+        # fires. Re-writing 'cancelled' on an already-cancelled event is
+        # filtered out, so reviving then re-cancelling is the only way to
+        # re-notify (intentional).
+        events_entering_cancel = self.env['sports.event']
+        if vals.get('state') == 'cancelled':
+            events_entering_cancel = self.filtered(lambda e: e.state != 'cancelled')
+
         old_times = {}
         if sync_t_to_d or sync_d_to_t:
             old_times = {
@@ -601,9 +619,23 @@ class SportsEvent(models.Model):
 
         if {'assigned_staff_ids', 'team_ids', 'state', 'date_end', 'therapist_end'}.intersection(vals):
             self.sudo()._sync_event_auto_staff()
+
+        if events_entering_cancel:
+            events_entering_cancel._notify_assigned_staff_cancelled(
+                reason=self.env.context.get('cancel_reason')
+            )
         return res
 
     def unlink(self):
+        # Capture assigned-staff recipients + a human-readable label BEFORE
+        # the records (and their chatter) are gone, so we can still alert
+        # them about the deletion afterwards.
+        deletion_notices = []
+        for event in self:
+            partners = event.assigned_staff_ids.partner_id.filtered(lambda p: bool(p))
+            if partners:
+                deletion_notices.append((partners, event.display_name))
+
         # Detach this event from any auto-staff records, deleting orphans.
         Staff = self.env['sports.team.staff'].sudo()
         affected = Staff.search([('temporary_event_ids', 'in', self.ids)])
@@ -612,7 +644,11 @@ class SportsEvent(models.Model):
             lambda s: s.is_auto_created and not s.temporary_event_ids
         )
         orphan_auto.unlink()
-        return super().unlink()
+        res = super().unlink()
+
+        for partners, label in deletion_notices:
+            self._notify_assigned_staff_deleted(partners, label)
+        return res
 
     def _is_active_for_access(self):
         """An event is "active for access" while either the event itself
@@ -759,6 +795,108 @@ class SportsEvent(models.Model):
                     pass
                 event._update_state_from_timesheets()
         return True
+
+    # ========================================
+    # CANCELLATION / DELETION NOTIFICATIONS
+    # ========================================
+    def _notify_assigned_staff_cancelled(self, reason=None):
+        """Alert every assigned staff member that an event they're on has
+        been cancelled. Posts a chatter message addressed to each assignee
+        partner, which delivers an in-app inbox notification and/or an email
+        per the recipient's notification preference.
+
+        Centralised so all cancel paths (internal statusbar, cancel wizard,
+        portal controller) get the same notice. Runs under ``sudo`` because
+        a portal user cancelling their event must still be able to reach the
+        internal/portal recipients without tripping mail ACLs."""
+        reason = (reason or '').strip()
+        template = self.env.ref(
+            'bemade_sports_clinic.mail_template_event_cancelled',
+            raise_if_not_found=False,
+        )
+        author = self.env.user.partner_id
+        for event in self:
+            event_sudo = event.sudo()
+            # Read assignees under sudo: a portal user cancelling their own
+            # event cannot necessarily read res.users records directly.
+            partners = event_sudo.assigned_staff_ids.partner_id.filtered(
+                lambda p: bool(p)
+            )
+            if not partners:
+                continue
+            subject = body = None
+            if template:
+                try:
+                    ctx_template = template.sudo().with_context(cancel_reason=reason)
+                    body = ctx_template._render_field(
+                        'body_html', event_sudo.ids
+                    ).get(event_sudo.id)
+                    subject = ctx_template._render_field(
+                        'subject', event_sudo.ids
+                    ).get(event_sudo.id)
+                except Exception:  # pragma: no cover - template render guard
+                    _logger.exception(
+                        "Failed to render cancellation template for event %s",
+                        event.id,
+                    )
+                    body = subject = None
+            if not body:
+                body = self._cancel_notice_body(event_sudo.display_name, reason)
+            if not subject:
+                subject = _("Event cancelled: %s", event_sudo.display_name)
+            try:
+                event_sudo.message_post(
+                    body=body,
+                    subject=subject,
+                    partner_ids=partners.ids,
+                    message_type='comment',
+                    subtype_xmlid='mail.mt_comment',
+                    email_layout_xmlid='mail.mail_notification_light',
+                    author_id=author.id if author else None,
+                )
+            except Exception:  # pragma: no cover - never break the cancel txn
+                _logger.exception(
+                    "Failed to notify assigned staff of cancelled event %s",
+                    event.id,
+                )
+
+    def _notify_assigned_staff_deleted(self, partners, event_label):
+        """Alert assigned staff that an event was deleted. The event record
+        is already gone by the time this runs, so we send an out-of-thread
+        notification (``message_notify``) rather than a chatter post."""
+        partners = partners.filtered(lambda p: bool(p))
+        if not partners:
+            return
+        author = self.env.user.partner_id
+        body = _(
+            "The event \"%s\" you were assigned to has been deleted.",
+            event_label,
+        )
+        try:
+            self.env['mail.thread'].sudo().message_notify(
+                partner_ids=partners.ids,
+                subject=_("Event deleted: %s", event_label),
+                body=body,
+                author_id=author.id if author else None,
+            )
+        except Exception:  # pragma: no cover - never break the delete txn
+            _logger.exception(
+                "Failed to notify assigned staff of deleted event '%s'",
+                event_label,
+            )
+
+    @api.model
+    def _cancel_notice_body(self, event_label, reason=None):
+        """Plain HTML fallback body used when the mail template is missing
+        or fails to render."""
+        reason = (reason or '').strip()
+        body = escape(
+            _("The event \"%s\" you were assigned to has been cancelled.",
+              event_label)
+        )
+        if reason:
+            body += escape(_(" Reason: %s", reason))
+        return Markup("<p>%s</p>") % body
 
     # ========================================
     # HELPERS

--- a/bemade_sports_clinic/models/sports_event.py
+++ b/bemade_sports_clinic/models/sports_event.py
@@ -257,7 +257,9 @@ class SportsEvent(models.Model):
 
     def _compute_has_uninvoiced_timesheets(self):
         for event in self:
-            ts = event.timesheet_ids
+            # One2many reads include archived rows; soft-deleted timesheets must
+            # not count toward billing readiness.
+            ts = event.timesheet_ids.filtered('active')
             event.has_uninvoiced_timesheets = any(t.customer_ready_to_invoice for t in ts)
     
     @api.depends('date_start')
@@ -321,7 +323,7 @@ class SportsEvent(models.Model):
 
     def _compute_timesheet_count(self):
         for event in self:
-            event.timesheet_count = len(event.timesheet_ids)
+            event.timesheet_count = len(event.timesheet_ids.filtered('active'))
 
     def _compute_activity_count(self):
         for event in self:
@@ -526,7 +528,7 @@ class SportsEvent(models.Model):
             # Guardrails per record
             for event in self:
                 # Prevent marking invoiced if customer side still needs invoicing
-                if new_state == 'invoiced' and any(t.customer_ready_to_invoice for t in event.timesheet_ids):
+                if new_state == 'invoiced' and any(t.customer_ready_to_invoice for t in event.timesheet_ids.filtered('active')):
                     raise ValidationError("Cannot mark Invoiced while timesheets remain to invoice.")
                 # Portal may only cancel
                 if not self.env.user.has_group('base.group_user') and new_state != 'cancelled':
@@ -707,7 +709,8 @@ class SportsEvent(models.Model):
         for event in self:
             if event.state == 'cancelled':
                 continue
-            ts = event.timesheet_ids
+            # Exclude soft-deleted timesheets (One2many reads include archived).
+            ts = event.timesheet_ids.filtered('active')
             if ts and all(t.state == 'invoiced' for t in ts):
                 if event.state != 'invoiced':
                     try:
@@ -769,7 +772,8 @@ class SportsEvent(models.Model):
         assigned = self.assigned_staff_ids
         if not assigned:
             return self.env['res.users']
-        have_ts_users = self.timesheet_ids.mapped('user_id')
+        # Soft-deleted timesheets don't count; their owner is "missing" again.
+        have_ts_users = self.timesheet_ids.filtered('active').mapped('user_id')
         missing = assigned - have_ts_users
         return missing
 

--- a/bemade_sports_clinic/models/sports_event.py
+++ b/bemade_sports_clinic/models/sports_event.py
@@ -817,11 +817,28 @@ class SportsEvent(models.Model):
     # ========================================
     # CANCELLATION / DELETION NOTIFICATIONS
     # ========================================
+    @staticmethod
+    def _group_partners_by_lang(partners, default_lang):
+        """Split a res.partner recordset by preferred language."""
+        by_lang = {}
+        for partner in partners:
+            lang = partner.lang or default_lang
+            by_lang[lang] = by_lang.get(lang, partner.browse()) | partner
+        return by_lang
+
     def _notify_assigned_staff_cancelled(self, reason=None):
         """Alert every assigned staff member that an event they're on has
-        been cancelled. Posts a chatter message addressed to each assignee
-        partner, which delivers an in-app inbox notification and/or an email
-        per the recipient's notification preference.
+        been cancelled.
+
+        User-centric delivery (dev-review 2026-07-04 round 2):
+        - ``message_notify`` targets EXACTLY the assignee partners — no
+          spillover to event followers (e.g. the commercial partner) the way
+          an ``mt_comment`` post notifies.
+        - The canceller is notified only when they are themselves an
+          assignee (``mail_notify_author`` keeps them when in partner_ids;
+          Odoo drops the author otherwise).
+        - Recipients are grouped by language and each group gets the notice
+          rendered in its own language.
 
         Centralised so all cancel paths (internal statusbar, cancel wizard,
         portal controller) get the same notice. Runs under ``sudo`` because
@@ -833,6 +850,7 @@ class SportsEvent(models.Model):
             raise_if_not_found=False,
         )
         author = self.env.user.partner_id
+        default_lang = self.env.lang or 'en_US'
         for event in self:
             event_sudo = event.sudo()
             # Read assignees under sudo: a portal user cancelling their own
@@ -844,86 +862,85 @@ class SportsEvent(models.Model):
             )
             if not partners:
                 continue
-            subject = body = None
-            if template:
+            for lang, lang_partners in self._group_partners_by_lang(partners, default_lang).items():
+                subject = body = None
+                if template:
+                    try:
+                        ctx_template = template.sudo().with_context(
+                            lang=lang, cancel_reason=reason)
+                        body = ctx_template._render_field(
+                            'body_html', event_sudo.ids
+                        ).get(event_sudo.id)
+                        subject = ctx_template._render_field(
+                            'subject', event_sudo.ids
+                        ).get(event_sudo.id)
+                    except Exception:  # pragma: no cover - template render guard
+                        _logger.exception(
+                            "Failed to render cancellation template for event %s",
+                            event.id,
+                        )
+                        body = subject = None
+                localized = self.with_context(lang=lang)
+                if not body:
+                    body = localized._cancel_notice_body(event_sudo.display_name, reason)
+                if not subject:
+                    subject = localized.env._("Event cancelled: %s", event_sudo.display_name)
                 try:
-                    ctx_template = template.sudo().with_context(cancel_reason=reason)
-                    body = ctx_template._render_field(
-                        'body_html', event_sudo.ids
-                    ).get(event_sudo.id)
-                    subject = ctx_template._render_field(
-                        'subject', event_sudo.ids
-                    ).get(event_sudo.id)
-                except Exception:  # pragma: no cover - template render guard
+                    event_sudo.with_context(mail_notify_author=True, lang=lang).message_notify(
+                        body=body,
+                        subject=subject,
+                        partner_ids=lang_partners.ids,
+                        email_layout_xmlid='mail.mail_notification_light',
+                        author_id=author.id if author else None,
+                    )
+                except Exception:  # pragma: no cover - never break the cancel txn
                     _logger.exception(
-                        "Failed to render cancellation template for event %s",
+                        "Failed to notify assigned staff of cancelled event %s",
                         event.id,
                     )
-                    body = subject = None
-            if not body:
-                body = self._cancel_notice_body(event_sudo.display_name, reason)
-            if not subject:
-                subject = _("Event cancelled: %s", event_sudo.display_name)
-            try:
-                # mail_notify_author: Odoo normally drops the message author
-                # from the recipients, so a canceller who is themselves an
-                # assignee (e.g. a portal TP cancelling their own event, or
-                # an internal user clicking the statusbar while assigned)
-                # would silently get NO notice — and with a single assignee,
-                # nobody would. Every assigned staff member must be alerted
-                # on every cancel path (dev-review 2026-07-04).
-                event_sudo.with_context(mail_notify_author=True).message_post(
-                    body=body,
-                    subject=subject,
-                    partner_ids=partners.ids,
-                    message_type='comment',
-                    subtype_xmlid='mail.mt_comment',
-                    email_layout_xmlid='mail.mail_notification_light',
-                    author_id=author.id if author else None,
-                )
-            except Exception:  # pragma: no cover - never break the cancel txn
-                _logger.exception(
-                    "Failed to notify assigned staff of cancelled event %s",
-                    event.id,
-                )
 
     def _notify_assigned_staff_deleted(self, partners, event_label,
                                        date_start=None, team_names=None):
         """Alert assigned staff that an event was deleted. The event record
         is already gone by the time this runs, so we send an out-of-thread
         notification (``message_notify``) rather than a chatter post. Carries
-        the same details as the cancellation notice: name, date, team(s)."""
+        the same details as the cancellation notice (name, date, team(s)),
+        targets ONLY the assignee partners (deleter included solely when they
+        are an assignee), and is rendered per recipient language."""
         partners = partners.filtered(lambda p: bool(p))
         if not partners:
             return
         author = self.env.user.partner_id
-        details = [Markup("<p>%s</p>") % _(
-            "The event \"%s\" you were assigned to has been deleted.",
-            event_label,
-        )]
-        if date_start:
-            details.append(Markup("<p><strong>%s</strong> %s</p>") % (
-                _("Date:"), format_datetime(self.env, date_start)))
-        if team_names:
-            details.append(Markup("<p><strong>%s</strong> %s</p>") % (
-                _("Team(s):"), team_names))
-        body = Markup("").join(details)
-        try:
-            # mail_notify_author: keep the deleter notified too when they are
-            # an assignee, mirroring the cancellation notice behavior.
-            self.env['mail.thread'].sudo().with_context(
-                mail_notify_author=True,
-            ).message_notify(
-                partner_ids=partners.ids,
-                subject=_("Event deleted: %s", event_label),
-                body=body,
-                author_id=author.id if author else None,
-            )
-        except Exception:  # pragma: no cover - never break the delete txn
-            _logger.exception(
-                "Failed to notify assigned staff of deleted event '%s'",
+        default_lang = self.env.lang or 'en_US'
+        for lang, lang_partners in self._group_partners_by_lang(partners, default_lang).items():
+            lenv = self.with_context(lang=lang).env
+            details = [Markup("<p>%s</p>") % lenv._(
+                "The event \"%s\" you were assigned to has been deleted.",
                 event_label,
-            )
+            )]
+            if date_start:
+                details.append(Markup("<p><strong>%s</strong> %s</p>") % (
+                    lenv._("Date:"), format_datetime(lenv, date_start)))
+            if team_names:
+                details.append(Markup("<p><strong>%s</strong> %s</p>") % (
+                    lenv._("Team(s):"), team_names))
+            body = Markup("").join(details)
+            try:
+                # mail_notify_author: keep the deleter notified too when they
+                # are an assignee, mirroring the cancellation notice behavior.
+                self.env['mail.thread'].sudo().with_context(
+                    mail_notify_author=True, lang=lang,
+                ).message_notify(
+                    partner_ids=lang_partners.ids,
+                    subject=lenv._("Event deleted: %s", event_label),
+                    body=body,
+                    author_id=author.id if author else None,
+                )
+            except Exception:  # pragma: no cover - never break the delete txn
+                _logger.exception(
+                    "Failed to notify assigned staff of deleted event '%s'",
+                    event_label,
+                )
 
     @api.model
     def _cancel_notice_body(self, event_label, reason=None):

--- a/bemade_sports_clinic/models/sports_event_timesheet.py
+++ b/bemade_sports_clinic/models/sports_event_timesheet.py
@@ -28,6 +28,12 @@ class SportsEventTimesheet(models.Model):
         'res.partner', string='Therapist Partner',
         related='user_id.partner_id', readonly=True)
 
+    # Soft-delete: therapists may archive their own, non-invoiced timesheets
+    # from the portal (they have no unlink right). Archived rows are excluded
+    # from portal lists/counters (default search) and must be filtered out of
+    # every event-side One2many aggregation (One2many reads include archived).
+    active = fields.Boolean(default=True)
+
     # State
     state = fields.Selection(
         [
@@ -257,6 +263,22 @@ class SportsEventTimesheet(models.Model):
         if any(rec.state == 'invoiced' for rec in self):
             raise ValidationError('Invoiced timesheets cannot be deleted.')
         return super().unlink()
+
+    def action_soft_delete(self):
+        """Archive (soft-delete) the caller's own, non-invoiced timesheets.
+
+        Therapists have no unlink right on this model; this lets them remove an
+        erroneous timesheet from the portal without a hard delete. Guards mirror
+        the portal/edit constraints: invoiced rows are read-only, and a user may
+        only remove their own timesheets.
+        """
+        for rec in self:
+            if rec.state == 'invoiced':
+                raise ValidationError('Invoiced timesheets cannot be deleted.')
+            if rec.user_id.id != self.env.user.id:
+                raise ValidationError('You can only delete your own timesheets.')
+        self.write({'active': False})
+        return True
 
     def action_reset_if_unlinked(self):
         # Reset if EITHER side is fully unlinked:

--- a/bemade_sports_clinic/models/sports_team.py
+++ b/bemade_sports_clinic/models/sports_team.py
@@ -213,6 +213,30 @@ class TeamStaff(models.Model):
         "Each partner can only be related to a given team once.",
     )
 
+    def _is_follower_eligible(self):
+        """Whether this staff member should be auto-subscribed as a follower
+        of the team's patients/injuries.
+
+        Eligible only while they still hold clinic access:
+          - not flagged silent,
+          - their contact is active, and
+          - if the contact has any user account at all, at least one of those
+            users is active. A user whose portal access was revoked (archived)
+            must stop receiving notifications even though the contact may
+            legitimately stay active; a pure contact that never had a user
+            remains a valid follower.
+        """
+        self.ensure_one()
+        if self.silent_notifications:
+            return False
+        partner = self.partner_id
+        if not partner.active:
+            return False
+        all_users = partner.with_context(active_test=False).user_ids
+        if all_users and not all_users.filtered("active"):
+            return False
+        return True
+
     @api.constrains("role")
     def _constrain_role(self):
         teams = self.mapped("team_id")

--- a/bemade_sports_clinic/models/sports_team.py
+++ b/bemade_sports_clinic/models/sports_team.py
@@ -333,7 +333,11 @@ class TeamStaff(models.Model):
     def _action_revoke_portal_access(self):
         """Private method containing the actual sudo operations for revoking portal access."""
         group_public = self.env.ref("base.group_public")
-        
+
+        # Archiving the user triggers the staff purge, which DELETES this
+        # staff row (dev-review 2026-07-04) — capture the partner first and
+        # never touch self afterwards.
+        partner = self.partner_id
         # Deactivate the user and set to public user type (standard Odoo approach)
         if self.user_ids:
             self.user_ids.sudo().write(
@@ -342,12 +346,16 @@ class TeamStaff(models.Model):
                     "active": False,
                 }
             )
-        
-        # If there's an active signup invitation, cancel it
-        # This uses the portal.wizard from Odoo core to handle all the details
-        if self.partner_id and self.has_portal_access:
-            self.env['res.partner'].sudo().invalidate_model(['signup_valid'])
-            users = self.env['res.users'].sudo().search([('partner_id', '=', self.partner_id.id)])
+
+        # If there's an active signup invitation, cancel it. Archiving any
+        # remaining users is idempotent, so no has_portal_access guard needed
+        # (self may already be deleted here).
+        if partner:
+            Partner = self.env['res.partner'].sudo()
+            # signup_valid comes from auth_signup, which may not be installed.
+            if 'signup_valid' in Partner._fields:
+                Partner.invalidate_model(['signup_valid'])
+            users = self.env['res.users'].sudo().search([('partner_id', '=', partner.id)])
             users.write({'active': False})
 
     def action_grant_portal_access(self):

--- a/bemade_sports_clinic/models/treatment_note.py
+++ b/bemade_sports_clinic/models/treatment_note.py
@@ -17,12 +17,29 @@ class TreatmentNote(models.Model):
         ('general', 'General Note'),
         ('injury', 'Injury-specific')
     ], string='Note Type', compute='_compute_note_type', store=True)
-    
+    author_initials = fields.Char(
+        string='Author Initials',
+        compute='_compute_author_initials',
+        help="Initials of the note author, for compact list/portal display.",
+    )
+
     @api.depends('injury_id')
     def _compute_note_type(self):
         """Determine whether this is a general note or injury-specific"""
         for record in self:
             record.note_type = 'injury' if record.injury_id else 'general'
+
+    @api.depends('user_id', 'user_id.name')
+    def _compute_author_initials(self):
+        """Derive the author's initials (first + last token, uppercased)."""
+        for record in self:
+            tokens = (record.user_id.name or '').split()
+            if not tokens:
+                record.author_initials = ''
+            elif len(tokens) == 1:
+                record.author_initials = tokens[0][0].upper()
+            else:
+                record.author_initials = (tokens[0][0] + tokens[-1][0]).upper()
     
     @api.constrains('note')
     def _check_note_content(self):

--- a/bemade_sports_clinic/static/src/scss/portal_badges.scss
+++ b/bemade_sports_clinic/static/src/scss/portal_badges.scss
@@ -88,3 +88,27 @@
   color: var(--bs-dark, #212529) !important;
   border: 1px solid var(--bs-dark, #212529) !important;
 }
+
+/* Treatment-note author initials: pure-CSS tooltip with the full name.
+   No JS/Bootstrap dependency — the Bootstrap tooltip init proved unreliable
+   on portal pages (dev-review 2026-07-04 round 2). */
+.o_sc_note_author {
+  position: relative;
+  cursor: help;
+}
+.o_sc_note_author:hover::after {
+  content: attr(data-author);
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 4px);
+  transform: translateX(-50%);
+  background: rgba(33, 37, 41, 0.95);
+  color: #fff;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  font-weight: 400;
+  white-space: nowrap;
+  z-index: 1080;
+  pointer-events: none;
+}

--- a/bemade_sports_clinic/static/src/scss/portal_badges.scss
+++ b/bemade_sports_clinic/static/src/scss/portal_badges.scss
@@ -96,19 +96,38 @@
   position: relative;
   cursor: help;
 }
+/* Bubble to the RIGHT of the badge: stays inside the table box (no
+   clipping by the overflow container, unlike an above-the-row bubble)
+   and overlays neighboring cells without reflowing the columns. */
 .o_sc_note_author:hover::after {
   content: attr(data-author);
   position: absolute;
-  left: 50%;
-  bottom: calc(100% + 4px);
-  transform: translateX(-50%);
+  left: calc(100% + 6px);
+  top: 50%;
+  transform: translateY(-50%);
   background: rgba(33, 37, 41, 0.95);
   color: #fff;
-  padding: 4px 8px;
+  padding: 2px 8px;
   border-radius: 4px;
   font-size: 0.85rem;
   font-weight: 400;
   white-space: nowrap;
-  z-index: 1080;
+  z-index: 10;
   pointer-events: none;
+}
+
+/* Notes tables: fixed layout so the Note column takes the remaining
+   width and long lines WRAP instead of growing the table into the
+   horizontal scroll region. Also undo o_portal_my_doc_table's
+   `td { white-space: nowrap; overflow: hidden }` — it both prevented
+   note text from wrapping AND clipped the author-name hover bubble at
+   the cell edge. */
+.o_sc_notes_table table {
+  table-layout: fixed;
+  width: 100%;
+}
+.o_sc_notes_table td {
+  white-space: normal !important;
+  overflow: visible !important;
+  text-overflow: clip !important;
 }

--- a/bemade_sports_clinic/tests/__init__.py
+++ b/bemade_sports_clinic/tests/__init__.py
@@ -12,6 +12,7 @@ from . import test_event_invoicing_wizard
 from . import test_team_org_backlink
 from . import test_therapist_access_revoke
 from . import test_silent_therapist
+from . import test_archive_staff_purge
 from . import test_event_auto_access
 from . import test_hide_injury_from_coach
 from . import test_events_calendar_portal

--- a/bemade_sports_clinic/tests/__init__.py
+++ b/bemade_sports_clinic/tests/__init__.py
@@ -51,3 +51,4 @@ from . import test_cov_events_portal_post
 from . import test_cov_task_management_portal_post
 from . import test_cov_sports_event
 from . import test_cov_portal_cross_team
+from . import test_cov_portal_player_search_add_to_team

--- a/bemade_sports_clinic/tests/__init__.py
+++ b/bemade_sports_clinic/tests/__init__.py
@@ -9,6 +9,7 @@ from . import test_mail_activity_portal_integration
 from . import test_portal_activity_default_todo
 from . import test_portal_injury_autoassign_integration
 from . import test_event_invoicing_wizard
+from . import test_event_cancel_notifications
 from . import test_team_org_backlink
 from . import test_therapist_access_revoke
 from . import test_silent_therapist

--- a/bemade_sports_clinic/tests/__init__.py
+++ b/bemade_sports_clinic/tests/__init__.py
@@ -55,3 +55,4 @@ from . import test_cov_sports_event
 from . import test_cov_portal_cross_team
 from . import test_cov_portal_player_search_add_to_team
 from . import test_player_activities_tab
+from . import test_event_detail_timesheet_confidentiality

--- a/bemade_sports_clinic/tests/__init__.py
+++ b/bemade_sports_clinic/tests/__init__.py
@@ -51,3 +51,4 @@ from . import test_cov_events_portal_post
 from . import test_cov_task_management_portal_post
 from . import test_cov_sports_event
 from . import test_cov_portal_cross_team
+from . import test_player_activities_tab

--- a/bemade_sports_clinic/tests/test_archive_staff_purge.py
+++ b/bemade_sports_clinic/tests/test_archive_staff_purge.py
@@ -131,6 +131,52 @@ class TestArchiveStaffPurge(TransactionCase):
             event.with_context(active_test=False).assigned_staff_ids,
         )
 
+    def test_archive_user_deletes_staff_rows_no_restore_on_unarchive(self):
+        """Archiving the user DELETES the team-membership rows (not merely
+        soft-hides them via partner.active), so unarchiving the user later
+        does NOT silently restore old team access — the returning staff
+        member must be explicitly re-added (dev-review 2026-07-04)."""
+        partner = self.tp_user.partner_id
+        self._staff(partner)
+        Staff = self.env["sports.team.staff"].with_context(active_test=False)
+
+        self.tp_user.action_archive()
+
+        self.assertFalse(
+            Staff.search([("partner_id", "=", partner.id)]),
+            "staff membership rows must be deleted on archive",
+        )
+
+        self.tp_user.action_unarchive()
+
+        self.assertFalse(
+            Staff.search([("partner_id", "=", partner.id)]),
+            "unarchiving must not resurrect team membership",
+        )
+        self.assertNotIn(partner, self.player.message_partner_ids)
+
+    def test_archived_staff_stay_visible_on_past_events(self):
+        """Past events keep archived staff in assigned_staff_ids for history
+        (the m2m no longer active_test-filters them away on read)."""
+        partner = self.tp_user.partner_id
+        self._staff(partner)
+        now = fields.Datetime.now()
+        past_event = self.env["sports.event"].create({
+            "name": "Past Game",
+            "date_start": now - timedelta(days=7),
+            "date_end": now - timedelta(days=7) + timedelta(hours=2),
+            "team_ids": [(6, 0, [self.team.id])],
+            "assigned_staff_ids": [(6, 0, self.tp_user.ids)],
+        })
+
+        self.tp_user.action_archive()
+
+        past_event.invalidate_recordset(["assigned_staff_ids"])
+        self.assertIn(
+            self.tp_user, past_event.assigned_staff_ids,
+            "archived staff must remain visible on past events (default read)",
+        )
+
     def test_archive_unlinks_auto_created_staff(self):
         """Auto-staff created by an event assignment must be removed when the
         assignee is archived."""

--- a/bemade_sports_clinic/tests/test_archive_staff_purge.py
+++ b/bemade_sports_clinic/tests/test_archive_staff_purge.py
@@ -1,0 +1,155 @@
+"""Tests for purging access/followers when a therapist/coach is archived (task 399).
+
+Acceptance criteria:
+- Archiving a therapist/coach (user archived on portal revoke, or a pure-contact
+  staff partner archived) removes them as a follower of the team's patients and
+  their injuries.
+- Archived staff are dropped from future sports.event.assigned_staff_ids and
+  from any auto-created event-coverage staff records.
+- No further notifications are emitted to the archived person: a follower
+  recompute must NOT re-subscribe an archived staff member.
+- Legitimate pure-contact followers (staff partner that never had a user) are
+  unaffected — they must keep following.
+
+Note: Odoo core forbids archiving a contact that still has an active linked
+user, so the realistic "archive a therapist" flow is to archive the *user*
+(portal-access revoke). The contact may legitimately stay active.
+"""
+
+from datetime import timedelta
+
+from odoo import fields
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("-at_install", "post_install")
+class TestArchiveStaffPurge(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.team = cls.env["sports.team"].create({"name": "Archive Team"})
+        cls.player = cls.env["sports.patient"].create({
+            "first_name": "Arch", "last_name": "Player",
+            "team_ids": [(6, 0, [cls.team.id])],
+        })
+        cls.injury = cls.env["sports.patient.injury"].create({
+            "patient_id": cls.player.id,
+            "diagnosis": "Sprained ankle",
+        })
+        cls.tp_user = cls.env["res.users"].create({
+            "name": "Archive TP", "login": "archive.tp@example.com",
+            "group_ids": [(6, 0, [cls.env.ref("base.group_user").id])],
+        })
+
+    def _staff(self, partner, **vals):
+        return self.env["sports.team.staff"].create({
+            "team_id": self.team.id,
+            "partner_id": partner.id,
+            "role": "therapist",
+            **vals,
+        })
+
+    def _future_event(self, users):
+        now = fields.Datetime.now()
+        return self.env["sports.event"].create({
+            "name": "Future Game",
+            "date_start": now + timedelta(days=2),
+            "date_end": now + timedelta(days=2, hours=2),
+            "team_ids": [(6, 0, [self.team.id])],
+            "assigned_staff_ids": [(6, 0, users.ids)],
+        })
+
+    # ---- followers --------------------------------------------------------
+
+    def test_archive_user_removes_follower(self):
+        """Revoking portal access archives the *user* but the partner contact
+        may legitimately stay active. The person must still drop off."""
+        partner = self.tp_user.partner_id
+        self._staff(partner)
+        self.assertIn(partner, self.player.message_partner_ids)
+        self.assertIn(partner, self.injury.message_partner_ids)
+
+        self.tp_user.action_archive()
+
+        self.assertTrue(partner.active, "partner contact should stay active")
+        self.assertNotIn(partner, self.player.message_partner_ids)
+        self.assertNotIn(partner, self.injury.message_partner_ids)
+
+    def test_archive_contact_removes_follower(self):
+        """A pure-contact staff member (no user) archived directly drops off."""
+        contact = self.env["res.partner"].create({"name": "Plain Coach"})
+        self._staff(contact, role="coach")
+        self.assertIn(contact, self.player.message_partner_ids)
+        self.assertIn(contact, self.injury.message_partner_ids)
+
+        contact.action_archive()
+
+        self.assertNotIn(contact, self.player.message_partner_ids)
+        self.assertNotIn(contact, self.injury.message_partner_ids)
+
+    def test_recompute_does_not_resubscribe_archived_user(self):
+        partner = self.tp_user.partner_id
+        self._staff(partner)
+        self.tp_user.action_archive()
+        self.assertNotIn(partner, self.player.message_partner_ids)
+
+        # A later, unrelated recompute must NOT bring the archived person back.
+        self.player.recompute_followers()
+        self.assertNotIn(partner, self.player.message_partner_ids)
+
+    def test_recompute_does_not_resubscribe_archived_contact(self):
+        contact = self.env["res.partner"].create({"name": "Plain Coach"})
+        self._staff(contact, role="coach")
+        contact.action_archive()
+        self.player.recompute_followers()
+        self.assertNotIn(contact, self.player.message_partner_ids)
+
+    def test_pure_contact_follower_survives(self):
+        """A staff partner that never had a user account is a legitimate
+        follower and must not be dropped by the archive guard."""
+        contact = self.env["res.partner"].create({"name": "Active Coach"})
+        self._staff(contact, role="coach")
+        self.assertIn(contact, self.player.message_partner_ids)
+
+        self.player.recompute_followers()
+        self.assertIn(contact, self.player.message_partner_ids)
+
+    # ---- events -----------------------------------------------------------
+
+    def test_archive_user_drops_future_event_assignment(self):
+        partner = self.tp_user.partner_id
+        self._staff(partner)
+        event = self._future_event(self.tp_user)
+        self.assertIn(self.tp_user, event.assigned_staff_ids)
+
+        self.tp_user.action_archive()
+
+        event.invalidate_recordset(["assigned_staff_ids"])
+        self.assertNotIn(
+            self.tp_user,
+            event.with_context(active_test=False).assigned_staff_ids,
+        )
+
+    def test_archive_unlinks_auto_created_staff(self):
+        """Auto-staff created by an event assignment must be removed when the
+        assignee is archived."""
+        partner = self.tp_user.partner_id
+        # No manual staff row: the event assignment auto-creates one.
+        self._future_event(self.tp_user)
+        Staff = self.env["sports.team.staff"].with_context(active_test=False)
+        auto = Staff.search([
+            ("team_id", "=", self.team.id),
+            ("partner_id", "=", partner.id),
+            ("is_auto_created", "=", True),
+        ])
+        self.assertTrue(auto, "auto-staff should have been created by the event")
+
+        self.tp_user.action_archive()
+
+        auto = Staff.search([
+            ("team_id", "=", self.team.id),
+            ("partner_id", "=", partner.id),
+            ("is_auto_created", "=", True),
+        ])
+        self.assertFalse(auto, "auto-staff should be unlinked on archive")

--- a/bemade_sports_clinic/tests/test_cov_events_portal.py
+++ b/bemade_sports_clinic/tests/test_cov_events_portal.py
@@ -1,3 +1,6 @@
+from datetime import datetime
+
+from odoo import Command
 from odoo.tests import tagged
 
 from .portal_cov_common import PortalCovCommon
@@ -10,6 +13,28 @@ class TestCovEventsPortal(PortalCovCommon):
     def test_view_events_list(self):
         self._login_tp()
         self.assertEqual(self.url_open('/my/events').status_code, 200)
+
+    def test_cancelled_event_hidden_then_shown(self):
+        """Portal events list hides cancelled events by default (task 1235)
+        and surfaces them again with show_cancelled=1."""
+        self._login_tp()
+        self.env['sports.event'].create({
+            'name': 'PC Cancelled Zebra',
+            'event_type': 'game',
+            'team_ids': [Command.set([self.team_a.id])],
+            'date_start': datetime(2026, 2, 3, 10, 0),
+            'date_end': datetime(2026, 2, 3, 12, 0),
+            'state': 'cancelled',
+            'assigned_staff_ids': [Command.set([self.tp.id])],
+        })
+        # no_default_dates avoids the today-onward default date filter that
+        # would otherwise hide these Feb-2026 fixtures regardless of state.
+        resp = self.url_open('/my/events?no_default_dates=1')
+        self.assertIn(b'PC Event', resp.content)              # confirmed shows
+        self.assertNotIn(b'PC Cancelled Zebra', resp.content)  # cancelled hidden
+
+        resp = self.url_open('/my/events?no_default_dates=1&show_cancelled=1')
+        self.assertIn(b'PC Cancelled Zebra', resp.content)     # toggle reveals it
 
     def test_view_events_filtered(self):
         self._login_tp()

--- a/bemade_sports_clinic/tests/test_cov_events_portal_post.py
+++ b/bemade_sports_clinic/tests/test_cov_events_portal_post.py
@@ -1,3 +1,5 @@
+import re
+
 from odoo import Command
 from odoo.tests import tagged
 
@@ -7,6 +9,71 @@ from .portal_cov_common import PortalCovCommon
 @tagged('-at_install', 'post_install')
 class TestCovEventsPortalPost(PortalCovCommon):
     """POST-route sampling for the events portal (add timesheet / cancel / create)."""
+
+    # ---- events list: My->All filter clearing + dropdown scope (task 1226) ----
+
+    def test_all_events_link_drops_assigned_user_filter(self):
+        """Switching from My Events back to All Events must clear assigned_user_id
+        from the URL so the full accessible list shows (not the user-filtered one).
+        Regression: the All Events nav link conditionally carried assigned_user_id."""
+        self._login_tp()
+        resp = self.url_open(f'/my/events?view_type=my&assigned_user_id={self.tp.id}')
+        self.assertEqual(resp.status_code, 200)
+        m = re.search(r'href="([^"]*view_type=all[^"]*)"[^>]*>\s*All Events', resp.text)
+        self.assertTrue(m, "the All Events nav link should be present")
+        self.assertNotIn('assigned_user_id', m.group(1),
+                         "the All Events link must not carry the assigned_user_id filter")
+
+    def test_my_events_link_keeps_assigned_user_filter(self):
+        """Sanity: the My Events nav link must still set assigned_user_id to the
+        current user (so the fix only touches the All link, not My)."""
+        self._login_tp()
+        resp = self.url_open('/my/events?view_type=all')
+        self.assertEqual(resp.status_code, 200)
+        m = re.search(r'href="([^"]*view_type=my[^"]*)"[^>]*>\s*My Events', resp.text)
+        self.assertTrue(m, "the My Events nav link should be present")
+        self.assertIn(f'assigned_user_id={self.tp.id}', m.group(1),
+                      "the My Events link must filter to the current user")
+
+    def test_team_dropdown_lists_all_teams_for_coach(self):
+        """The team filter dropdown lists every team regardless of the coach's
+        assignment (the coach staffs team_a only; team_b must still appear)."""
+        self._login_coach()
+        resp = self.url_open('/my/events')
+        self.assertEqual(resp.status_code, 200)
+        self.assertRegex(
+            resp.text,
+            r'<option[^>]*>\s*%s\s*</option>' % re.escape(self.team_b.name),
+            "a team the coach does not staff should still appear in the filter dropdown")
+
+    def test_org_dropdown_lists_all_orgs_for_coach(self):
+        """The organization filter dropdown lists every organization regardless
+        of the coach's assignment."""
+        # A second, unrelated org/team the coach has no relationship with.
+        other_org = self.env['res.partner'].create({'name': 'PC Other Org', 'is_company': True})
+        self.env['sports.team'].create({'name': 'PC Other Team', 'parent_id': other_org.id})
+        self._login_coach()
+        resp = self.url_open('/my/events')
+        self.assertEqual(resp.status_code, 200)
+        self.assertRegex(
+            resp.text,
+            r'<option[^>]*>\s*%s\s*</option>' % re.escape(other_org.name),
+            "an organization the coach has no relationship with should still appear")
+
+    def test_coach_cannot_open_nonstaffed_team_event(self):
+        """No new exposure: widening the dropdowns must not let a coach open an
+        event detail for a team they don't staff."""
+        ev_b = self.env['sports.event'].create({
+            'name': 'Team B Only Event', 'event_type': 'game',
+            'team_ids': [Command.set([self.team_b.id])],
+            'date_start': '2026-03-10 10:00:00', 'date_end': '2026-03-10 12:00:00',
+            'state': 'confirmed',
+        })
+        self.env.flush_all()
+        self._login_coach()
+        resp = self.url_open(f'/my/event?event_id={ev_b.id}')
+        self.assertEqual(resp.status_code, 403,
+                         "a coach must not open an event for a team they don't staff")
 
     # ---- add_timesheet ----
 

--- a/bemade_sports_clinic/tests/test_cov_patient_injury.py
+++ b/bemade_sports_clinic/tests/test_cov_patient_injury.py
@@ -103,6 +103,14 @@ class TestCovPatientInjury(TransactionCase):
         self.assertEqual(action['res_model'], 'sports.patient.injury')
         self.assertEqual(action['res_id'], injury.id)
 
+    def test_action_view_patient(self):
+        injury = self._injury()
+        action = injury.action_view_patient()
+        self.assertEqual(action['res_model'], 'sports.patient')
+        self.assertEqual(action['view_mode'], 'form')
+        self.assertEqual(action['res_id'], self.patient.id,
+                         "the back-link action should target the injury's own patient")
+
     def test_track_subtype_is_note(self):
         injury = self._injury()
         self.assertEqual(injury._track_subtype({}), self.env.ref('mail.mt_note'))

--- a/bemade_sports_clinic/tests/test_cov_portal_cross_team.py
+++ b/bemade_sports_clinic/tests/test_cov_portal_cross_team.py
@@ -28,8 +28,10 @@ class TestCovPortalCrossTeam(PortalCovCommon):
         })
 
     def test_event_detail_timesheet_table_other_therapist(self):
-        # A timesheet on the event filed by a therapist the viewer can't read:
-        # the detail page's timesheet table reads ts.user_id.name.
+        # A timesheet on the event filed by another therapist: the page must
+        # not 500 — and since the confidentiality fix (dev-review 2026-07-04)
+        # the other therapist's row must NOT render: TPs only see their own
+        # timesheets on the event detail.
         self.env['sports.event.timesheet'].create({
             'event_id': self.event.id, 'user_id': self.other.id,
         })
@@ -37,8 +39,8 @@ class TestCovPortalCrossTeam(PortalCovCommon):
         self._login_tp()
         resp = self.url_open(f'/my/event/{self.event.id}')
         self.assertEqual(resp.status_code, 200, "detail must not 500 on a cross-user timesheet")
-        self.assertIn('Cross Team Therapist', resp.text,
-                      "the timesheet's therapist name should render")
+        self.assertNotIn('<span>Cross Team Therapist</span>', resp.text,
+                         "other therapists' timesheet rows must not render")
 
     def test_injury_edit_prechecks_cross_team_tp(self):
         self.injury.sudo().write({'treatment_professional_ids': [Command.set([self.other.id])]})

--- a/bemade_sports_clinic/tests/test_cov_portal_player_search_add_to_team.py
+++ b/bemade_sports_clinic/tests/test_cov_portal_player_search_add_to_team.py
@@ -1,0 +1,91 @@
+"""Task 1225: the broadened /my/players search must not offer a (403-bound)
+"View" link for players the current user cannot open, and must instead offer an
+"Add to Team" action limited to teams the user staffs. Using it links the player
+and the detail page then becomes reachable.
+
+Personas come from PortalCovCommon: cls.tp staffs team_a only; cls.player
+("Pat One") is on team_a (accessible); cls.player_b ("Pat Two") is on team_b
+(out of reach for the TP).
+"""
+from odoo import Command
+from odoo.tests import tagged
+
+from .portal_cov_common import PortalCovCommon
+
+
+@tagged('-at_install', 'post_install')
+class TestPortalPlayerSearchAddToTeam(PortalCovCommon):
+
+    # ---- search results: hide View, offer Add-to-Team for out-of-reach ----
+
+    def test_search_hides_view_link_for_inaccessible_player(self):
+        """A TP searching by name finds an out-of-team player, but the result
+        carries no /my/player View link (which would 403) - it carries the
+        Add-to-Team form instead."""
+        self._login_tp()
+        resp = self.url_open(f'/my/players?last_name=Two')
+        self.assertEqual(resp.status_code, 200)
+        # The out-of-team player is surfaced by the broadened search...
+        self.assertIn('Two', resp.text, "the broadened search should surface the out-of-team player")
+        # ...but with NO clickable View link (no 403 reachable)...
+        self.assertNotIn(f'/my/player?player_id={self.player_b.id}', resp.text,
+                         "no View link may point at a player the user cannot open")
+        # ...and WITH an Add-to-Team action.
+        self.assertIn(f'/my/player/{self.player_b.id}/add_to_team', resp.text,
+                      "an Add-to-Team action must be offered for the out-of-team player")
+
+    def test_search_keeps_view_link_for_accessible_player(self):
+        """An own-team player keeps the normal View link and no Add-to-Team."""
+        self._login_tp()
+        resp = self.url_open(f'/my/players?last_name=One')
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn(f'/my/player?player_id={self.player.id}', resp.text,
+                      "an accessible player must keep its View link")
+        self.assertNotIn(f'/my/player/{self.player.id}/add_to_team', resp.text,
+                         "an accessible player must not show Add-to-Team")
+
+    # ---- add-to-team action ----
+
+    def test_add_to_team_links_player_and_grants_access(self):
+        """Posting Add-to-Team for a staffed team links the player and the
+        detail page (previously 403) becomes reachable."""
+        self._login_tp()
+        # Pre-condition: TP cannot open player_b.
+        pre = self.url_open(f'/my/player?player_id={self.player_b.id}')
+        self.assertEqual(pre.status_code, 403)
+
+        resp = self.url_open(f'/my/player/{self.player_b.id}/add_to_team', data={
+            'csrf_token': self._csrf(), 'team_id': self.team_a.id,
+        })
+        self.assertEqual(resp.status_code, 200)
+        self.player_b.invalidate_recordset(['team_ids'])
+        self.assertIn(self.team_a, self.player_b.team_ids,
+                      "the player should be linked to the chosen staffed team")
+
+        # The View now works.
+        post = self.url_open(f'/my/player?player_id={self.player_b.id}')
+        self.assertEqual(post.status_code, 200,
+                         "the detail page must be reachable once the player is on a staffed team")
+
+    def test_add_to_team_rejects_unstaffed_team(self):
+        """A TP may not add a player to a team they do not staff (the posted
+        team_id is never trusted)."""
+        self._login_tp()
+        # team_b is NOT staffed by the TP. self.player is on team_a only.
+        self.url_open(f'/my/player/{self.player.id}/add_to_team', data={
+            'csrf_token': self._csrf(), 'team_id': self.team_b.id,
+        })
+        self.player.invalidate_recordset(['team_ids'])
+        self.assertNotIn(self.team_b, self.player.team_ids,
+                         "the player must not be linked to a team the user does not staff")
+
+    def test_add_to_team_denied_for_coach(self):
+        """Coaches keep the request-based flow; the direct Add-to-Team link is
+        TP/admin only and must not mutate the roster for a coach."""
+        self._login_coach()
+        self.url_open(f'/my/player/{self.player_b.id}/add_to_team', data={
+            'csrf_token': self._csrf(), 'team_id': self.team_a.id,
+        })
+        self.player_b.invalidate_recordset(['team_ids'])
+        self.assertNotIn(self.team_a, self.player_b.team_ids,
+                         "a coach must not directly link a player via Add-to-Team")

--- a/bemade_sports_clinic/tests/test_cov_sports_event.py
+++ b/bemade_sports_clinic/tests/test_cov_sports_event.py
@@ -1,9 +1,11 @@
 from datetime import datetime, date, timedelta
 
+from lxml import etree
+
 from odoo import Command
 from odoo.exceptions import ValidationError
 from odoo.tests import TransactionCase, tagged
-from odoo.tools import mute_logger
+from odoo.tools import mute_logger, safe_eval
 
 
 @tagged('post_install', '-at_install')
@@ -193,3 +195,34 @@ class TestCovSportsEvent(TransactionCase):
         ev = self._event()
         ev.unlink()
         self.assertFalse(ev.exists())
+
+    # ----- cancelled events excluded from default views (task 1235) -----
+    def test_action_hides_cancelled_by_default(self):
+        """The internal events action defaults to a 'Hide Cancelled' search
+        filter so cancelled events drop out of the default list and calendar,
+        while staying reachable by removing the (removable) default facet."""
+        action = self.env.ref('bemade_sports_clinic.sports_event_action')
+        ctx = safe_eval.safe_eval(action.context or '{}')
+        self.assertEqual(
+            ctx.get('search_default_hide_cancelled'), 1,
+            "Events action must default-apply the hide_cancelled filter.",
+        )
+
+    def test_search_view_has_hide_cancelled_filter(self):
+        """The search view exposes a hide_cancelled filter (domain excludes
+        cancelled) and keeps the explicit Cancelled filter for opting back in."""
+        search = self.env.ref('bemade_sports_clinic.sports_event_view_search')
+        tree = etree.fromstring(search.arch.encode())
+
+        hide = tree.xpath("//filter[@name='hide_cancelled']")
+        self.assertTrue(hide, "hide_cancelled filter must exist.")
+        domain = hide[0].get('domain')
+        self.assertIn("'state'", domain)
+        self.assertIn("'!='", domain)
+        self.assertIn("'cancelled'", domain)
+
+        # The explicit opt-in filter must still exist.
+        self.assertTrue(
+            tree.xpath("//filter[@name='cancelled']"),
+            "Explicit Cancelled filter must remain available.",
+        )

--- a/bemade_sports_clinic/tests/test_cov_sports_event.py
+++ b/bemade_sports_clinic/tests/test_cov_sports_event.py
@@ -227,6 +227,17 @@ class TestCovSportsEvent(TransactionCase):
             "Events action must default-apply the hide_cancelled filter.",
         )
 
+    def test_action_defaults_to_upcoming(self):
+        """The internal events action defaults the 'Upcoming' filter (task 374
+        intent, dev-review 2026-07-04): past events drop out of the default
+        views but come back when the removable facet is cleared."""
+        action = self.env.ref('bemade_sports_clinic.sports_event_action')
+        ctx = safe_eval.safe_eval(action.context or '{}')
+        self.assertEqual(
+            ctx.get('search_default_upcoming'), 1,
+            "Events action must default-apply the upcoming filter.",
+        )
+
     def test_search_view_has_hide_cancelled_filter(self):
         """The search view exposes a hide_cancelled filter (domain excludes
         cancelled) and keeps the explicit Cancelled filter for opting back in."""

--- a/bemade_sports_clinic/tests/test_cov_sports_event.py
+++ b/bemade_sports_clinic/tests/test_cov_sports_event.py
@@ -193,3 +193,23 @@ class TestCovSportsEvent(TransactionCase):
         ev = self._event()
         ev.unlink()
         self.assertFalse(ev.exists())
+
+    # ----- default ordering (start date ascending) -----
+
+    def test_model_order_is_date_start_ascending(self):
+        """The model's default _order sorts by date_start ascending."""
+        self.assertTrue(self.env['sports.event']._order.startswith('date_start asc'))
+
+    def test_default_search_orders_by_date_start_ascending(self):
+        """A default search([]) returns events sorted by date_start ascending."""
+        # Create out of chronological order to prove sorting, not insertion order.
+        mid = self._event(name='SE Order Mid', date_start=datetime(2026, 3, 10, 10, 0),
+                          date_end=datetime(2026, 3, 10, 12, 0))
+        late = self._event(name='SE Order Late', date_start=datetime(2026, 5, 20, 10, 0),
+                           date_end=datetime(2026, 5, 20, 12, 0))
+        early = self._event(name='SE Order Early', date_start=datetime(2026, 1, 2, 10, 0),
+                            date_end=datetime(2026, 1, 2, 12, 0))
+        ordered = self.env['sports.event'].search([('id', 'in', (mid + late + early).ids)])
+        self.assertEqual(ordered.ids, [early.id, mid.id, late.id])
+        starts = ordered.mapped('date_start')
+        self.assertEqual(starts, sorted(starts))

--- a/bemade_sports_clinic/tests/test_cov_sports_event_timesheet.py
+++ b/bemade_sports_clinic/tests/test_cov_sports_event_timesheet.py
@@ -148,3 +148,71 @@ class TestCovSportsEventTimesheet(TransactionCase):
         self.assertTrue(ts.vendor_ready_to_po)
         self.assertFalse(ts.customer_invoiced_complete)
         self.assertFalse(ts.fully_processed)
+
+    # ----- soft-delete (#991: therapists archive own, non-invoiced timesheets) -----
+
+    def _make_user(self, login, *group_xmlids):
+        return self.env['res.users'].create({
+            'name': login,
+            'login': login,
+            'email': f'{login}@example.com',
+            'group_ids': [Command.set([self.env.ref(g).id for g in group_xmlids])],
+        })
+
+    def test_soft_delete_owner_archives_submitted(self):
+        owner = self._make_user('cov_ts_sd_owner', 'base.group_user')
+        ts = self._ts(user_id=owner.id)
+        self.assertEqual(self.event.timesheet_count, 1)
+        ts.with_user(owner).action_soft_delete()
+        self.assertFalse(ts.active)
+        # Disappears from event aggregations (One2many reads include archived,
+        # so the computes must filter on active explicitly).
+        self.event.invalidate_recordset()
+        self.assertEqual(self.event.timesheet_count, 0)
+        self.assertFalse(self.event.has_uninvoiced_timesheets)
+
+    def test_soft_delete_resets_event_state(self):
+        owner = self._make_user('cov_ts_sd_state', 'base.group_user')
+        ts = self._ts(user_id=owner.id)  # ready-to-invoice -> event to_invoice
+        self.assertEqual(self.event.state, 'to_invoice')
+        ts.with_user(owner).action_soft_delete()
+        self.event.invalidate_recordset()
+        self.assertEqual(self.event.state, 'confirmed')
+
+    def test_soft_delete_owner_reappears_in_missing(self):
+        owner = self._make_user('cov_ts_sd_missing', 'base.group_user')
+        self.event.assigned_staff_ids = [Command.link(owner.id)]
+        ts = self._ts(user_id=owner.id)
+        self.assertNotIn(owner, self.event._get_missing_timesheet_user_ids())
+        ts.with_user(owner).action_soft_delete()
+        self.event.invalidate_recordset()
+        self.assertIn(owner, self.event._get_missing_timesheet_user_ids())
+
+    @mute_logger('odoo.addons.bemade_sports_clinic.models.sports_event_timesheet')
+    def test_soft_delete_invoiced_refused(self):
+        owner = self._make_user('cov_ts_sd_inv', 'base.group_user')
+        ts = self._ts(user_id=owner.id)
+        ts.state = 'invoiced'
+        with self.assertRaises(ValidationError):
+            ts.with_user(owner).action_soft_delete()
+        self.assertTrue(ts.active)
+
+    @mute_logger('odoo.addons.bemade_sports_clinic.models.sports_event_timesheet')
+    def test_soft_delete_non_owner_refused(self):
+        owner = self._make_user('cov_ts_sd_o2', 'base.group_user')
+        other = self._make_user('cov_ts_sd_other', 'base.group_user')
+        ts = self._ts(user_id=owner.id)
+        with self.assertRaises(ValidationError):
+            ts.with_user(other).action_soft_delete()
+        self.assertTrue(ts.active)
+
+    def test_soft_delete_portal_tp_owner(self):
+        owner = self._make_user(
+            'cov_ts_sd_portal',
+            'bemade_sports_clinic.group_portal_treatment_professional',
+        )
+        ts = self._ts(user_id=owner.id)
+        # A portal TP cannot unlink, but the write-own record rule permits the
+        # active=False soft delete on their own record.
+        ts.with_user(owner).action_soft_delete()
+        self.assertFalse(ts.active)

--- a/bemade_sports_clinic/tests/test_cov_team_staff_portal.py
+++ b/bemade_sports_clinic/tests/test_cov_team_staff_portal.py
@@ -59,6 +59,24 @@ class TestCovTeamStaffPortal(HttpCase):
         self.authenticate('tsp.tp@example.com', 'tsp-tp')
         self.assertEqual(self.url_open('/my').status_code, 200)
 
+    def test_home_portal_values_role_other_no_403(self):
+        """A portal user whose only clinic tie is a staff row with role
+        'other' (no TP/coach group) must reach the portal home without the
+        mail.activity counter raising an AccessError (task 1222 dev-review
+        fix, 2026-07-04)."""
+        other = self.env['res.users'].with_context(no_reset_password=True).create({
+            'name': 'TSP Other', 'login': 'tsp.other@example.com', 'password': 'tsp-other',
+            'group_ids': [Command.set([self.env.ref('base.group_portal').id])],
+        })
+        self.env['sports.team.staff'].create({
+            'team_id': self.team_a.id, 'partner_id': other.partner_id.id, 'role': 'other',
+        })
+        self.authenticate('tsp.other@example.com', 'tsp-other')
+        resp = self.url_open('/my')
+        self.assertEqual(resp.status_code, 200)
+        # The Activities home card is hidden for roles without activity ACLs.
+        self.assertNotIn('/my/activities', resp.text)
+
 
     # ----- /my/teams -----
 

--- a/bemade_sports_clinic/tests/test_cov_timesheets_portal.py
+++ b/bemade_sports_clinic/tests/test_cov_timesheets_portal.py
@@ -20,9 +20,10 @@ class TestCovTimesheetsPortal(PortalCovCommon):
                f'&team_id={self.team_a.id}&group_by=event&sortby=date')
         self.assertEqual(self.url_open(url).status_code, 200)
 
-    def test_cancelled_event_timesheet_excluded(self):
-        """A timesheet on a cancelled event drops out of both the portal
-        list and the 'My Timesheets' home counter (task 990)."""
+    def test_cancelled_event_timesheet_still_visible(self):
+        """A timesheet on a cancelled event stays in the portal list and the
+        'My Timesheets' home counter: a last-minute cancellation can still be
+        payable/invoiceable (owner reversal of task 990, dev-review 2026-07-04)."""
         now = datetime(2026, 3, 3, 10, 0)
         cancelled_event = self.env['sports.event'].create({
             'name': 'PC Cancelled Event', 'event_type': 'game',
@@ -38,13 +39,13 @@ class TestCovTimesheetsPortal(PortalCovCommon):
 
         self._login_tp()
 
-        # List route: keeps the confirmed-event timesheet, drops the cancelled one.
+        # List route: keeps both the confirmed-event and cancelled-event timesheets.
         resp = self.url_open('/my/sc/timesheets')
         self.assertEqual(resp.status_code, 200)
         self.assertIn('PC Event', resp.text)
-        self.assertNotIn('PC Cancelled Event', resp.text)
+        self.assertIn('PC Cancelled Event', resp.text)
 
-        # Home counter: the async /my/counters route excludes it too. Baseline
-        # is the single confirmed-event timesheet created in PortalCovCommon.
+        # Home counter: the async /my/counters route counts it too. Baseline is
+        # the single confirmed-event timesheet created in PortalCovCommon.
         counters = self._jsonrpc('/my/counters', counters=['event_timesheets_count'])
-        self.assertEqual(counters['event_timesheets_count'], 1)
+        self.assertEqual(counters['event_timesheets_count'], 2)

--- a/bemade_sports_clinic/tests/test_cov_timesheets_portal.py
+++ b/bemade_sports_clinic/tests/test_cov_timesheets_portal.py
@@ -1,3 +1,6 @@
+from datetime import datetime, timedelta
+
+from odoo import Command
 from odoo.tests import tagged
 
 from .portal_cov_common import PortalCovCommon
@@ -16,3 +19,32 @@ class TestCovTimesheetsPortal(PortalCovCommon):
         url = ('/my/sc/timesheets?date_from=2026-01-01&date_to=2026-12-31'
                f'&team_id={self.team_a.id}&group_by=event&sortby=date')
         self.assertEqual(self.url_open(url).status_code, 200)
+
+    def test_cancelled_event_timesheet_excluded(self):
+        """A timesheet on a cancelled event drops out of both the portal
+        list and the 'My Timesheets' home counter (task 990)."""
+        now = datetime(2026, 3, 3, 10, 0)
+        cancelled_event = self.env['sports.event'].create({
+            'name': 'PC Cancelled Event', 'event_type': 'game',
+            'team_ids': [Command.set([self.team_a.id])],
+            'date_start': now, 'date_end': now + timedelta(hours=2),
+            'state': 'confirmed',
+            'assigned_staff_ids': [Command.set([self.tp.id])],
+        })
+        self.env['sports.event.timesheet'].create({
+            'event_id': cancelled_event.id, 'user_id': self.tp.id,
+        })
+        cancelled_event.state = 'cancelled'
+
+        self._login_tp()
+
+        # List route: keeps the confirmed-event timesheet, drops the cancelled one.
+        resp = self.url_open('/my/sc/timesheets')
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn('PC Event', resp.text)
+        self.assertNotIn('PC Cancelled Event', resp.text)
+
+        # Home counter: the async /my/counters route excludes it too. Baseline
+        # is the single confirmed-event timesheet created in PortalCovCommon.
+        counters = self._jsonrpc('/my/counters', counters=['event_timesheets_count'])
+        self.assertEqual(counters['event_timesheets_count'], 1)

--- a/bemade_sports_clinic/tests/test_event_cancel_notifications.py
+++ b/bemade_sports_clinic/tests/test_event_cancel_notifications.py
@@ -1,0 +1,192 @@
+"""Assigned staff are alerted when an event they're on is cancelled or deleted.
+
+Acceptance criteria:
+- Cancelling an event (statusbar ``action_cancel``, the cancel wizard, or the
+  portal controller — all funnel through ``write({'state': 'cancelled'})``)
+  notifies every assigned staff member (an in-app message that lists each
+  assignee partner as a recipient, delivered by email/inbox per their pref).
+- Deleting an event notifies the assigned staff captured before deletion.
+- A single cancel produces exactly one cancellation notice (no duplicate from
+  ``write`` + ``action_cancel`` both firing).
+- Re-cancelling an already-cancelled event does not re-notify.
+- The cancellation reason (wizard/portal) is carried into the notice.
+- An event with no assigned staff cancels/deletes without error.
+"""
+
+from datetime import datetime
+
+from odoo import Command
+from odoo.tests import TransactionCase, tagged
+from odoo.tools import mute_logger
+
+
+@tagged('post_install', '-at_install')
+class TestEventCancelNotifications(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.org = cls.env['res.partner'].create({
+            'name': 'Notif Org', 'is_company': True,
+        })
+        cls.team = cls.env['sports.team'].create({
+            'name': 'Notif Team', 'parent_id': cls.org.id,
+        })
+        internal = cls.env.ref('base.group_user').id
+        tp = cls.env.ref(
+            'bemade_sports_clinic.group_sports_clinic_treatment_professional'
+        ).id
+        cls.staff1 = cls.env['res.users'].create({
+            'name': 'Staff One', 'login': 'notif.staff1@example.com',
+            'email': 'notif.staff1@example.com',
+            'group_ids': [(6, 0, [internal, tp])],
+        })
+        cls.staff2 = cls.env['res.users'].create({
+            'name': 'Staff Two', 'login': 'notif.staff2@example.com',
+            'email': 'notif.staff2@example.com',
+            'group_ids': [(6, 0, [internal, tp])],
+        })
+        cls.staff_partners = cls.staff1.partner_id | cls.staff2.partner_id
+
+    def _make_event(self, with_staff=True, **vals):
+        staff = [self.staff1.id, self.staff2.id] if with_staff else []
+        return self.env['sports.event'].create({
+            'name': vals.pop('name', 'Notif Event'),
+            'team_ids': [Command.set([self.team.id])],
+            'assigned_staff_ids': [Command.set(staff)],
+            'date_start': datetime(2026, 3, 5, 10, 0),
+            'date_end': datetime(2026, 3, 5, 12, 0),
+            'state': 'confirmed',
+            **vals,
+        })
+
+    def _cancel_notices(self, event):
+        """Messages on the event that notify at least one assigned staff."""
+        return event.message_ids.filtered(
+            lambda m: self.staff_partners & m.notified_partner_ids
+        )
+
+    @mute_logger('odoo.addons.bemade_sports_clinic.models.sports_event')
+    def test_action_cancel_notifies_each_assigned_staff(self):
+        event = self._make_event()
+        event.action_cancel()
+        self.assertEqual(event.state, 'cancelled')
+        notices = self._cancel_notices(event)
+        # Exactly one cancellation notice (no duplicate from write + action_cancel).
+        self.assertEqual(
+            len(notices), 1,
+            "exactly one cancellation notice should reach assigned staff",
+        )
+        notified = notices.notified_partner_ids
+        self.assertIn(self.staff1.partner_id, notified)
+        self.assertIn(self.staff2.partner_id, notified)
+
+    @mute_logger('odoo.addons.bemade_sports_clinic.models.sports_event')
+    def test_cancel_wizard_notifies_with_reason(self):
+        event = self._make_event()
+        wizard = self.env['sports.event.cancel.wizard'].create({
+            'event_id': event.id, 'reason': 'Field flooded',
+        })
+        wizard.action_confirm_cancel()
+        self.assertEqual(event.state, 'cancelled')
+        notices = self._cancel_notices(event)
+        self.assertTrue(notices, "wizard cancel should notify assigned staff")
+        self.assertIn(self.staff1.partner_id, notices.notified_partner_ids)
+        self.assertIn(self.staff2.partner_id, notices.notified_partner_ids)
+        self.assertTrue(
+            any('Field flooded' in (m.body or '') for m in notices),
+            "the cancellation reason should appear in the staff notice",
+        )
+
+    @mute_logger('odoo.addons.bemade_sports_clinic.models.sports_event')
+    def test_write_cancel_carries_reason_via_context(self):
+        # Mirrors what the portal controller does: write with cancel_reason ctx.
+        event = self._make_event()
+        event.with_context(cancel_reason='Coach unavailable').write(
+            {'state': 'cancelled'}
+        )
+        notices = self._cancel_notices(event)
+        self.assertTrue(notices)
+        self.assertTrue(
+            any('Coach unavailable' in (m.body or '') for m in notices),
+        )
+
+    @mute_logger('odoo.addons.bemade_sports_clinic.models.sports_event')
+    def test_recancel_does_not_renotify(self):
+        event = self._make_event()
+        event.action_cancel()
+        first = self._cancel_notices(event)
+        self.assertEqual(len(first), 1)
+        # Writing state='cancelled' again must not produce a new notice.
+        event.write({'state': 'cancelled'})
+        self.assertEqual(
+            len(self._cancel_notices(event)), 1,
+            "re-cancelling an already-cancelled event must not re-notify",
+        )
+
+    @mute_logger('odoo.addons.bemade_sports_clinic.models.sports_event')
+    def test_unlink_notifies_captured_staff(self):
+        event = self._make_event(name='Doomed Event')
+        pre = self.env['mail.message'].search([
+            ('notified_partner_ids', 'in', self.staff_partners.ids),
+        ])
+        event.unlink()
+        new = self.env['mail.message'].search([
+            ('notified_partner_ids', 'in', self.staff_partners.ids),
+            ('id', 'not in', pre.ids),
+        ])
+        self.assertTrue(new, "deleting an event should notify assigned staff")
+        notified = new.notified_partner_ids
+        self.assertIn(self.staff1.partner_id, notified)
+        self.assertIn(self.staff2.partner_id, notified)
+        self.assertTrue(
+            any('Doomed Event' in (m.body or '') or 'Doomed Event' in (m.subject or '')
+                for m in new),
+            "the deletion notice should identify the event",
+        )
+
+    @mute_logger('odoo.addons.bemade_sports_clinic.models.sports_event')
+    def test_portal_user_cancel_notifies_without_acl_error(self):
+        # A portal therapist cancelling their own event (the controller path:
+        # write with portal_cancel_event + cancel_reason) must reach the
+        # assigned-staff notice without tripping res.users ACLs.
+        portal = self.env.ref('base.group_portal').id
+        tp = self.env.ref(
+            'bemade_sports_clinic.group_portal_treatment_professional'
+        ).id
+        portal_tp = self.env['res.users'].with_context(
+            no_reset_password=True
+        ).create({
+            'name': 'Portal TP', 'login': 'notif.portaltp@example.com',
+            'email': 'notif.portaltp@example.com',
+            'group_ids': [(6, 0, [portal, tp])],
+        })
+        self.env['sports.team.staff'].create({
+            'team_id': self.team.id,
+            'partner_id': portal_tp.partner_id.id,
+            'role': 'therapist',
+        })
+        event = self._make_event()
+        event.assigned_staff_ids = [Command.link(portal_tp.id)]
+        event.with_user(portal_tp).with_context(
+            portal_cancel_event=True, cancel_reason='Portal cancel',
+        ).write({'state': 'cancelled'})
+        self.assertEqual(event.state, 'cancelled')
+        notices = self._cancel_notices(event)
+        self.assertTrue(notices, "portal cancel should notify assigned staff")
+        # The other assignees are notified; the canceller (message author) is
+        # excluded by Odoo's standard self-notification suppression.
+        notified = notices.notified_partner_ids
+        self.assertIn(self.staff1.partner_id, notified)
+        self.assertIn(self.staff2.partner_id, notified)
+        self.assertNotIn(portal_tp.partner_id, notified)
+
+    @mute_logger('odoo.addons.bemade_sports_clinic.models.sports_event')
+    def test_cancel_and_delete_without_staff_do_not_error(self):
+        event = self._make_event(with_staff=False)
+        event.action_cancel()
+        self.assertEqual(event.state, 'cancelled')
+        # And deletion of a staff-less event is also fine.
+        event2 = self._make_event(with_staff=False, name='Empty 2')
+        event2.unlink()
+        self.assertFalse(event2.exists())

--- a/bemade_sports_clinic/tests/test_event_cancel_notifications.py
+++ b/bemade_sports_clinic/tests/test_event_cancel_notifications.py
@@ -61,8 +61,16 @@ class TestEventCancelNotifications(TransactionCase):
         })
 
     def _cancel_notices(self, event):
-        """Messages on the event that notify at least one assigned staff."""
-        return event.message_ids.filtered(
+        """Messages on the event that notify at least one assigned staff.
+
+        The notice is sent via message_notify (user_notification type), which
+        the message_ids one2many deliberately filters out — search
+        mail.message directly."""
+        messages = self.env['mail.message'].search([
+            ('model', '=', 'sports.event'),
+            ('res_id', '=', event.id),
+        ])
+        return messages.filtered(
             lambda m: self.staff_partners & m.notified_partner_ids
         )
 
@@ -191,7 +199,10 @@ class TestEventCancelNotifications(TransactionCase):
         event = self._make_event(with_staff=False, name='Solo Cancel Event')
         event.assigned_staff_ids = [Command.link(self.staff1.id)]
         event.with_user(self.staff1).write({'state': 'cancelled'})
-        notices = event.message_ids.filtered(
+        messages = self.env['mail.message'].search([
+            ('model', '=', 'sports.event'), ('res_id', '=', event.id),
+        ])
+        notices = messages.filtered(
             lambda m: self.staff1.partner_id in m.notified_partner_ids
         )
         self.assertTrue(notices, "sole-assignee cancel must still notify the canceller")

--- a/bemade_sports_clinic/tests/test_event_cancel_notifications.py
+++ b/bemade_sports_clinic/tests/test_event_cancel_notifications.py
@@ -174,12 +174,27 @@ class TestEventCancelNotifications(TransactionCase):
         self.assertEqual(event.state, 'cancelled')
         notices = self._cancel_notices(event)
         self.assertTrue(notices, "portal cancel should notify assigned staff")
-        # The other assignees are notified; the canceller (message author) is
-        # excluded by Odoo's standard self-notification suppression.
+        # EVERY assignee is notified, including the canceller: without
+        # mail_notify_author the author is silently dropped, so a sole-assignee
+        # portal TP cancelling their own event would notify nobody
+        # (dev-review 2026-07-04).
         notified = notices.notified_partner_ids
         self.assertIn(self.staff1.partner_id, notified)
         self.assertIn(self.staff2.partner_id, notified)
-        self.assertNotIn(portal_tp.partner_id, notified)
+        self.assertIn(portal_tp.partner_id, notified)
+
+    @mute_logger('odoo.addons.bemade_sports_clinic.models.sports_event')
+    def test_sole_assignee_canceller_still_notified(self):
+        """Statusbar-style cancel (bare state write) by a user who is the only
+        assignee must still produce a notification — the author-suppression
+        regression found in dev-review 2026-07-04."""
+        event = self._make_event(with_staff=False, name='Solo Cancel Event')
+        event.assigned_staff_ids = [Command.link(self.staff1.id)]
+        event.with_user(self.staff1).write({'state': 'cancelled'})
+        notices = event.message_ids.filtered(
+            lambda m: self.staff1.partner_id in m.notified_partner_ids
+        )
+        self.assertTrue(notices, "sole-assignee cancel must still notify the canceller")
 
     @mute_logger('odoo.addons.bemade_sports_clinic.models.sports_event')
     def test_cancel_and_delete_without_staff_do_not_error(self):

--- a/bemade_sports_clinic/tests/test_event_detail_timesheet_confidentiality.py
+++ b/bemade_sports_clinic/tests/test_event_detail_timesheet_confidentiality.py
@@ -1,0 +1,56 @@
+"""Event-detail timesheet confidentiality (dev-review finding, 2026-07-04).
+
+Acceptance criteria:
+- A TP assigned to an event sees ONLY their own timesheets on the event detail
+  page (tab renamed 'My Timesheets'); other TPs' rows never render.
+- A TP who is NOT assigned to the event sees neither the My Timesheets tab nor
+  the 'Add My Timesheet' button/modal.
+"""
+from datetime import datetime, timedelta
+
+from odoo import Command
+from odoo.tests import tagged
+
+from .portal_cov_common import PortalCovCommon
+
+
+@tagged('-at_install', 'post_install')
+class TestEventDetailTimesheetConfidentiality(PortalCovCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        env = cls.env
+        portal = env.ref('base.group_portal').id
+        tp_g = env.ref('bemade_sports_clinic.group_portal_treatment_professional').id
+        cls.tp2 = env['res.users'].with_context(no_reset_password=True).create({
+            'name': 'PC TP Two', 'login': 'pc.tp2@example.com', 'password': 'pc-tp2xx',
+            'group_ids': [Command.set([portal, tp_g])],
+        })
+        env['sports.team.staff'].create({
+            'team_id': cls.team_a.id, 'partner_id': cls.tp2.partner_id.id, 'role': 'therapist',
+        })
+        # Second TP is also assigned to the shared event and has a timesheet on it.
+        cls.event.write({'assigned_staff_ids': [Command.link(cls.tp2.id)]})
+        cls.ts_tp2 = env['sports.event.timesheet'].create({
+            'event_id': cls.event.id, 'user_id': cls.tp2.id,
+        })
+
+    def test_assigned_tp_sees_only_own_timesheets(self):
+        self._login_tp()
+        resp = self.url_open(f'/my/event/{self.event.id}')
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn('My Timesheets', resp.text)
+        # Own row renders in the timesheet table (name cell markup)...
+        self.assertIn('<span>PC TP</span>', resp.text)
+        # ...but the other TP's row must not (their name may still appear in the
+        # Assigned Staff panel, which uses different markup).
+        self.assertNotIn('<span>PC TP Two</span>', resp.text)
+
+    def test_unassigned_tp_has_no_tab_or_add_button(self):
+        self.event.sudo().write({'assigned_staff_ids': [Command.unlink(self.tp.id)]})
+        self._login_tp()
+        resp = self.url_open(f'/my/event/{self.event.id}')
+        self.assertEqual(resp.status_code, 200)
+        self.assertNotIn('My Timesheets', resp.text)
+        self.assertNotIn('Add My Timesheet', resp.text)

--- a/bemade_sports_clinic/tests/test_events_calendar_portal.py
+++ b/bemade_sports_clinic/tests/test_events_calendar_portal.py
@@ -92,6 +92,15 @@ class TestEventsCalendarPortal(HttpCase):
             "date_start": now + timedelta(days=3),
             "date_end": now + timedelta(days=3, hours=2),
         })
+        # A cancelled event for team A (task 1235): must be hidden from the
+        # default calendar feed but reachable with show_cancelled=1.
+        cls.cancelled_a = cls.env["sports.event"].create({
+            "name": "Cancelled Team A",
+            "team_ids": [(6, 0, [cls.team_a.id])],
+            "date_start": now + timedelta(days=4),
+            "date_end": now + timedelta(days=4, hours=2),
+            "state": "cancelled",
+        })
 
     def _get_data(self, start, end):
         url = (
@@ -128,6 +137,37 @@ class TestEventsCalendarPortal(HttpCase):
         self.assertIn(self.future_a.id, ids)
         self.assertIn(self.past_a.id, ids)
         self.assertIn(self.future_b.id, ids)
+
+    def test_cancelled_hidden_from_default_feed(self):
+        """Cancelled events must not appear in the default calendar feed."""
+        self.authenticate("cal.coach.611@example.com", "cal-coach")
+        start = datetime.now() - timedelta(days=30)
+        end = datetime.now() + timedelta(days=30)
+        ids = {e["id"] for e in self._get_data(start, end).json()}
+        self.assertIn(self.future_a.id, ids)
+        self.assertNotIn(self.cancelled_a.id, ids)
+
+    def test_cancelled_visible_with_show_cancelled(self):
+        """show_cancelled=1 brings cancelled events back into the feed."""
+        self.authenticate("cal.coach.611@example.com", "cal-coach")
+        start = datetime.now() - timedelta(days=30)
+        end = datetime.now() + timedelta(days=30)
+        url = (
+            f"/my/events/calendar/data"
+            f"?start={start.isoformat()}&end={end.isoformat()}"
+            f"&show_cancelled=1"
+        )
+        ids = {e["id"] for e in self.url_open(url).json()}
+        self.assertIn(self.cancelled_a.id, ids)
+        self.assertIn(self.future_a.id, ids)
+
+    def test_therapist_also_hides_cancelled_by_default(self):
+        """The exclusion applies to therapists (who otherwise see all)."""
+        self.authenticate("cal.tp.611@example.com", "cal-tp")
+        start = datetime.now() - timedelta(days=30)
+        end = datetime.now() + timedelta(days=30)
+        ids = {e["id"] for e in self._get_data(start, end).json()}
+        self.assertNotIn(self.cancelled_a.id, ids)
 
     def test_plain_portal_user_data_empty(self):
         self.authenticate("plain.611@example.com", "plain")

--- a/bemade_sports_clinic/tests/test_events_calendar_portal.py
+++ b/bemade_sports_clinic/tests/test_events_calendar_portal.py
@@ -73,12 +73,19 @@ class TestEventsCalendarPortal(HttpCase):
             "group_ids": [Command.set([cls.env.ref("base.group_portal").id])],
         })
 
+        cls.venue = cls.env["res.partner"].create({
+            "name": "Cal Arena",
+            "is_venue": True,
+        })
+
         now = datetime.now()
         cls.future_a = cls.env["sports.event"].create({
             "name": "Future Team A",
             "team_ids": [(6, 0, [cls.team_a.id])],
             "date_start": now + timedelta(days=2),
             "date_end": now + timedelta(days=2, hours=2),
+            "therapist_start": now + timedelta(days=2, hours=-1),
+            "venue_id": cls.venue.id,
         })
         cls.past_a = cls.env["sports.event"].create({
             "name": "Past Team A",
@@ -183,3 +190,73 @@ class TestEventsCalendarPortal(HttpCase):
             parsed.replace(tzinfo=None).replace(microsecond=0),
             self.future_a.date_start.replace(microsecond=0),
         )
+
+    def test_event_payload_carries_therapist_start_and_venue(self):
+        """The popover needs an 'Arrive by' time (therapist start) and a
+        venue name, so the feed must expose both in extendedProps."""
+        self.authenticate("cal.coach.611@example.com", "cal-coach")
+        start = datetime.now() - timedelta(days=30)
+        end = datetime.now() + timedelta(days=30)
+        events = self._get_data(start, end).json()
+        e = next(e for e in events if e["id"] == self.future_a.id)
+        props = e.get("extendedProps", {})
+        self.assertIn("therapist_start", props)
+        self.assertIn("venue", props)
+        # therapist_start must carry an explicit UTC marker like start/end.
+        self.assertTrue(
+            props["therapist_start"].endswith("+00:00")
+            or props["therapist_start"].endswith("Z"),
+            f"therapist_start should be UTC ISO, got {props['therapist_start']!r}",
+        )
+        self.assertEqual(props["venue"], "Cal Arena")
+
+    def test_event_payload_drops_state(self):
+        """Status/state was removed from the popover; the feed should no
+        longer leak it in extendedProps."""
+        self.authenticate("cal.tp.611@example.com", "cal-tp")
+        start = datetime.now() - timedelta(days=30)
+        end = datetime.now() + timedelta(days=30)
+        events = self._get_data(start, end).json()
+        e = next(e for e in events if e["id"] == self.future_a.id)
+        self.assertNotIn("state", e.get("extendedProps", {}))
+
+    def test_calendar_data_honors_team_filter(self):
+        """A therapist sees all teams by default, but passing team_id should
+        scope the feed to that team (same filter the list view exposes)."""
+        self.authenticate("cal.tp.611@example.com", "cal-tp")
+        start = datetime.now() - timedelta(days=30)
+        end = datetime.now() + timedelta(days=30)
+        url = (
+            f"/my/events/calendar/data"
+            f"?start={start.isoformat()}&end={end.isoformat()}"
+            f"&team_id={self.team_b.id}"
+        )
+        events = self.url_open(url).json()
+        ids = {e["id"] for e in events}
+        self.assertIn(self.future_b.id, ids)
+        self.assertNotIn(self.future_a.id, ids)
+
+    def test_calendar_page_has_single_close_control(self):
+        """The popover close control must render exactly one X. The old
+        markup combined Bootstrap's btn-close (which draws its own glyph
+        via CSS) with a literal multiplication sign, producing two."""
+        self.authenticate("cal.coach.611@example.com", "cal-coach")
+        resp = self.url_open("/my/events/calendar")
+        self.assertEqual(resp.status_code, 200)
+        content = resp.content.decode("utf-8")
+        self.assertIn("data-popover-close", content)
+        # No literal multiplication sign anywhere on the page — btn-close
+        # supplies the only X via CSS.
+        self.assertNotIn("×", content)
+        # Status line must be gone from the popover markup.
+        self.assertNotIn("data-popover-state", content)
+
+    def test_calendar_page_renders_filter_bar(self):
+        """The calendar page should carry the same list-style filter
+        controls (organization, team, assigned professional)."""
+        self.authenticate("cal.coach.611@example.com", "cal-coach")
+        resp = self.url_open("/my/events/calendar")
+        content = resp.content.decode("utf-8")
+        self.assertIn('name="team_id"', content)
+        self.assertIn('name="organization_id"', content)
+        self.assertIn('name="assigned_user_id"', content)

--- a/bemade_sports_clinic/tests/test_events_calendar_portal.py
+++ b/bemade_sports_clinic/tests/test_events_calendar_portal.py
@@ -300,3 +300,36 @@ class TestEventsCalendarPortal(HttpCase):
         self.assertIn('name="team_id"', content)
         self.assertIn('name="organization_id"', content)
         self.assertIn('name="assigned_user_id"', content)
+
+    def test_calendar_page_renders_quick_filters_and_cancelled_toggle(self):
+        """The calendar carries the list view's quick filters and the
+        show-cancelled checkbox (dev-review 2026-07-04)."""
+        self.authenticate("cal.coach.611@example.com", "cal-coach")
+        content = self.url_open("/my/events/calendar").content.decode("utf-8")
+        self.assertIn('id="cal-quick-filters"', content)
+        self.assertIn('data-view-type="my"', content)
+        self.assertIn('data-view-type="unassigned"', content)
+        self.assertIn('id="cal-filter-show-cancelled"', content)
+
+    def test_calendar_page_dropdowns_sudo_widened(self):
+        """Team/org dropdown CHOICES list every team, like the list view
+        (task 1226) — record visibility is still scoped by the feed domain."""
+        self.authenticate("cal.coach.611@example.com", "cal-coach")
+        content = self.url_open("/my/events/calendar").content.decode("utf-8")
+        # The coach staffs team A only, but team B must appear as an option.
+        self.assertIn("Cal Team B", content)
+
+    def test_calendar_data_honors_view_type_my(self):
+        """The feed honors view_type=my: only events assigned to the current
+        user are returned (dev-review 2026-07-04)."""
+        self.future_a.assigned_staff_ids = [Command.link(self.therapist_user.id)]
+        self.authenticate("cal.tp.611@example.com", "cal-tp")
+        start = datetime.now() - timedelta(days=30)
+        end = datetime.now() + timedelta(days=30)
+        url = (
+            f"/my/events/calendar/data"
+            f"?start={start.isoformat()}&end={end.isoformat()}&view_type=my"
+        )
+        titles = [e["title"] for e in json.loads(self.url_open(url).content)]
+        self.assertIn("Future Team A", titles)
+        self.assertNotIn("Future Team B", titles)

--- a/bemade_sports_clinic/tests/test_mail_activity_portal_integration.py
+++ b/bemade_sports_clinic/tests/test_mail_activity_portal_integration.py
@@ -641,6 +641,108 @@ class TestMailActivityPortalIntegration(HttpCase):
         # Should handle gracefully and show error message
         self.assertNotEqual(response.status_code, 500, "Should not cause server error with invalid data")
 
+    def test_17_team_activities_tab_team_only(self):
+        """Task 1223: the team portal page (/my/team) has an Activities tab that
+        lists ONLY team-level activities (res_model='sports.team') for that team,
+        plus a shared add-activity header (fields + button) posting to
+        /my/activity/save with model=sports.team. Player/injury activities for the
+        team's players must NOT appear in the team tab.
+        """
+        team = self.authorized_team
+
+        team_type = self.env['mail.activity.type'].create({
+            'name': 'Team Task 1223',
+            'res_model': 'sports.team',
+            'category': 'default',
+        })
+
+        # A team-level activity (should appear on the team Activities tab).
+        team_activity = self.env['mail.activity'].create({
+            'activity_type_id': team_type.id,
+            'summary': 'TeamScopedActivity1223',
+            'user_id': self.therapist_user.id,
+            'date_deadline': fields.Date.today(),
+            'res_model_id': self.env['ir.model']._get_id('sports.team'),
+            'res_id': team.id,
+        })
+
+        # A player-level activity on a player who is ON this team (must NOT appear
+        # in the team tab - it belongs to the player, not the team).
+        player_activity = self.env['mail.activity'].create({
+            'activity_type_id': self.patient_activity_type.id,
+            'summary': 'PlayerScopedActivity1223',
+            'user_id': self.therapist_user.id,
+            'date_deadline': fields.Date.today(),
+            'res_model_id': self.env['ir.model']._get_id('sports.patient'),
+            'res_id': self.authorized_patient.id,
+        })
+
+        # An injury-level activity for one of this team's players (must NOT appear).
+        injury_activity = self.env['mail.activity'].create({
+            'activity_type_id': self.injury_activity_type.id,
+            'summary': 'InjuryScopedActivity1223',
+            'user_id': self.therapist_user.id,
+            'date_deadline': fields.Date.today(),
+            'res_model_id': self.env['ir.model']._get_id('sports.patient.injury'),
+            'res_id': self.authorized_injury.id,
+        })
+
+        self.authenticate('integration.therapist@example.com', 'integration123')
+        response = self.url_open(f'/my/team?team_id={team.id}', timeout=30)
+        self.assertEqual(response.status_code, 200, "Team page should render")
+        body = response.text
+
+        # The team activity appears...
+        self.assertIn('TeamScopedActivity1223', body,
+                      "Team Activities tab must list the team-level activity")
+        # ...but the player and injury activities do NOT.
+        self.assertNotIn('PlayerScopedActivity1223', body,
+                         "Team tab must NOT include a team player's activities")
+        self.assertNotIn('InjuryScopedActivity1223', body,
+                         "Team tab must NOT include a team player's injury activities")
+
+        # The shared add-activity header is present and targets the team model.
+        self.assertIn('/my/activity/save', body,
+                      "Add-activity header must post to /my/activity/save")
+        self.assertIn('name="model" value="sports.team"', body,
+                      "Add header must scope the new activity to the team model")
+        self.assertIn(f'name="res_id" value="{team.id}"', body,
+                      "Add header must scope the new activity to this team")
+        for field_name in ('activity_type_id', 'date_deadline', 'user_id', 'summary'):
+            self.assertIn(field_name, body,
+                          f"Add header should expose the {field_name} field")
+
+    def test_18_team_activities_tab_add_creates_team_activity(self):
+        """Task 1223: submitting the team tab's add header creates a team-scoped
+        activity via the shared /my/activity/save endpoint.
+        """
+        team = self.authorized_team
+        team_type = self.env['mail.activity.type'].create({
+            'name': 'Team Task 1223b',
+            'res_model': 'sports.team',
+            'category': 'default',
+        })
+        self.authenticate('integration.therapist@example.com', 'integration123')
+        form_data = {
+            'csrf_token': self.csrf_token(),
+            'activity_type_id': team_type.id,
+            'summary': 'TeamAddHeaderCreated1223',
+            'note': 'created from team tab',
+            'user_id': self.therapist_user.id,
+            'date_deadline': fields.Date.today().strftime('%Y-%m-%d'),
+            'model': 'sports.team',
+            'res_id': team.id,
+        }
+        response = self.url_open('/my/activity/save', data=form_data, timeout=30)
+        self.assertIn(response.status_code, [200, 302])
+        created = self.env['mail.activity'].search([
+            ('summary', '=', 'TeamAddHeaderCreated1223'),
+            ('res_model', '=', 'sports.team'),
+            ('res_id', '=', team.id),
+        ])
+        self.assertTrue(created.exists(),
+                        "Team add header should create a team-scoped activity")
+
     def test_640_tp_can_find_and_link_unteamed_player(self):
         """Task 640: a treatment professional can FIND a player with no team
         affiliation in the add-to-team search and LINK them to a team they staff,

--- a/bemade_sports_clinic/tests/test_patient.py
+++ b/bemade_sports_clinic/tests/test_patient.py
@@ -211,6 +211,35 @@ class TestPatient(TransactionCase):
         )
         return team2, therapist, coach
 
+    def test_creating_patient_with_team_via_form_no_double_follower(self):
+        """Reproduces the 'a partner can't follow an object twice' error when a
+        patient is created from the list view with a team (and its staff) assigned
+        before the first save. The follower recomputation must be idempotent so the
+        coach partner ends up as a follower exactly once."""
+        with Form(self.env["sports.patient"]) as patient_form:
+            patient_form.first_name = "Form"
+            patient_form.last_name = "Created"
+            patient_form.team_ids.add(self.team1)
+        patient = patient_form.record
+
+        coach_partner = self.coach.partner_id
+        self.assertIn(coach_partner, patient.message_partner_ids)
+        self.assertEqual(
+            len(patient.message_partner_ids.filtered(lambda p: p == coach_partner)),
+            1,
+            "Coach must follow the patient exactly once after a Form create.",
+        )
+
+    def test_recompute_followers_is_idempotent(self):
+        """Calling recompute_followers repeatedly must never raise the unique
+        follower constraint nor add the same partner twice."""
+        coach_partner = self.coach.partner_id
+        before = self.patient1.message_partner_ids
+        self.patient1.recompute_followers()
+        self.patient1.recompute_followers()
+        self.assertEqual(self.patient1.message_partner_ids, before)
+        self.assertIn(coach_partner, self.patient1.message_partner_ids)
+
     def test_changing_patient_name_changes_on_partner(self):
         new_last_name = "New last name"
         new_first_name = "New first name"

--- a/bemade_sports_clinic/tests/test_player_activities_tab.py
+++ b/bemade_sports_clinic/tests/test_player_activities_tab.py
@@ -1,0 +1,135 @@
+from odoo import Command, fields
+from odoo.tests import tagged
+
+from .portal_cov_common import PortalCovCommon
+
+
+@tagged('-at_install', 'post_install')
+class TestPlayerActivitiesTab(PortalCovCommon):
+    """Task 1222: the player's own + its injuries' activities are consolidated
+    into an Activities tab on the player detail page, with an inline add header,
+    replacing the separate /my/player/activities page and the top-of-page
+    activity buttons.
+    """
+
+    def test_activities_tab_lists_player_and_injury_activities(self):
+        """The player page has an Activities tab listing the player's own AND
+        its injuries' activities (acceptance #1)."""
+        self._login_tp()
+        resp = self.url_open(f'/my/player?player_id={self.player.id}')
+        self.assertEqual(resp.status_code, 200)
+        # The new tab pane + nav button exist.
+        self.assertIn('id="activities"', resp.text)
+        self.assertIn('id="activities-tab"', resp.text)
+        # Both the player-level and the injury-level activity appear.
+        self.assertIn('Player task', resp.text)
+        self.assertIn('Injury task', resp.text)
+
+    def test_injury_activity_row_links_to_injury_and_detail(self):
+        """Injury activity rows show a followable link to the injury detail, and
+        the activity itself links to its detail page (acceptance #2)."""
+        self._login_tp()
+        resp = self.url_open(f'/my/player?player_id={self.player.id}')
+        self.assertEqual(resp.status_code, 200)
+        # Injury column is a followable link to the injury detail.
+        self.assertIn(f'/my/injury/edit?injury_id={self.injury.id}', resp.text)
+        # Clicking the activity opens its detail page.
+        self.assertIn(f'/my/activity/{self.act_injury.id}', resp.text)
+
+    def test_inline_add_activity_header_present(self):
+        """An inline add-activity header (fields + button) lives in the tab and
+        posts to /my/activity/save against this player (acceptance #3)."""
+        self._login_tp()
+        resp = self.url_open(f'/my/player?player_id={self.player.id}')
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn('action="/my/activity/save"', resp.text)
+        self.assertIn('name="activity_type_id"', resp.text)
+        self.assertIn('name="summary"', resp.text)
+        self.assertIn('name="date_deadline"', resp.text)
+        self.assertIn('name="model" value="sports.patient"', resp.text)
+
+    def test_inline_add_activity_creates_activity(self):
+        """Posting the inline header creates the activity against the player."""
+        self._login_tp()
+        token = self._csrf()
+        resp = self.url_open('/my/activity/save', data={
+            'csrf_token': token,
+            'model': 'sports.patient',
+            'res_id': self.player.id,
+            'activity_type_id': self.env.ref('mail.mail_activity_data_todo').id,
+            'summary': 'Inline added activity',
+            'user_id': self.tp.id,
+            'date_deadline': fields.Date.today().strftime('%Y-%m-%d'),
+        })
+        self.assertIn(resp.status_code, (200, 302))
+        created = self.env['mail.activity'].search([
+            ('summary', '=', 'Inline added activity'),
+            ('res_model', '=', 'sports.patient'),
+            ('res_id', '=', self.player.id),
+        ])
+        self.assertTrue(
+            created, 'inline header should create the activity via /my/activity/save')
+
+    def test_old_top_activity_buttons_removed(self):
+        """The old top-of-page activity buttons are gone (acceptance #4).
+
+        The separate player-activities page link no longer appears anywhere on
+        the player detail page (nothing else on that page references it)."""
+        self._login_tp()
+        resp = self.url_open(f'/my/player?player_id={self.player.id}')
+        self.assertEqual(resp.status_code, 200)
+        self.assertNotIn('/my/player/activities', resp.text)
+
+    def test_injury_edit_has_activities_button(self):
+        """Injury detail (portal, edit) has a button linking to that injury's
+        activities list (acceptance #5)."""
+        self._login_tp()
+        resp = self.url_open(f'/my/injury/edit?injury_id={self.injury.id}')
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn(f'/my/injury/activities?injury_id={self.injury.id}', resp.text)
+
+    def test_player_activities_route_redirects_to_tab(self):
+        """The old /my/player/activities route redirects to the player page's
+        Activities tab anchor (back-compat)."""
+        self._login_tp()
+        resp = self.url_open(
+            f'/my/player/activities?player_id={self.player.id}',
+            allow_redirects=False,
+        )
+        self.assertIn(resp.status_code, (302, 303))
+        location = resp.headers.get('Location', '')
+        self.assertIn(f'/my/player?player_id={self.player.id}', location)
+        self.assertIn('activities', location)
+
+    def test_other_role_staffer_no_500_and_no_tab(self):
+        """A team staffer with role='other' holds neither portal group and has
+        NO mail.activity ACL, yet still reaches the player page via team-staff
+        access. The page must load (no 500 from an ungated mail.activity search)
+        and must NOT show the Activities tab."""
+        env = self.env
+        other_user = env['res.users'].with_context(no_reset_password=True).create({
+            'name': 'PC Other', 'login': 'pc.other@example.com', 'password': 'pc-other',
+            'group_ids': [Command.set([env.ref('base.group_portal').id])],
+        })
+        env['sports.team.staff'].create({
+            'team_id': self.team_a.id, 'partner_id': other_user.partner_id.id,
+            'role': 'other',
+        })
+        self.authenticate('pc.other@example.com', 'pc-other')
+        resp = self.url_open(f'/my/player?player_id={self.player.id}')
+        self.assertEqual(resp.status_code, 200,
+                         'player page must not 500 for an other-role staffer')
+        self.assertNotIn('id="activities-tab"', resp.text,
+                         'Activities tab must be hidden from non-TP/non-coach staff')
+
+    def test_injury_activity_scoped_to_visible_injuries(self):
+        """An activity on an injury the player does NOT own must never surface
+        on this player's Activities tab (team/record scoping preserved)."""
+        self._login_tp()
+        # act on player_b's injury context would be unrelated; build a foreign
+        # injury under the same accessible player set is not possible, so assert
+        # the unrelated team activity does not appear in this player's tab.
+        resp = self.url_open(f'/my/player?player_id={self.player.id}')
+        self.assertEqual(resp.status_code, 200)
+        self.assertNotIn('Team task', resp.text)
+        self.assertNotIn('Event task', resp.text)

--- a/bemade_sports_clinic/tests/test_portal_access.py
+++ b/bemade_sports_clinic/tests/test_portal_access.py
@@ -84,6 +84,7 @@ class TestPortalAccess(TransactionCase):
         self.assertFalse(user.active, "User should be inactive after revoking access")
         self.assertFalse(user.has_group('base.group_portal'), "User should not be in portal group")
         
-        # Computing portal access should now return false
-        staff.invalidate_recordset(['has_portal_access'])
-        self.assertFalse(staff.has_portal_access, "Staff should not have portal access after revoking it")
+        # The revoke purge DELETES the staff membership row (dev-review
+        # 2026-07-04): unarchiving the user later must not silently restore
+        # team access — re-adding the person to a team is explicit.
+        self.assertFalse(staff.exists(), "staff row must be deleted on portal revoke")

--- a/bemade_sports_clinic/tests/test_treatment_notes.py
+++ b/bemade_sports_clinic/tests/test_treatment_notes.py
@@ -121,6 +121,54 @@ class TestTreatmentNotes(TransactionCase):
         # Verify count
         self.assertEqual(self.patient.treatment_note_count, 3)
         
+    def test_author_initials_compute(self):
+        """Author initials are derived from the note author's name."""
+        note = self.env['sports.treatment.note'].create({
+            'patient_id': self.patient.id,
+            'note': 'Initials note',
+            'date': date.today(),
+            'user_id': self.user_therapist.id,
+        })
+        # "Test Therapist" -> "TT"
+        self.assertEqual(note.author_initials, 'TT')
+
+        single = self.env['res.users'].create({
+            'name': 'Madonna',
+            'login': 'test_madonna',
+            'email': 'madonna@example.com',
+            'group_ids': [(6, 0, [self.treatment_prof_group.id])],
+        })
+        note.user_id = single
+        self.assertEqual(note.author_initials, 'M')
+
+        triple = self.env['res.users'].create({
+            'name': 'Anne Marie Dubois',
+            'login': 'test_amd',
+            'email': 'amd@example.com',
+            'group_ids': [(6, 0, [self.treatment_prof_group.id])],
+        })
+        note.user_id = triple
+        # first + last token only
+        self.assertEqual(note.author_initials, 'AD')
+
+    def test_injury_form_has_no_treatment_notes_page(self):
+        """Treatment notes must no longer surface as a page on the injury form."""
+        view = self.env.ref(
+            'bemade_sports_clinic.sports_patient_injury_view_form')
+        arch = self.env['sports.patient.injury'].get_view(
+            view_id=view.id, view_type='form')['arch']
+        self.assertNotIn('treatment_note_ids', arch,
+                         "Injury form should not embed the treatment notes list.")
+
+    def test_search_view_filters(self):
+        """Standalone notes search supports injury/date filters and group-by injury."""
+        view = self.env.ref('bemade_sports_clinic.view_treatment_note_search')
+        arch = view.arch
+        self.assertIn('group_by_injury', arch)
+        self.assertIn('filter_injury_specific', arch)
+        self.assertIn('filter_general', arch)
+        self.assertIn('filter_recent', arch)
+
     def test_injury_treatment_note_count(self):
         """Test that injury only counts notes that are linked to it."""
         # Initial count should be zero

--- a/bemade_sports_clinic/tests/test_users.py
+++ b/bemade_sports_clinic/tests/test_users.py
@@ -8,6 +8,89 @@ class TestUsers(TransactionCase):
     def setUpClass(cls):
         super().setUpClass()
 
+    def _coach_partner_with_staff(self, role="head_coach"):
+        """Create a partner that is staff (coach role) on a team, with no user yet."""
+        partner = self.env["res.partner"].create(
+            {"name": f"Coach {role}", "email": f"coach_{role}@example.com"}
+        )
+        team = self.env["sports.team"].create({"name": f"Team {role}"})
+        staff = self.env["sports.team.staff"].create(
+            {"team_id": team.id, "partner_id": partner.id, "role": role}
+        )
+        return partner, team, staff
+
+    def test_create_portal_user_for_head_coach_gets_coach_group(self):
+        """Creating a portal user for an existing head-coach staff member must
+        grant the portal team-coach group (not only the therapist group)."""
+        partner, _team, _staff = self._coach_partner_with_staff("head_coach")
+        coach_group = self.env.ref("bemade_sports_clinic.group_portal_team_coach")
+        portal_group = self.env.ref("base.group_portal")
+
+        user = self.env["res.users"].with_context(no_reset_password=True).create(
+            {
+                "name": "Coach User",
+                "login": "coach_create",
+                "partner_id": partner.id,
+                "group_ids": [Command.set([portal_group.id])],
+            }
+        )
+        self.assertIn(
+            coach_group,
+            user.group_ids,
+            "portal user created for a head-coach staff member should be in the "
+            "portal team-coach group",
+        )
+
+    def test_grant_portal_access_to_head_coach_gets_coach_group(self):
+        """Granting portal access (write) to an existing head-coach staff
+        member must grant the portal team-coach group."""
+        partner, _team, _staff = self._coach_partner_with_staff("head_coach")
+        coach_group = self.env.ref("bemade_sports_clinic.group_portal_team_coach")
+        portal_group = self.env.ref("base.group_portal")
+
+        # User exists for the partner but has no portal access yet.
+        user = self.env["res.users"].with_context(no_reset_password=True).create(
+            {
+                "name": "Coach User",
+                "login": "coach_grant",
+                "partner_id": partner.id,
+                "group_ids": [Command.set([])],
+            }
+        )
+        self.assertNotIn(coach_group, user.group_ids)
+
+        user.write({"group_ids": [Command.link(portal_group.id)]})
+        self.assertIn(
+            coach_group,
+            user.group_ids,
+            "granting portal access to a head-coach staff member should add the "
+            "portal team-coach group",
+        )
+
+    def test_remove_head_coach_role_removes_coach_group(self):
+        """Demoting a head-coach staff member to a non-coach role must remove
+        the portal team-coach group from their portal user."""
+        partner, _team, staff = self._coach_partner_with_staff("head_coach")
+        coach_group = self.env.ref("bemade_sports_clinic.group_portal_team_coach")
+        portal_group = self.env.ref("base.group_portal")
+
+        user = self.env["res.users"].with_context(no_reset_password=True).create(
+            {
+                "name": "Coach User",
+                "login": "coach_demote",
+                "partner_id": partner.id,
+                "group_ids": [Command.set([portal_group.id])],
+            }
+        )
+        self.assertIn(coach_group, user.group_ids)
+
+        staff.write({"role": "other"})
+        self.assertNotIn(
+            coach_group,
+            user.group_ids,
+            "removing the coach role should drop the portal team-coach group",
+        )
+
     def test_add_team_access_to_user(self):
         user = self.env["res.users"].create(
             {

--- a/bemade_sports_clinic/views/events_portal_templates.xml
+++ b/bemade_sports_clinic/views/events_portal_templates.xml
@@ -451,6 +451,35 @@
                         </div>
                     </div>
 
+                    <!-- Quick filters (same set as the list view) + cancelled
+                         toggle. JS-driven: clicking refetches the feed
+                         without a page reload (dev-review 2026-07-04). -->
+                    <div class="row mb-2">
+                        <div class="col-12 d-flex flex-wrap align-items-center gap-2">
+                            <ul class="nav nav-pills" id="cal-quick-filters">
+                                <li class="nav-item">
+                                    <button type="button" t-attf-class="nav-link #{'active' if view_type == 'all' else ''}" data-view-type="all">All Events</button>
+                                </li>
+                                <li class="nav-item">
+                                    <button type="button" t-attf-class="nav-link #{'active' if view_type == 'my' else ''}" data-view-type="my">My Events</button>
+                                </li>
+                                <li class="nav-item">
+                                    <button type="button" t-attf-class="nav-link #{'active' if view_type == 'unassigned' else ''}" data-view-type="unassigned">Unassigned Events</button>
+                                </li>
+                                <t t-if="is_therapist">
+                                    <li class="nav-item">
+                                        <button type="button" t-attf-class="nav-link #{'active' if view_type == 'missing_timesheets' else ''}" data-view-type="missing_timesheets">Missing Timesheets</button>
+                                    </li>
+                                </t>
+                            </ul>
+                            <div class="form-check ms-auto">
+                                <input type="checkbox" class="form-check-input" id="cal-filter-show-cancelled"
+                                       t-att-checked="'checked' if show_cancelled else None"/>
+                                <label class="form-check-label" for="cal-filter-show-cancelled">Show cancelled events</label>
+                            </div>
+                        </div>
+                    </div>
+
                     <!-- List-style filters (team / organization / assigned /
                          date range). JS reads these and refetches the feed. -->
                     <div class="row mb-3">
@@ -559,6 +588,17 @@
                                     params += '&amp;' + key + '=' + encodeURIComponent(node.value);
                                 }
                             });
+                            // Quick filter (All / My / Unassigned / Missing Timesheets).
+                            var activePill = document.querySelector('#cal-quick-filters .nav-link.active');
+                            var viewType = activePill ? activePill.dataset.viewType : 'all';
+                            if (viewType &amp;&amp; viewType !== 'all') {
+                                params += '&amp;view_type=' + encodeURIComponent(viewType);
+                            }
+                            // Checkbox: send only when checked (its .value is constant).
+                            var showCancelled = document.getElementById('cal-filter-show-cancelled');
+                            if (showCancelled &amp;&amp; showCancelled.checked) {
+                                params += '&amp;show_cancelled=1';
+                            }
                             return params;
                         }
                         function fmtDate(d) {
@@ -621,9 +661,28 @@
                                 var link = popover.querySelector('[data-popover-link]');
                                 link.href = info.event.url || '#';
                                 var rect = info.el.getBoundingClientRect();
-                                popover.style.left = (window.scrollX + rect.left) + 'px';
-                                popover.style.top = (window.scrollY + rect.bottom + 4) + 'px';
+                                // Un-hide first so offsetWidth/offsetHeight are
+                                // measurable, then clamp within the viewport —
+                                // events near the right/bottom edges used to
+                                // push the popover off-screen.
                                 popover.classList.remove('d-none');
+                                var pw = popover.offsetWidth;
+                                var ph = popover.offsetHeight;
+                                var margin = 8;
+                                var left = window.scrollX + rect.left;
+                                var top = window.scrollY + rect.bottom + 4;
+                                var maxLeft = window.scrollX + document.documentElement.clientWidth - pw - margin;
+                                left = Math.max(window.scrollX + margin, Math.min(left, maxLeft));
+                                var maxTop = window.scrollY + document.documentElement.clientHeight - ph - margin;
+                                if (top > maxTop) {
+                                    // Prefer flipping above the event; clamp if that overflows too.
+                                    var above = window.scrollY + rect.top - ph - 4;
+                                    top = above >= window.scrollY + margin
+                                        ? above
+                                        : Math.max(window.scrollY + margin, maxTop);
+                                }
+                                popover.style.left = left + 'px';
+                                popover.style.top = top + 'px';
                             },
                         });
                         calendar.render();
@@ -634,6 +693,19 @@
                             if (node) {
                                 node.addEventListener('change', function () { calendar.refetchEvents(); });
                             }
+                        });
+                        var showCancelledNode = document.getElementById('cal-filter-show-cancelled');
+                        if (showCancelledNode) {
+                            showCancelledNode.addEventListener('change', function () { calendar.refetchEvents(); });
+                        }
+                        document.querySelectorAll('#cal-quick-filters .nav-link').forEach(function (pill) {
+                            pill.addEventListener('click', function () {
+                                document.querySelectorAll('#cal-quick-filters .nav-link').forEach(function (p) {
+                                    p.classList.remove('active');
+                                });
+                                pill.classList.add('active');
+                                calendar.refetchEvents();
+                            });
                         });
                     });
                 </script>

--- a/bemade_sports_clinic/views/events_portal_templates.xml
+++ b/bemade_sports_clinic/views/events_portal_templates.xml
@@ -432,16 +432,81 @@
                         </div>
                     </div>
 
+                    <!-- List-style filters (team / organization / assigned /
+                         date range). JS reads these and refetches the feed. -->
+                    <div class="row mb-3">
+                        <div class="col-12">
+                            <div class="o_portal_search_panel">
+                                <div class="row g-2 mb-2">
+                                    <div class="col-md-4">
+                                        <select id="cal-filter-organization" name="organization_id" class="form-select">
+                                            <option value="">All Organizations</option>
+                                            <t t-foreach="organizations" t-as="organization">
+                                                <option t-att-value="organization.id" t-att-selected="organization_id and organization_id == organization.id">
+                                                    <t t-esc="organization.name"/>
+                                                </option>
+                                            </t>
+                                        </select>
+                                    </div>
+                                    <div class="col-md-4">
+                                        <select id="cal-filter-team" name="team_id" class="form-select">
+                                            <option value="">All Teams</option>
+                                            <t t-foreach="teams" t-as="team">
+                                                <option t-att-value="team.id" t-att-selected="team_id and team_id == team.id">
+                                                    <t t-esc="team.name"/>
+                                                </option>
+                                            </t>
+                                        </select>
+                                    </div>
+                                    <div class="col-md-4">
+                                        <select id="cal-filter-assigned" name="assigned_user_id" class="form-select">
+                                            <option value="">All Assigned Professionals</option>
+                                            <t t-foreach="treatment_professionals" t-as="user">
+                                                <option t-att-value="user.id" t-att-selected="assigned_user_id and assigned_user_id == user.id">
+                                                    <t t-esc="user.name"/>
+                                                </option>
+                                            </t>
+                                        </select>
+                                    </div>
+                                </div>
+                                <div class="row g-2">
+                                    <div class="col-md-6">
+                                        <label for="cal-filter-date-from" class="form-label text-muted small">From Date</label>
+                                        <div class="input-group">
+                                            <input type="date" id="cal-filter-date-from" name="date_from" class="form-control" t-att-value="date_from"/>
+                                            <button type="button" class="btn btn-outline-secondary" title="Clear From Date"
+                                                    onclick="var n=document.getElementById('cal-filter-date-from'); n.value=''; n.dispatchEvent(new Event('change'));">
+                                                <i class="fa fa-times"/>
+                                            </button>
+                                        </div>
+                                    </div>
+                                    <div class="col-md-6">
+                                        <label for="cal-filter-date-to" class="form-label text-muted small">To Date</label>
+                                        <div class="input-group">
+                                            <input type="date" id="cal-filter-date-to" name="date_to" class="form-control" t-att-value="date_to"/>
+                                            <button type="button" class="btn btn-outline-secondary" title="Clear To Date"
+                                                    onclick="var n=document.getElementById('cal-filter-date-to'); n.value=''; n.dispatchEvent(new Event('change'));">
+                                                <i class="fa fa-times"/>
+                                            </button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
                     <div id="portal-events-calendar" style="min-height:600px;"/>
 
                     <div id="portal-events-calendar-popover" class="d-none position-absolute bg-white border rounded shadow p-3" style="z-index:1080;max-width:320px;">
-                        <h5 class="mb-1" data-popover-title=""/>
+                        <h5 class="mb-1 pe-4" data-popover-title=""/>
                         <div class="text-muted small mb-2" data-popover-when=""/>
+                        <div class="mb-1"><strong>Arrive by:</strong> <span data-popover-arrive=""/></div>
+                        <div class="mb-1"><strong>Venue:</strong> <span data-popover-venue=""/></div>
                         <div class="mb-1"><strong>Teams:</strong> <span data-popover-teams=""/></div>
                         <div class="mb-1"><strong>Assigned:</strong> <span data-popover-assigned=""/></div>
-                        <div class="mb-1"><strong>Status:</strong> <span data-popover-state=""/></div>
                         <a class="btn btn-primary btn-sm mt-2" data-popover-link="" href="#">Open event</a>
-                        <button type="button" class="btn-close position-absolute end-0 top-0 m-2" data-popover-close="">×</button>
+                        <!-- btn-close draws its own X glyph via CSS; no literal text node (avoids the doubled-X). -->
+                        <button type="button" class="btn-close position-absolute end-0 top-0 m-2" data-popover-close="" aria-label="Close"/>
                     </div>
                 </div>
 
@@ -456,6 +521,33 @@
                     document.addEventListener('DOMContentLoaded', function () {
                         var el = document.getElementById('portal-events-calendar');
                         if (!el || typeof FullCalendar === 'undefined') { return; }
+
+                        // IDs of the filter controls, keyed by the query param
+                        // the feed expects. Read on every fetch so the calendar
+                        // and list honor an identical filter set.
+                        var FILTER_IDS = {
+                            organization_id: 'cal-filter-organization',
+                            team_id: 'cal-filter-team',
+                            assigned_user_id: 'cal-filter-assigned',
+                            date_from: 'cal-filter-date-from',
+                            date_to: 'cal-filter-date-to'
+                        };
+                        function filterParams() {
+                            var params = '';
+                            Object.keys(FILTER_IDS).forEach(function (key) {
+                                var node = document.getElementById(FILTER_IDS[key]);
+                                if (node &amp;&amp; node.value) {
+                                    params += '&amp;' + key + '=' + encodeURIComponent(node.value);
+                                }
+                            });
+                            return params;
+                        }
+                        function fmtDate(d) {
+                            return d.toLocaleDateString([], { weekday: 'short', month: 'short', day: 'numeric' });
+                        }
+                        function fmtTime(d) {
+                            return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+                        }
 
                         var popover = document.getElementById('portal-events-calendar-popover');
                         function hidePopover() { popover.classList.add('d-none'); }
@@ -479,7 +571,8 @@
                             height: 'auto',
                             events: function (info, success, failure) {
                                 var url = '/my/events/calendar/data?start=' + encodeURIComponent(info.startStr)
-                                          + '&amp;end=' + encodeURIComponent(info.endStr);
+                                          + '&amp;end=' + encodeURIComponent(info.endStr)
+                                          + filterParams();
                                 fetch(url, { credentials: 'same-origin' })
                                     .then(function (r) { return r.json(); })
                                     .then(success)
@@ -488,13 +581,24 @@
                             eventClick: function (info) {
                                 info.jsEvent.preventDefault();
                                 var p = info.event.extendedProps || {};
-                                popover.querySelector('[data-popover-title]').textContent = info.event.title || '';
-                                var startStr = info.event.start ? info.event.start.toLocaleString() : '';
-                                var endStr = info.event.end ? ' - ' + info.event.end.toLocaleString() : '';
-                                popover.querySelector('[data-popover-when]').textContent = startStr + endStr;
+                                var ev = info.event;
+                                popover.querySelector('[data-popover-title]').textContent = ev.title || '';
+                                // Date once, then start–end times on one line.
+                                var whenStr = '';
+                                if (ev.start) {
+                                    whenStr = fmtDate(ev.start) + ', ' + fmtTime(ev.start);
+                                    if (ev.end) {
+                                        var sameDay = ev.start.toDateString() === ev.end.toDateString();
+                                        whenStr += ' – ' + (sameDay ? '' : fmtDate(ev.end) + ', ') + fmtTime(ev.end);
+                                    }
+                                }
+                                popover.querySelector('[data-popover-when]').textContent = whenStr;
+                                // 'Arrive by' = therapist start (time only).
+                                var arrive = p.therapist_start ? new Date(p.therapist_start) : null;
+                                popover.querySelector('[data-popover-arrive]').textContent = arrive ? fmtTime(arrive) : '—';
+                                popover.querySelector('[data-popover-venue]').textContent = p.venue || '—';
                                 popover.querySelector('[data-popover-teams]').textContent = (p.teams || []).join(', ') || '—';
                                 popover.querySelector('[data-popover-assigned]').textContent = (p.assigned || []).join(', ') || '—';
-                                popover.querySelector('[data-popover-state]').textContent = p.state || '';
                                 var link = popover.querySelector('[data-popover-link]');
                                 link.href = info.event.url || '#';
                                 var rect = info.el.getBoundingClientRect();
@@ -504,6 +608,14 @@
                             },
                         });
                         calendar.render();
+
+                        // Re-fetch events when any filter changes.
+                        Object.keys(FILTER_IDS).forEach(function (key) {
+                            var node = document.getElementById(FILTER_IDS[key]);
+                            if (node) {
+                                node.addEventListener('change', function () { calendar.refetchEvents(); });
+                            }
+                        });
                     });
                 </script>
             </t>

--- a/bemade_sports_clinic/views/events_portal_templates.xml
+++ b/bemade_sports_clinic/views/events_portal_templates.xml
@@ -25,8 +25,11 @@
                         <div class="col-12">
                             <ul class="nav nav-pills">
                                 <li class="nav-item">
-                                    <a t-attf-class="nav-link #{'active' if view_type == 'all' else ''}" 
-                                       t-attf-href="/my/events?view_type=all#{project_id and '&amp;project_id=%s' % project_id or ''}#{assigned_user_id and '&amp;assigned_user_id=%s' % assigned_user_id or ''}#{date_from and '&amp;date_from=%s' % date_from or ''}#{date_to and '&amp;date_to=%s' % date_to or ''}#{group_by and '&amp;group_by=%s' % group_by or ''}#{sortby and '&amp;sortby=%s' % sortby or ''}#{no_default_dates and '&amp;no_default_dates=1' or ''}">
+                                    <!-- "All Events" deliberately omits assigned_user_id so switching
+                                         back from "My Events" clears the per-user filter and shows the
+                                         full accessible list (task 1226). -->
+                                    <a t-attf-class="nav-link #{'active' if view_type == 'all' else ''}"
+                                       t-attf-href="/my/events?view_type=all#{project_id and '&amp;project_id=%s' % project_id or ''}#{date_from and '&amp;date_from=%s' % date_from or ''}#{date_to and '&amp;date_to=%s' % date_to or ''}#{group_by and '&amp;group_by=%s' % group_by or ''}#{sortby and '&amp;sortby=%s' % sortby or ''}#{no_default_dates and '&amp;no_default_dates=1' or ''}">
                                         All Events
                                     </a>
                                 </li>

--- a/bemade_sports_clinic/views/events_portal_templates.xml
+++ b/bemade_sports_clinic/views/events_portal_templates.xml
@@ -144,6 +144,22 @@
                                         </div>
                                     </div>
                                 </div>
+
+                                <!-- Show cancelled toggle (task 1235): cancelled events are
+                                     hidden by default; check this to bring them back. -->
+                                <div class="row g-2 mt-1">
+                                    <div class="col-12">
+                                        <div class="form-check">
+                                            <input type="checkbox" class="form-check-input" id="show_cancelled"
+                                                   name="show_cancelled" value="1"
+                                                   t-att-checked="'checked' if show_cancelled else None"
+                                                   onchange="this.form.submit();"/>
+                                            <label class="form-check-label text-muted small" for="show_cancelled">
+                                                Show cancelled events
+                                            </label>
+                                        </div>
+                                    </div>
+                                </div>
                             </form>
                         </div>
                     </div>

--- a/bemade_sports_clinic/views/injury_management_portal_templates.xml
+++ b/bemade_sports_clinic/views/injury_management_portal_templates.xml
@@ -32,13 +32,20 @@
                                         <a t-att-href="return_url" class="btn bg-o-color-2 text-white">
                                             <i class="fa fa-times"></i> Cancel
                                         </a>
-                                        <button type="submit" class="btn bg-o-color-1 text-white">
-                                            <i class="fa fa-save"></i> Save Changes
-                                        </button>
+                                        <div class="d-flex gap-2">
+                                            <!-- Backlink to this injury's activities list (task 1222) -->
+                                            <a t-attf-href="/my/injury/activities?injury_id={{ injury.id }}{{ ('&amp;team_id=%s' % team_context_id) if team_context_id else '' }}"
+                                               class="btn bg-o-color-2 text-white">
+                                                <i class="fa fa-tasks"></i> Activities
+                                            </a>
+                                            <button type="submit" class="btn bg-o-color-1 text-white">
+                                                <i class="fa fa-save"></i> Save Changes
+                                            </button>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
-                            
+
                             <!-- Injury Details Section -->
                             <div class="card mb-4">
                                 <div class="card-header bg-primary text-white">

--- a/bemade_sports_clinic/views/injury_management_portal_templates.xml
+++ b/bemade_sports_clinic/views/injury_management_portal_templates.xml
@@ -363,7 +363,7 @@
                                 </h4>
                             </div>
                             <div class="card-body p-0">
-                                <div class="table-responsive">
+                                <div class="table-responsive o_sc_notes_table">
                                     <table class="table table-striped mb-0">
                                         <thead>
                                             <tr>
@@ -397,7 +397,11 @@
                                                         </t>
                                                     </td>
                                                     <td>
-                                                        <p t-field="note.note" style="margin: 0; line-height: 1.35;"/>
+                                                        <!-- One <p> per line: wraps normally, ~1.5-line
+                                                             gap between paragraphs. -->
+                                                        <t t-foreach="(note.note or '').splitlines()" t-as="note_line">
+                                                            <p t-if="note_line.strip()" style="margin: 0 0 0.5em 0; line-height: 1.35;" t-esc="note_line"/>
+                                                        </t>
                                                     </td>
                                                 </tr>
                                             </t>

--- a/bemade_sports_clinic/views/injury_management_portal_templates.xml
+++ b/bemade_sports_clinic/views/injury_management_portal_templates.xml
@@ -360,9 +360,9 @@
                                     <table class="table table-striped mb-0">
                                         <thead>
                                             <tr>
-                                                <th>Date</th>
-                                                <th>Author</th>
-                                                <th>Related To</th>
+                                                <th style="width: 7rem;">Date</th>
+                                                <th style="width: 4rem;" class="text-center">By</th>
+                                                <th style="width: 12rem;">Related To</th>
                                                 <th>Note</th>
                                             </tr>
                                         </thead>
@@ -373,7 +373,11 @@
                                             <t t-foreach="notes" t-as="note">
                                                 <tr>
                                                     <td><span t-field="note.date"/></td>
-                                                    <td><span t-field="note.user_id.name"/></td>
+                                                    <td class="text-center">
+                                                        <span class="badge text-bg-light border"
+                                                              t-att-title="note.user_id.name"
+                                                              t-esc="note.author_initials"/>
+                                                    </td>
                                                     <td>
                                                         <t t-if="note.injury_id">
                                                             <a t-att-href="'/my/injury/edit?injury_id=%s' % note.injury_id.id">
@@ -386,7 +390,7 @@
                                                         </t>
                                                     </td>
                                                     <td>
-                                                        <p t-field="note.note" style="white-space: pre-wrap;"/>
+                                                        <p t-field="note.note" style="white-space: pre-wrap; margin: 0; line-height: 1.35;"/>
                                                     </td>
                                                 </tr>
                                             </t>

--- a/bemade_sports_clinic/views/injury_management_portal_templates.xml
+++ b/bemade_sports_clinic/views/injury_management_portal_templates.xml
@@ -382,6 +382,7 @@
                                                     <td><span t-field="note.date"/></td>
                                                     <td class="text-center">
                                                         <span class="badge text-bg-light border" style="cursor: help;"
+                                                              data-bs-toggle="tooltip"
                                                               t-att-title="note.sudo().user_id.name"
                                                               t-esc="note.author_initials"/>
                                                     </td>
@@ -409,9 +410,19 @@
                     </div>
                 </div>
             </div>
+            <!-- Instant author-name tooltips on the initials badges -->
+            <script type="text/javascript">
+                document.addEventListener('DOMContentLoaded', function () {
+                    if (typeof bootstrap !== 'undefined') {
+                        document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(function (el) {
+                            new bootstrap.Tooltip(el);
+                        });
+                    }
+                });
+            </script>
         </t>
     </template>
-    
+
     <!-- Template for managing documents -->
     <template id="portal_injury_documents" name="Injury Documents">
         <t t-call="portal.portal_layout">

--- a/bemade_sports_clinic/views/injury_management_portal_templates.xml
+++ b/bemade_sports_clinic/views/injury_management_portal_templates.xml
@@ -381,9 +381,8 @@
                                                 <tr>
                                                     <td><span t-field="note.date"/></td>
                                                     <td class="text-center">
-                                                        <span class="badge text-bg-light border" style="cursor: help;"
-                                                              data-bs-toggle="tooltip"
-                                                              t-att-title="note.sudo().user_id.name"
+                                                        <span class="badge text-bg-light border o_sc_note_author"
+                                                              t-att-data-author="note.sudo().user_id.name"
                                                               t-esc="note.author_initials"/>
                                                     </td>
                                                     <td>
@@ -410,16 +409,6 @@
                     </div>
                 </div>
             </div>
-            <!-- Instant author-name tooltips on the initials badges -->
-            <script type="text/javascript">
-                document.addEventListener('DOMContentLoaded', function () {
-                    if (typeof bootstrap !== 'undefined') {
-                        document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(function (el) {
-                            new bootstrap.Tooltip(el);
-                        });
-                    }
-                });
-            </script>
         </t>
     </template>
 

--- a/bemade_sports_clinic/views/injury_management_portal_templates.xml
+++ b/bemade_sports_clinic/views/injury_management_portal_templates.xml
@@ -381,8 +381,8 @@
                                                 <tr>
                                                     <td><span t-field="note.date"/></td>
                                                     <td class="text-center">
-                                                        <span class="badge text-bg-light border"
-                                                              t-att-title="note.user_id.name"
+                                                        <span class="badge text-bg-light border" style="cursor: help;"
+                                                              t-att-title="note.sudo().user_id.name"
                                                               t-esc="note.author_initials"/>
                                                     </td>
                                                     <td>
@@ -397,7 +397,7 @@
                                                         </t>
                                                     </td>
                                                     <td>
-                                                        <p t-field="note.note" style="white-space: pre-wrap; margin: 0; line-height: 1.35;"/>
+                                                        <p t-field="note.note" style="margin: 0; line-height: 1.35;"/>
                                                     </td>
                                                 </tr>
                                             </t>

--- a/bemade_sports_clinic/views/portal_event_detail_template.xml
+++ b/bemade_sports_clinic/views/portal_event_detail_template.xml
@@ -35,8 +35,8 @@
                         </div>
                     </t>
 
-                    <!-- Add Timesheet Modal -->
-                    <t t-if="can_edit">
+                    <!-- Add Timesheet Modal: only for TPs assigned to this event -->
+                    <t t-if="can_add_timesheet">
                         <div class="modal fade" id="addTimesheetModal" tabindex="-1" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -91,14 +91,14 @@
                                        class="btn bg-o-color-2 text-white">
                                         <i class="fa fa-tasks"></i> Add Activity
                                     </a>
+                                    <!-- Add My Timesheet: only for TPs assigned to this event -->
+                                    <button t-if="can_add_timesheet" type="button" class="btn btn-success" data-bs-toggle="modal" data-bs-target="#addTimesheetModal">
+                                        <i class="fa fa-clock-o"/> Add My Timesheet
+                                    </button>
                                     <t t-if="can_edit">
                                         <a t-att-href="('/my/event/%s/edit' % event.id) + (return_url and ('?return_url=%s' % return_url) or '')" class="btn btn-primary">
                                             <i class="fa fa-edit"/> Edit Event
                                         </a>
-                                        <!-- Add My Timesheet button -->
-                                        <button type="button" class="btn btn-success" data-bs-toggle="modal" data-bs-target="#addTimesheetModal">
-                                            <i class="fa fa-clock-o"/> Add My Timesheet
-                                        </button>
                                         <t t-if="event.state not in ['cancelled', 'invoiced']">
                                             <button type="button" class="btn btn-danger" data-bs-toggle="modal" data-bs-target="#cancelEventModal">
                                                 <i class="fa fa-times"/> Cancel Event
@@ -149,7 +149,7 @@
                                         </li>
                                         <li class="nav-item" role="presentation" t-if="can_view_timesheets">
                                             <button class="nav-link" id="tab-timesheets-tab" data-bs-toggle="tab" data-bs-target="#tab-timesheets" type="button" role="tab" aria-controls="tab-timesheets" aria-selected="false">
-                                                <i class="fa fa-clock-o"/> Timesheets
+                                                <i class="fa fa-clock-o"/> My Timesheets
                                             </button>
                                         </li>
                                     </ul>
@@ -250,7 +250,9 @@
 
                                     <div class="tab-pane fade" id="tab-timesheets" role="tabpanel" aria-labelledby="tab-timesheets-tab" t-if="can_view_timesheets">
                                         <!-- One2many reads include archived rows; only show active (non-soft-deleted) timesheets. -->
-                                        <t t-set="visible_timesheets" t-value="event.timesheet_ids.filtered('active')"/>
+                                        <!-- Confidentiality: TPs see only their OWN timesheets;
+                                             system admins keep the full event view. -->
+                                        <t t-set="visible_timesheets" t-value="event.timesheet_ids.filtered(lambda t: t.active and (show_all_timesheets or t.user_id.id == request.env.user.id))"/>
                                         <t t-if="visible_timesheets">
                                             <div class="table-responsive">
                                                 <table class="table table-sm align-middle">

--- a/bemade_sports_clinic/views/portal_event_detail_template.xml
+++ b/bemade_sports_clinic/views/portal_event_detail_template.xml
@@ -165,14 +165,7 @@
                                                         <t t-esc="dict(event._fields['event_type'].selection).get(event.event_type, event.event_type)"/>
                                                     </span>
                                                 </dd>
-                                                
-                                                <dt class="col-sm-4">Status:</dt>
-                                                <dd class="col-sm-8">
-                                                    <span t-attf-class="badge #{event.state == 'invoiced' and 'bg-success' or event.state == 'cancelled' and 'bg-danger' or event.state == 'to_invoice' and 'bg-warning' or 'bg-secondary'}">
-                                                        <t t-esc="dict(event._fields['state'].selection).get(event.state, event.state)"/>
-                                                    </span>
-                                                </dd>
-                                                
+
                                                 <dt class="col-sm-4">Teams:</dt>
                                                 <dd class="col-sm-8">
                                                     <i class="fa fa-users"/>

--- a/bemade_sports_clinic/views/portal_event_detail_template.xml
+++ b/bemade_sports_clinic/views/portal_event_detail_template.xml
@@ -256,7 +256,9 @@
                                     </div>
 
                                     <div class="tab-pane fade" id="tab-timesheets" role="tabpanel" aria-labelledby="tab-timesheets-tab" t-if="can_view_timesheets">
-                                        <t t-if="event.timesheet_ids">
+                                        <!-- One2many reads include archived rows; only show active (non-soft-deleted) timesheets. -->
+                                        <t t-set="visible_timesheets" t-value="event.timesheet_ids.filtered('active')"/>
+                                        <t t-if="visible_timesheets">
                                             <div class="table-responsive">
                                                 <table class="table table-sm align-middle">
                                                     <thead>
@@ -272,7 +274,7 @@
                                                         </tr>
                                                     </thead>
                                                     <tbody>
-                                                        <t t-foreach="event.timesheet_ids" t-as="ts">
+                                                        <t t-foreach="visible_timesheets" t-as="ts">
                                                             <tr>
                                                                 <td><span t-esc="ts.user_id.name"/></td>
                                                                 <td class="text-nowrap"><span t-esc="ts.travel_start" t-options="{'widget': 'datetime'}"/></td>
@@ -286,6 +288,9 @@
                                                                         <button type="button" class="btn btn-sm btn-outline-primary" data-bs-toggle="modal" t-attf-data-bs-target="#editTs{{ ts.id }}">
                                                                             <i class="fa fa-edit"/> Edit
                                                                         </button>
+                                                                        <button type="button" class="btn btn-sm btn-outline-danger" data-bs-toggle="modal" t-attf-data-bs-target="#deleteTs{{ ts.id }}">
+                                                                            <i class="fa fa-trash"/> Delete
+                                                                        </button>
                                                                     </t>
                                                                 </td>
                                                             </tr>
@@ -295,7 +300,7 @@
                                             </div>
 
                                             <!-- Edit modals (active user's timesheets only) -->
-                                            <t t-foreach="event.timesheet_ids.filtered(lambda t: t.user_id.id == request.env.user.id and t.state != 'invoiced')" t-as="ts">
+                                            <t t-foreach="visible_timesheets.filtered(lambda t: t.user_id.id == request.env.user.id and t.state != 'invoiced')" t-as="ts">
                                                 <div t-attf-id="editTs{{ ts.id }}" class="modal fade" tabindex="-1" aria-hidden="true">
                                                     <div class="modal-dialog">
                                                         <div class="modal-content">
@@ -335,8 +340,34 @@
                                                     </div>
                                                 </div>
                                             </t>
+
+                                            <!-- Delete confirmation modals (active user's timesheets only) -->
+                                            <t t-foreach="visible_timesheets.filtered(lambda t: t.user_id.id == request.env.user.id and t.state != 'invoiced')" t-as="ts">
+                                                <div t-attf-id="deleteTs{{ ts.id }}" class="modal fade" tabindex="-1" aria-hidden="true">
+                                                    <div class="modal-dialog">
+                                                        <div class="modal-content">
+                                                            <form t-attf-action="/my/sc/timesheet/{{ ts.id }}/delete" method="post">
+                                                                <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+                                                                <input type="hidden" name="return_url" t-att-value="event_return_url + '#tab-timesheets'"/>
+                                                                <div class="modal-header">
+                                                                    <h5 class="modal-title">Delete Timesheet</h5>
+                                                                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                                                                </div>
+                                                                <div class="modal-body">
+                                                                    <p>Are you sure you want to delete your timesheet for
+                                                                        <strong t-esc="event.name or 'this event'"/>? This cannot be undone from the portal.</p>
+                                                                </div>
+                                                                <div class="modal-footer">
+                                                                    <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                                                                    <button type="submit" class="btn btn-danger"><i class="fa fa-trash"/> Delete</button>
+                                                                </div>
+                                                            </form>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </t>
                                         </t>
-                                        <t t-if="not event.timesheet_ids">
+                                        <t t-if="not visible_timesheets">
                                             <p class="text-muted mb-0">No timesheets yet.</p>
                                         </t>
                                     </div>

--- a/bemade_sports_clinic/views/portal_timesheets_templates.xml
+++ b/bemade_sports_clinic/views/portal_timesheets_templates.xml
@@ -184,6 +184,9 @@
                   <button t-if="ts.state != 'invoiced'" class="btn btn-sm btn-outline-primary" data-bs-toggle="modal" t-attf-data-bs-target="#editTs{{ ts.id }}">
                     <i class="fa fa-pencil"/> Edit
                   </button>
+                  <button t-if="ts.state != 'invoiced' and ts.user_id.id == request.env.user.id" class="btn btn-sm btn-outline-danger" data-bs-toggle="modal" t-attf-data-bs-target="#deleteTs{{ ts.id }}">
+                    <i class="fa fa-trash"/> Delete
+                  </button>
                   <button t-if="ts.state == 'invoiced'" class="btn btn-sm btn-outline-secondary" disabled="disabled" title="Invoiced (read-only)">
                     <i class="fa fa-lock"/> Locked
                   </button>
@@ -254,6 +257,29 @@
               <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
                 <button type="submit" class="btn bg-o-color-1 text-white"><i class="fa fa-save"/> Save</button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+
+      <!-- Delete Confirmation Modal -->
+      <div t-if="ts.state != 'invoiced' and ts.user_id.id == request.env.user.id" t-attf-id="deleteTs{{ ts.id }}" class="modal fade" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
+          <div class="modal-content">
+            <form t-attf-action="/my/sc/timesheet/{{ ts.id }}/delete" method="post">
+              <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+              <div class="modal-header">
+                <h5 class="modal-title">Delete Timesheet</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+              </div>
+              <div class="modal-body">
+                <p>Are you sure you want to delete this timesheet for
+                  <strong t-esc="ts.event_id.name or 'this event'"/>? This cannot be undone from the portal.</p>
+              </div>
+              <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="submit" class="btn btn-danger"><i class="fa fa-trash"/> Delete</button>
               </div>
             </form>
           </div>

--- a/bemade_sports_clinic/views/sports_clinic_portal_views.xml
+++ b/bemade_sports_clinic/views/sports_clinic_portal_views.xml
@@ -1745,6 +1745,7 @@
 
                                 <t t-if="treatment_notes">
                                     <t t-call="portal.portal_table">
+                                        <t t-set="classes">o_sc_notes_table</t>
                                         <thead>
                                             <tr>
                                                 <th style="width: 7rem;">Date</th>
@@ -1774,7 +1775,11 @@
                                                         </t>
                                                     </td>
                                                     <td>
-                                                        <p t-field="note.note" style="margin: 0; line-height: 1.35;"/>
+                                                        <!-- One <p> per line: wraps normally, ~1.5-line
+                                                             gap between paragraphs. -->
+                                                        <t t-foreach="(note.note or '').splitlines()" t-as="note_line">
+                                                            <p t-if="note_line.strip()" style="margin: 0 0 0.5em 0; line-height: 1.35;" t-esc="note_line"/>
+                                                        </t>
                                                     </td>
                                                 </tr>
                                             </t>

--- a/bemade_sports_clinic/views/sports_clinic_portal_views.xml
+++ b/bemade_sports_clinic/views/sports_clinic_portal_views.xml
@@ -1758,9 +1758,8 @@
                                                 <tr>
                                                     <td><span t-field="note.date"/></td>
                                                     <td class="text-center">
-                                                        <span class="badge text-bg-light border" style="cursor: help;"
-                                                              data-bs-toggle="tooltip"
-                                                              t-att-title="note.sudo().user_id.name"
+                                                        <span class="badge text-bg-light border o_sc_note_author"
+                                                              t-att-data-author="note.sudo().user_id.name"
                                                               t-esc="note.author_initials"/>
                                                     </td>
                                                     <td>
@@ -1786,16 +1785,6 @@
                                     <i class="fa fa-clipboard-list fa-3x mb-3"/>
                                     <p>No treatment notes recorded</p>
                                 </div>
-                                <!-- Instant author-name tooltips on the initials badges -->
-                                <script type="text/javascript">
-                                    document.addEventListener('DOMContentLoaded', function () {
-                                        if (typeof bootstrap !== 'undefined') {
-                                            document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(function (el) {
-                                                new bootstrap.Tooltip(el);
-                                            });
-                                        }
-                                    });
-                                </script>
                             </div>
 
                             <!-- Activities Tab (task 1222): player's own + its

--- a/bemade_sports_clinic/views/sports_clinic_portal_views.xml
+++ b/bemade_sports_clinic/views/sports_clinic_portal_views.xml
@@ -1669,9 +1669,9 @@
                                     <t t-call="portal.portal_table">
                                         <thead>
                                             <tr>
-                                                <th>Date</th>
-                                                <th>Author</th>
-                                                <th>Related To</th>
+                                                <th style="width: 7rem;">Date</th>
+                                                <th style="width: 4rem;" class="text-center">By</th>
+                                                <th style="width: 12rem;">Related To</th>
                                                 <th>Note</th>
                                             </tr>
                                         </thead>
@@ -1679,7 +1679,11 @@
                                             <t t-foreach="treatment_notes" t-as="note">
                                                 <tr>
                                                     <td><span t-field="note.date"/></td>
-                                                    <td><span t-field="note.user_id.name"/></td>
+                                                    <td class="text-center">
+                                                        <span class="badge text-bg-light border"
+                                                              t-att-title="note.user_id.name"
+                                                              t-esc="note.author_initials"/>
+                                                    </td>
                                                     <td>
                                                         <t t-if="note.injury_id">
                                                             <a t-attf-href="/my/injury/edit?injury_id={{ note.injury_id.id }}">
@@ -1692,7 +1696,7 @@
                                                         </t>
                                                     </td>
                                                     <td>
-                                                        <p t-field="note.note" style="white-space: pre-wrap;margin:0;"/>
+                                                        <p t-field="note.note" style="white-space: pre-wrap; margin: 0; line-height: 1.35;"/>
                                                     </td>
                                                 </tr>
                                             </t>

--- a/bemade_sports_clinic/views/sports_clinic_portal_views.xml
+++ b/bemade_sports_clinic/views/sports_clinic_portal_views.xml
@@ -1118,14 +1118,9 @@
                             data-bs-toggle="modal" t-attf-data-bs-target="#requestRemovalModal{{ player.id }}">
                         <i class="fa fa-user-times"></i> Request Removal
                     </button>
-                    <a t-if="request.env.user.has_group('bemade_sports_clinic.group_portal_treatment_professional') or request.env.user.has_group('bemade_sports_clinic.group_portal_team_coach')"
-                       t-att-href="team_context_id and ('/my/player/activities?player_id=%s&amp;team_id=%s' % (player.id, team_context_id)) or ('/my/player/activities?player_id=%s' % player.id)"
-                       class="btn bg-o-color-2 text-white">
-                        <i class="fa fa-tasks"></i> Activities
-                    </a>
-                    <a t-if="request.env.user.has_group('bemade_sports_clinic.group_portal_treatment_professional') or request.env.user.has_group('bemade_sports_clinic.group_portal_team_coach')" t-att-href="team_context_id and ('/my/activity/create?model=sports.patient&amp;res_id=%s&amp;team_id=%s&amp;return_url=/my/player?player_id=%s&amp;team_id=%s' % (player.id, team_context_id, player.id, team_context_id)) or ('/my/activity/create?model=sports.patient&amp;res_id=%s&amp;return_url=/my/player?player_id=%s' % (player.id, player.id))" class="btn bg-o-color-2 text-white">
-                        <i class="fa fa-tasks"></i> Add Activity
-                    </a>
+                    <!-- Activity buttons removed (task 1222): the player's and its
+                         injuries' activities now live in the Activities tab below,
+                         with an inline add header. -->
                 </div>
 
                 <!-- Therapist: Direct Remove Modal -->
@@ -1290,6 +1285,15 @@
                                     <i class="fa fa-clipboard-list"></i> Notes
                                     <span class="badge badge-pill badge-secondary ms-1" t-if="treatment_notes">
                                         <t t-esc="len(treatment_notes)"/>
+                                    </span>
+                                </button>
+                            </li>
+                            <li class="nav-item" role="presentation"
+                                t-if="is_treatment_prof or request.env.user.has_group('bemade_sports_clinic.group_portal_team_coach')">
+                                <button class="nav-link" id="activities-tab" data-bs-toggle="tab" data-bs-target="#activities" type="button" role="tab" aria-controls="activities" aria-selected="false">
+                                    <i class="fa fa-tasks"></i> Activities
+                                    <span class="badge badge-pill badge-secondary ms-1" t-if="player_activities">
+                                        <t t-esc="len(player_activities)"/>
                                     </span>
                                 </button>
                             </li>
@@ -1702,6 +1706,110 @@
                                 <div t-else="" class="text-center text-muted py-4">
                                     <i class="fa fa-clipboard-list fa-3x mb-3"/>
                                     <p>No treatment notes recorded</p>
+                                </div>
+                            </div>
+
+                            <!-- Activities Tab (task 1222): player's own + its
+                                 injuries' activities, with an inline add header. -->
+                            <div class="tab-pane fade" id="activities" role="tabpanel" aria-labelledby="activities-tab"
+                                 t-if="is_treatment_prof or request.env.user.has_group('bemade_sports_clinic.group_portal_team_coach')">
+                                <!-- Inline add-activity header (mirrors Docs/Notes) -->
+                                <div class="card mb-3">
+                                    <div class="card-header">
+                                        <i class="fa fa-tasks"/> Add Activity
+                                    </div>
+                                    <div class="card-body">
+                                        <form action="/my/activity/save" method="post">
+                                            <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+                                            <input type="hidden" name="model" value="sports.patient"/>
+                                            <input type="hidden" name="res_id" t-att-value="player.id"/>
+                                            <input type="hidden" name="return_url" t-att-value="activities_tab_return"/>
+                                            <input type="hidden" name="team_id" t-if="team_context_id" t-att-value="team_context_id"/>
+                                            <div class="row g-3">
+                                                <div class="col-md-4">
+                                                    <label class="form-label">Activity Type <span class="text-danger">*</span></label>
+                                                    <select name="activity_type_id" class="form-select" required="required">
+                                                        <t t-foreach="activity_types" t-as="atype">
+                                                            <option t-att-value="atype.id"
+                                                                    t-att-selected="'selected' if (default_activity_type and atype.id == default_activity_type.id) else None"
+                                                                    t-esc="atype.name"/>
+                                                        </t>
+                                                    </select>
+                                                </div>
+                                                <div class="col-md-4">
+                                                    <label class="form-label">Summary <span class="text-danger">*</span></label>
+                                                    <input type="text" name="summary" class="form-control" required="required"
+                                                           placeholder="Brief description of the activity"/>
+                                                </div>
+                                                <div class="col-md-4">
+                                                    <label class="form-label">Due Date <span class="text-danger">*</span></label>
+                                                    <input type="date" name="date_deadline" class="form-control" required="required"
+                                                           t-att-min="today" t-att-value="today"/>
+                                                </div>
+                                                <div class="col-md-8">
+                                                    <label class="form-label">Assigned To <span class="text-danger">*</span></label>
+                                                    <select name="user_id" class="form-select" required="required">
+                                                        <t t-foreach="assignable_users" t-as="au">
+                                                            <option t-att-value="au.id"
+                                                                    t-att-selected="'selected' if au.id == request.env.user.id else None"
+                                                                    t-esc="au.name"/>
+                                                        </t>
+                                                    </select>
+                                                </div>
+                                                <div class="col-12 d-flex justify-content-end">
+                                                    <button type="submit" class="btn bg-o-color-1 text-white">
+                                                        <i class="fa fa-plus"/> Add Activity
+                                                    </button>
+                                                </div>
+                                            </div>
+                                        </form>
+                                    </div>
+                                </div>
+
+                                <t t-if="player_activities">
+                                    <t t-call="portal.portal_table">
+                                        <thead>
+                                            <tr>
+                                                <th>Due Date</th>
+                                                <th>Activity</th>
+                                                <th>Summary</th>
+                                                <th>Injury</th>
+                                                <th>Assigned To</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            <t t-foreach="player_activities" t-as="activity">
+                                                <tr>
+                                                    <td><span t-field="activity.date_deadline" t-options="{'widget': 'date'}"/></td>
+                                                    <td><span t-field="activity.activity_type_id"/></td>
+                                                    <td>
+                                                        <a t-attf-href="/my/activity/{{ activity.id }}">
+                                                            <span t-field="activity.summary"/>
+                                                        </a>
+                                                    </td>
+                                                    <td>
+                                                        <t t-if="activity.res_model == 'sports.patient.injury'">
+                                                            <t t-set="row_injury" t-value="injuries.filtered(lambda i: i.id == activity.res_id)"/>
+                                                            <a t-if="row_injury"
+                                                               t-attf-href="/my/injury/edit?injury_id={{ activity.res_id }}{{ ('&amp;team_id=%s' % team_context_id) if team_context_id else '' }}">
+                                                                <span class="badge text-bg-info me-1">Injury</span>
+                                                                <t t-esc="row_injury.diagnosis or 'Injury'"/>
+                                                            </a>
+                                                            <span t-else="" class="text-muted">—</span>
+                                                        </t>
+                                                        <t t-else="">
+                                                            <span class="text-muted">—</span>
+                                                        </t>
+                                                    </td>
+                                                    <td><span t-field="activity.user_id"/></td>
+                                                </tr>
+                                            </t>
+                                        </tbody>
+                                    </t>
+                                </t>
+                                <div t-else="" class="text-center text-muted py-4">
+                                    <i class="fa fa-tasks fa-3x mb-3"/>
+                                    <p>No activities recorded</p>
                                 </div>
                             </div>
 

--- a/bemade_sports_clinic/views/sports_clinic_portal_views.xml
+++ b/bemade_sports_clinic/views/sports_clinic_portal_views.xml
@@ -985,10 +985,9 @@
 
 
 
-                <!-- Can the current user see/use the team Activities tab?
-                     Treatment professionals (and admins) and team coaches. -->
-                <t t-set="can_view_activities"
-                   t-value="request.env.user.has_group('bemade_sports_clinic.group_portal_treatment_professional') or request.env.user.has_group('base.group_system') or request.env.user.has_group('bemade_sports_clinic.group_portal_team_coach')"/>
+                <!-- can_view_activities comes from the controller (it also
+                     gates the mail.activity fetches — roles without the ACL,
+                     e.g. staff role 'other', would 403 otherwise). -->
 
                 <!-- Tabbed view: Players (roster) and Activities (team-level only, task 1223) -->
                 <ul class="nav nav-tabs mb-3" role="tablist">
@@ -1029,6 +1028,11 @@
                                     <div class="col-12 col-lg-8">
                                         <t t-set="is_team_view" t-value="True"/>
                                         <t t-set="show_player_activities" t-value="False"/>
+                                        <!-- Team roster: the viewer staffs this team
+                                             (_check_team_access), so every player is
+                                             openable — without this flag the 1225 card
+                                             renders no link at all. -->
+                                        <t t-set="accessible" t-value="True"/>
                                         <t t-call="bemade_sports_clinic.portal_patient_card"/>
                                     </div>
                                 </t>
@@ -1755,6 +1759,7 @@
                                                     <td><span t-field="note.date"/></td>
                                                     <td class="text-center">
                                                         <span class="badge text-bg-light border" style="cursor: help;"
+                                                              data-bs-toggle="tooltip"
                                                               t-att-title="note.sudo().user_id.name"
                                                               t-esc="note.author_initials"/>
                                                     </td>
@@ -1781,6 +1786,16 @@
                                     <i class="fa fa-clipboard-list fa-3x mb-3"/>
                                     <p>No treatment notes recorded</p>
                                 </div>
+                                <!-- Instant author-name tooltips on the initials badges -->
+                                <script type="text/javascript">
+                                    document.addEventListener('DOMContentLoaded', function () {
+                                        if (typeof bootstrap !== 'undefined') {
+                                            document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(function (el) {
+                                                new bootstrap.Tooltip(el);
+                                            });
+                                        }
+                                    });
+                                </script>
                             </div>
 
                             <!-- Activities Tab (task 1222): player's own + its

--- a/bemade_sports_clinic/views/sports_clinic_portal_views.xml
+++ b/bemade_sports_clinic/views/sports_clinic_portal_views.xml
@@ -502,12 +502,16 @@
                         <t t-set="url">/my/players</t>
                         <t t-set="placeholder_count">players_count</t>
                     </t>
-                    <t t-call="portal.portal_docs_entry">
-                        <t t-set="title">Activities</t>
-                        <!-- Keep global /my/activities dashboard as the home card entry point -->
-                        <t t-set="url">/my/activities</t>
-                        <t t-set="placeholder_count">activities_count</t>
-                        <t t-set="config_card" t-value="request.env.user.has_group('bemade_sports_clinic.group_portal_treatment_professional') or request.env.user.has_group('bemade_sports_clinic.group_portal_team_coach')"/>
+                    <!-- Activities: only for roles holding mail.activity ACLs
+                         (TP / coach / internal) — others 403 on the counter. -->
+                    <t t-if="request.env.user.has_group('bemade_sports_clinic.group_portal_treatment_professional') or request.env.user.has_group('bemade_sports_clinic.group_portal_team_coach') or request.env.user.has_group('base.group_user')">
+                        <t t-call="portal.portal_docs_entry">
+                            <t t-set="title">Activities</t>
+                            <!-- Keep global /my/activities dashboard as the home card entry point -->
+                            <t t-set="url">/my/activities</t>
+                            <t t-set="placeholder_count">activities_count</t>
+                            <t t-set="config_card" t-value="request.env.user.has_group('bemade_sports_clinic.group_portal_treatment_professional') or request.env.user.has_group('bemade_sports_clinic.group_portal_team_coach')"/>
+                        </t>
                     </t>
                     <t t-if="request.env.user.has_group('bemade_sports_clinic.group_portal_treatment_professional') or request.env.user.has_group('bemade_sports_clinic.group_portal_team_coach')">
                         <t t-call="portal.portal_docs_entry">
@@ -999,7 +1003,7 @@
                         <button class="nav-link" id="activities-tab" data-bs-toggle="tab"
                                 data-bs-target="#activities" type="button" role="tab"
                                 aria-controls="activities" aria-selected="false">
-                            <i class="fa fa-tasks me-1"/> Activities (<t t-esc="len(team_activities)"/>)
+                            <i class="fa fa-tasks me-1"/> Activities <span class="badge text-bg-secondary ms-1" t-esc="len(team_activities)"/>
                         </button>
                     </li>
                 </ul>
@@ -1750,8 +1754,8 @@
                                                 <tr>
                                                     <td><span t-field="note.date"/></td>
                                                     <td class="text-center">
-                                                        <span class="badge text-bg-light border"
-                                                              t-att-title="note.user_id.name"
+                                                        <span class="badge text-bg-light border" style="cursor: help;"
+                                                              t-att-title="note.sudo().user_id.name"
                                                               t-esc="note.author_initials"/>
                                                     </td>
                                                     <td>
@@ -1766,7 +1770,7 @@
                                                         </t>
                                                     </td>
                                                     <td>
-                                                        <p t-field="note.note" style="white-space: pre-wrap; margin: 0; line-height: 1.35;"/>
+                                                        <p t-field="note.note" style="margin: 0; line-height: 1.35;"/>
                                                     </td>
                                                 </tr>
                                             </t>

--- a/bemade_sports_clinic/views/sports_clinic_portal_views.xml
+++ b/bemade_sports_clinic/views/sports_clinic_portal_views.xml
@@ -550,9 +550,14 @@
                 <!-- Header: Player name and active injuries badge -->
                 <div class="card-header d-flex justify-content-between align-items-center">
                     <div class="d-flex align-items-center gap-2">
-                        <a t-attf-href="{{ url }}" class="text-decoration-none fw-bold">
+                        <!-- Task 1225: only link the name when the viewer can open
+                             the player (else the link would 403). -->
+                        <a t-if="accessible" t-attf-href="{{ url }}" class="text-decoration-none fw-bold">
                             <span t-field="player.last_name"/>, <span t-field="player.first_name"/>
                         </a>
+                        <span t-else="" class="fw-bold">
+                            <span t-field="player.last_name"/>, <span t-field="player.first_name"/>
+                        </span>
                     </div>
                     <!-- Desktop-only: Right-aligned badges next to injury count -->
                     <div class="d-none d-md-flex align-items-center justify-content-end flex-wrap gap-2">
@@ -606,8 +611,8 @@
                 </div>
                 <!-- Body: Teams (optional) and key fields -->
                 <div class="card-body">
-                    <!-- Make whole card clickable -->
-                    <a t-attf-href="{{ url }}" class="stretched-link" aria-label="Open player details"></a>
+                    <!-- Make whole card clickable (only when openable - task 1225) -->
+                    <a t-if="accessible" t-attf-href="{{ url }}" class="stretched-link" aria-label="Open player details"></a>
                     <!-- First line: Match/Practice badges (mobile only; desktop version is in header) -->
                     <div class="mb-2 d-flex d-md-none flex-wrap gap-2">
                         <!-- Match badge: Yes (green check) / No (red x) -->
@@ -679,7 +684,26 @@
                         </div>
                     </div>
                 </div>
-                <!-- Footer removed per spec -->
+                <!-- Task 1225: for a player the viewer cannot open (surfaced by
+                     the broadened search), offer to add them to one of the
+                     viewer's staffed teams instead of a dead/403 View link.
+                     add_to_team_teams is only populated for TP/admin on the
+                     /my/players page, so this never renders in team views. -->
+                <div t-if="not accessible and add_to_team_teams" class="card-footer position-relative">
+                    <form t-attf-action="/my/player/{{ player.id }}/add_to_team" method="post"
+                          class="d-flex flex-wrap align-items-center gap-2">
+                        <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+                        <input type="hidden" name="return_url" t-att-value="request.httprequest.full_path"/>
+                        <select name="team_id" class="form-select form-select-sm" style="max-width: 14rem;">
+                            <t t-foreach="add_to_team_teams" t-as="att_team">
+                                <option t-att-value="att_team.id"><t t-esc="att_team.name"/></option>
+                            </t>
+                        </select>
+                        <button type="submit" class="btn btn-sm bg-o-color-1 text-white">
+                            <i class="fa fa-user-plus me-1"/> Add to Team
+                        </button>
+                    </form>
+                </div>
             </div>
         </template>
 
@@ -982,6 +1006,7 @@
                             <div class="col-12 col-lg-8">
                                 <t t-set="is_team_view" t-value="True"/>
                                 <t t-set="show_player_activities" t-value="False"/>
+                                <t t-set="accessible" t-value="True"/>
                                 <t t-call="bemade_sports_clinic.portal_patient_card"/>
                             </div>
                         </t>
@@ -1092,6 +1117,7 @@
                             <div class="col-12 col-lg-8">
                                 <t t-set="is_team_view" t-value="False"/>
                                 <t t-set="show_player_activities" t-value="True"/>
+                                <t t-set="accessible" t-value="player.id in accessible_ids"/>
                                 <t t-call="bemade_sports_clinic.portal_patient_card"/>
                             </div>
                         </t>

--- a/bemade_sports_clinic/views/sports_clinic_portal_views.xml
+++ b/bemade_sports_clinic/views/sports_clinic_portal_views.xml
@@ -899,12 +899,6 @@
                         </t>
                     </h1>
                     <div class="d-flex flex-wrap gap-2">
-                        <a t-if="request.env.user.has_group('bemade_sports_clinic.group_portal_treatment_professional') or request.env.user.has_group('bemade_sports_clinic.group_portal_team_coach')" t-attf-href="/my/team/activities?team_id={{ team.id }}" class="btn bg-o-color-2 text-white">
-                            <i class="fa fa-tasks"></i> Activities
-                        </a>
-                        <a t-if="request.env.user.has_group('bemade_sports_clinic.group_portal_treatment_professional') or request.env.user.has_group('bemade_sports_clinic.group_portal_team_coach')" t-attf-href="/my/activity/create?model=sports.team&amp;res_id={{ team.id }}" class="btn bg-o-color-2 text-white">
-                            <i class="fa fa-tasks"></i> Add Activity
-                        </a>
                         <!-- Therapist: go to dedicated Add/Link Player page -->
                         <a t-if="request.env.user.has_group('bemade_sports_clinic.group_portal_treatment_professional') or request.env.user.has_group('base.group_system')"
                            t-attf-href="/my/team/{{ team.id }}/player/add_link" class="btn bg-o-color-1 text-white">
@@ -961,29 +955,76 @@
                     </div>
                 </div>
 
-                
-                
-                <!-- Pending Removals Alert -->
-                <t t-if="any(p.pending_removal for p in players) and user_has_group('bemade_sports_clinic.group_portal_treatment_professional')">
-                    <div class="alert alert-warning d-flex align-items-center" role="alert">
-                        <i class="fa fa-exclamation-triangle flex-shrink-0 me-2"></i>
-                        <div>
-                            <strong>Pending Removals:</strong> There are 
-                            <t t-set="pending_count" t-value="sum(1 for p in players if p.pending_removal)"/>
-                            <t t-esc="pending_count"/> player(s) with pending removal requests.
-                            <a href="#pending-removals" class="alert-link">Review now</a>
+
+
+                <!-- Can the current user see/use the team Activities tab?
+                     Treatment professionals (and admins) and team coaches. -->
+                <t t-set="can_view_activities"
+                   t-value="request.env.user.has_group('bemade_sports_clinic.group_portal_treatment_professional') or request.env.user.has_group('base.group_system') or request.env.user.has_group('bemade_sports_clinic.group_portal_team_coach')"/>
+
+                <!-- Tabbed view: Players (roster) and Activities (team-level only, task 1223) -->
+                <ul class="nav nav-tabs mb-3" role="tablist">
+                    <li class="nav-item" role="presentation">
+                        <button class="nav-link active" id="players-tab" data-bs-toggle="tab"
+                                data-bs-target="#players" type="button" role="tab"
+                                aria-controls="players" aria-selected="true">
+                            <i class="fa fa-users me-1"/> Players
+                        </button>
+                    </li>
+                    <li t-if="can_view_activities" class="nav-item" role="presentation">
+                        <button class="nav-link" id="activities-tab" data-bs-toggle="tab"
+                                data-bs-target="#activities" type="button" role="tab"
+                                aria-controls="activities" aria-selected="false">
+                            <i class="fa fa-tasks me-1"/> Activities (<t t-esc="len(team_activities)"/>)
+                        </button>
+                    </li>
+                </ul>
+
+                <div class="tab-content">
+                    <div class="tab-pane fade show active" id="players" role="tabpanel" aria-labelledby="players-tab">
+                        <!-- Pending Removals Alert -->
+                        <t t-if="any(p.pending_removal for p in players) and user_has_group('bemade_sports_clinic.group_portal_treatment_professional')">
+                            <div class="alert alert-warning d-flex align-items-center" role="alert">
+                                <i class="fa fa-exclamation-triangle flex-shrink-0 me-2"></i>
+                                <div>
+                                    <strong>Pending Removals:</strong> There are
+                                    <t t-set="pending_count" t-value="sum(1 for p in players if p.pending_removal)"/>
+                                    <t t-esc="pending_count"/> player(s) with pending removal requests.
+                                    <a href="#pending-removals" class="alert-link">Review now</a>
+                                </div>
+                            </div>
+                        </t>
+                        <!-- Cards grid replacing table -->
+                        <div class="container-fluid">
+                            <div class="row g-3 justify-content-center">
+                                <t t-foreach="players" t-as="player">
+                                    <div class="col-12 col-lg-8">
+                                        <t t-set="is_team_view" t-value="True"/>
+                                        <t t-set="show_player_activities" t-value="False"/>
+                                        <t t-call="bemade_sports_clinic.portal_patient_card"/>
+                                    </div>
+                                </t>
+                            </div>
                         </div>
                     </div>
-                </t>
-                <!-- Cards grid replacing table -->
-                <div class="container-fluid">
-                    <div class="row g-3 justify-content-center">
-                        <t t-foreach="players" t-as="player">
-                            <div class="col-12 col-lg-8">
-                                <t t-set="is_team_view" t-value="True"/>
-                                <t t-set="show_player_activities" t-value="False"/>
-                                <t t-call="bemade_sports_clinic.portal_patient_card"/>
-                            </div>
+
+                    <div t-if="can_view_activities" class="tab-pane fade" id="activities" role="tabpanel" aria-labelledby="activities-tab">
+                        <!-- Shared add-activity header (task 1223 reuses the 1222 partial),
+                             scoped strictly to this team (res_model='sports.team'). -->
+                        <t t-set="add_model" t-value="'sports.team'"/>
+                        <t t-set="add_res_id" t-value="team.id"/>
+                        <t t-set="add_return_url" t-value="'/my/team?team_id=%s' % team.id"/>
+                        <t t-call="bemade_sports_clinic.portal_activity_add_header"/>
+
+                        <!-- Team-level activity list. team_activities holds ONLY
+                             res_model='sports.team' rows for this team - a team
+                             player's or injury's activities are intentionally excluded. -->
+                        <t t-set="today_date" t-value="datetime.datetime.strptime(today, '%Y-%m-%d').date()"/>
+                        <t t-set="context_model" t-value="'sports.team'"/>
+                        <t t-set="context_res_id" t-value="team.id"/>
+                        <t t-call="bemade_sports_clinic.activity_list_table">
+                            <t t-set="filtered_activities" t-value="team_activities"/>
+                            <t t-set="show_assignee" t-value="True"/>
                         </t>
                     </div>
                 </div>

--- a/bemade_sports_clinic/views/sports_event_views.xml
+++ b/bemade_sports_clinic/views/sports_event_views.xml
@@ -41,6 +41,8 @@
                     <filter name="to_vendor_po" string="To Vendor PO" domain="[('vendor_ready_to_po', '=', True)]"/>
                     <filter name="fully_processed" string="Fully Processed" domain="[('fully_processed', '=', True)]"/>
                     <separator/>
+                    <filter name="archived" string="Archived" domain="[('active', '=', False)]"/>
+                    <separator/>
                     <group>
                         <filter name="group_event" string="Event" context="{'group_by': 'event_id'}"/>
                         <filter name="group_user" string="Therapist" context="{'group_by': 'user_id'}"/>

--- a/bemade_sports_clinic/views/sports_event_views.xml
+++ b/bemade_sports_clinic/views/sports_event_views.xml
@@ -281,6 +281,7 @@
             <field name="context">{
                 'form_view_ref': 'bemade_sports_clinic.sports_event_view_form_calendar_popup',
                 'search_default_hide_cancelled': 1,
+                'search_default_upcoming': 1,
             }</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">

--- a/bemade_sports_clinic/views/sports_event_views.xml
+++ b/bemade_sports_clinic/views/sports_event_views.xml
@@ -225,9 +225,18 @@
                     <filter name="to_invoice" string="To Invoice" domain="[('state', '=', 'to_invoice')]"/>
                     <filter name="invoiced" string="Invoiced" domain="[('state', '=', 'invoiced')]"/>
                     <filter name="cancelled" string="Cancelled" domain="[('state', '=', 'cancelled')]"/>
-                    
+
                     <separator/>
-                    
+
+                    <!-- Default facet (applied via the action's search_default_hide_cancelled
+                         context): drops cancelled events from the default list & calendar.
+                         It sits in its own group so it AND-combines with the other state
+                         filters. To see cancelled events, remove this removable "Hide
+                         Cancelled" facet (then the explicit Cancelled filter narrows to them). -->
+                    <filter name="hide_cancelled" string="Hide Cancelled" domain="[('state', '!=', 'cancelled')]"/>
+
+                    <separator/>
+
                     <group>
                         <filter name="group_partner" string="Organization" context="{'group_by': 'partner_id'}"/>
                         <filter name="group_team" string="Team (by Organization)" context="{'group_by': 'partner_id'}"/>
@@ -269,6 +278,7 @@
             <field name="search_view_id" ref="sports_event_view_search"/>
             <field name="context">{
                 'form_view_ref': 'bemade_sports_clinic.sports_event_view_form_calendar_popup',
+                'search_default_hide_cancelled': 1,
             }</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">

--- a/bemade_sports_clinic/views/sports_patient_injury_views.xml
+++ b/bemade_sports_clinic/views/sports_patient_injury_views.xml
@@ -78,6 +78,7 @@
                     <!-- Smart button: Player back-link -->
                     <button class="oe_stat_button" type="object" name="action_view_patient" icon="fa-user">
                         <div class="o_stat_info">
+                            <span class="o_stat_value text-truncate mw-100"><field name="patient_name"/></span>
                             <span class="o_stat_text">Player</span>
                         </div>
                     </button>

--- a/bemade_sports_clinic/views/sports_patient_injury_views.xml
+++ b/bemade_sports_clinic/views/sports_patient_injury_views.xml
@@ -75,6 +75,12 @@
             <form>
                 <header>
                     <field name="stage" widget="statusbar"/>
+                    <!-- Smart button: Player back-link -->
+                    <button class="oe_stat_button" type="object" name="action_view_patient" icon="fa-user">
+                        <div class="o_stat_info">
+                            <span class="o_stat_text">Player</span>
+                        </div>
+                    </button>
                     <!-- Smart button: Documents -->
                     <button class="oe_stat_button" type="action" name="%(action_sports_injury_documents)d" icon="fa-file">
                         <field name="document_count" string="Documents" widget="statinfo"/>

--- a/bemade_sports_clinic/views/sports_patient_injury_views.xml
+++ b/bemade_sports_clinic/views/sports_patient_injury_views.xml
@@ -76,11 +76,11 @@
                 <header>
                     <field name="stage" widget="statusbar"/>
                     <!-- Smart button: Player back-link -->
+                    <!-- Inline content (no o_stat_info block div): these buttons
+                         live in the header, where the button-box stat CSS does
+                         not apply — a block div wraps to a second line. -->
                     <button class="oe_stat_button" type="object" name="action_view_patient" icon="fa-user">
-                        <div class="o_stat_info">
-                            <span class="o_stat_value text-truncate mw-100"><field name="patient_name"/></span>
-                            <span class="o_stat_text">Player</span>
-                        </div>
+                        <span>Player</span>
                     </button>
                     <!-- Smart button: Documents -->
                     <button class="oe_stat_button" type="action" name="%(action_sports_injury_documents)d" icon="fa-file">

--- a/bemade_sports_clinic/views/sports_patient_injury_views.xml
+++ b/bemade_sports_clinic/views/sports_patient_injury_views.xml
@@ -127,15 +127,6 @@
                         </group>
                     </group>
                     <notebook>
-                        <page string="Treatment Notes">
-                            <field name="treatment_note_ids">
-                                <list string="Treatment Notes" editable="bottom">
-                                    <field name="date"/>
-                                    <field name="note"/>
-                                    <field name="user_id" readonly="1"/>
-                                </list>
-                            </field>
-                        </page>
                         <page string="Documents">
                             <field name="document_ids">
                                 <list string="Documents" editable="bottom">

--- a/bemade_sports_clinic/views/sports_patient_views.xml
+++ b/bemade_sports_clinic/views/sports_patient_views.xml
@@ -158,11 +158,12 @@
                                  <page string="Treatment Notes">
                                     <field name="treatment_note_ids">
                                         <list string="Treatment Notes" editable="bottom">
-                                            <field name="date"/>
-                                            <field name="injury_id" domain="[('patient_id', '=', parent.id)]" 
+                                            <field name="date" width="100"/>
+                                            <field name="injury_id" width="160" domain="[('patient_id', '=', parent.id)]"
                                                    options="{'no_create': True, 'no_open': False}"/>
                                             <field name="note"/>
-                                            <field name="user_id" readonly="1"/>
+                                            <field name="author_initials" string="By" width="60"/>
+                                            <field name="user_id" column_invisible="1"/>
                                         </list>
                                     </field>
                                  </page>

--- a/bemade_sports_clinic/views/sports_patient_views.xml
+++ b/bemade_sports_clinic/views/sports_patient_views.xml
@@ -159,10 +159,10 @@
                                     <field name="treatment_note_ids">
                                         <list string="Treatment Notes" editable="bottom">
                                             <field name="date" width="100"/>
+                                            <field name="author_initials" string="By" width="60"/>
                                             <field name="injury_id" width="160" domain="[('patient_id', '=', parent.id)]"
                                                    options="{'no_create': True, 'no_open': False}"/>
                                             <field name="note"/>
-                                            <field name="author_initials" string="By" width="60"/>
                                             <field name="user_id" column_invisible="1"/>
                                         </list>
                                     </field>

--- a/bemade_sports_clinic/views/task_management_portal_templates.xml
+++ b/bemade_sports_clinic/views/task_management_portal_templates.xml
@@ -438,6 +438,93 @@
         </script>
     </template>
     
+    <!-- Reusable inline "Add Activity" header (fields + button).
+         Standardized across the player activities tab (task 1222) and the team
+         activities tab (task 1223) so both stay in sync. Posts to the shared
+         /my/activity/save endpoint.
+         Expected context:
+           add_model, add_res_id          (required) - target record
+           add_return_url                 (optional) - where to redirect after save
+           activity_types                 (recordset) - options for the type select
+           assignable_users               (recordset) - options for the assignee select
+           default_activity_type_id       (optional) - pre-selected type
+           default_user_id                (optional) - pre-selected assignee
+           today                          (str 'YYYY-MM-DD') - default/min deadline
+           add_team_id                    (optional) - team context hidden field -->
+    <template id="portal_activity_add_header" name="Add Activity Header">
+        <div class="card mb-3">
+            <div class="card-header bg-o-color-2 text-white">
+                <i class="fa fa-plus me-1"/> Add Activity
+            </div>
+            <div class="card-body">
+                <form action="/my/activity/save" method="post">
+                    <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+                    <input type="hidden" name="model" t-att-value="add_model"/>
+                    <input type="hidden" name="res_id" t-att-value="add_res_id"/>
+                    <input type="hidden" name="return_url" t-att-value="add_return_url"/>
+                    <input type="hidden" name="team_id" t-if="add_team_id" t-att-value="add_team_id"/>
+
+                    <div class="row g-3">
+                        <div class="col-md-6">
+                            <label t-attf-for="add_activity_type_id_#{add_res_id}" class="form-label">
+                                Activity Type <span class="text-danger">*</span>
+                            </label>
+                            <select name="activity_type_id" t-attf-id="add_activity_type_id_#{add_res_id}"
+                                    class="form-select" required="required">
+                                <option value="">Select Activity Type</option>
+                                <t t-foreach="activity_types" t-as="activity_type">
+                                    <option t-att-value="activity_type.id"
+                                            t-att-selected="activity_type.id == default_activity_type_id and 'selected' or None">
+                                        <t t-esc="activity_type.name"/>
+                                    </option>
+                                </t>
+                            </select>
+                        </div>
+                        <div class="col-md-6">
+                            <label t-attf-for="add_date_deadline_#{add_res_id}" class="form-label">
+                                Due Date <span class="text-danger">*</span>
+                            </label>
+                            <input type="date" name="date_deadline" t-attf-id="add_date_deadline_#{add_res_id}"
+                                   class="form-control" required="required" t-att-min="today" t-att-value="today"/>
+                        </div>
+                        <div class="col-md-6">
+                            <label t-attf-for="add_user_id_#{add_res_id}" class="form-label">
+                                Assigned To <span class="text-danger">*</span>
+                            </label>
+                            <select name="user_id" t-attf-id="add_user_id_#{add_res_id}"
+                                    class="form-select" required="required">
+                                <t t-foreach="assignable_users" t-as="assignable_user">
+                                    <option t-att-value="assignable_user.id"
+                                            t-att-selected="assignable_user.id == default_user_id and 'selected' or None">
+                                        <t t-esc="assignable_user.name"/>
+                                    </option>
+                                </t>
+                            </select>
+                        </div>
+                        <div class="col-md-6">
+                            <label t-attf-for="add_summary_#{add_res_id}" class="form-label">
+                                Summary <span class="text-danger">*</span>
+                            </label>
+                            <input type="text" name="summary" t-attf-id="add_summary_#{add_res_id}"
+                                   class="form-control" required="required"
+                                   placeholder="Brief description of the activity"/>
+                        </div>
+                        <div class="col-12">
+                            <label t-attf-for="add_note_#{add_res_id}" class="form-label">Note</label>
+                            <textarea name="note" t-attf-id="add_note_#{add_res_id}" class="form-control" rows="3"
+                                      placeholder="Additional details or instructions"></textarea>
+                        </div>
+                    </div>
+                    <div class="mt-3 text-end">
+                        <button type="submit" class="btn bg-o-color-1 text-white">
+                            <i class="fa fa-plus me-1"/> Add Activity
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </template>
+
     <!-- Template for creating a new activity -->
     <template id="portal_create_activity" name="Create Activity">
         <t t-call="portal.portal_layout">

--- a/bemade_sports_clinic/views/treatment_note_views.xml
+++ b/bemade_sports_clinic/views/treatment_note_views.xml
@@ -89,11 +89,14 @@
         </field>
     </record>
 
+    <!-- Kept off the main menu (owner call, dev-review 2026-07-04 round 2):
+         notes are reached from the patient form; this audit-style list lives
+         under Admin, visible in debug mode only. -->
     <menuitem id="sports_clinic_treatment_notes"
-              name="Treatment Notes"
-              parent="sports_clinic_root"
-              groups="bemade_sports_clinic.group_sports_clinic_user"
+              name="Treatment Notes (Audit)"
+              parent="sports_clinic_staff_menu"
+              groups="base.group_no_one"
               action="action_treatment_notes"
-              sequence="20"/>
+              sequence="7"/>
     </data>
 </odoo>

--- a/bemade_sports_clinic/views/treatment_note_views.xml
+++ b/bemade_sports_clinic/views/treatment_note_views.xml
@@ -7,11 +7,13 @@
         <field name="model">sports.treatment.note</field>
         <field name="arch" type="xml">
             <list string="Treatment Notes">
-                <field name="date"/>
-                <field name="patient_id"/>
-                <field name="injury_id"/>
-                <field name="create_uid" string="Created By"/>
-                <field name="create_date" string="Created On"/>
+                <field name="date" width="100"/>
+                <field name="patient_id" width="160"/>
+                <field name="injury_id" width="160"/>
+                <field name="author_initials" string="By" width="60" optional="show"/>
+                <field name="note"/>
+                <field name="create_uid" string="Created By" optional="hide"/>
+                <field name="create_date" string="Created On" optional="hide"/>
             </list>
         </field>
     </record>
@@ -56,6 +58,11 @@
                 <field name="note"/>
                 <field name="date"/>
                 <field name="create_uid"/>
+                <filter string="Injury-specific" name="filter_injury_specific" domain="[('note_type', '=', 'injury')]"/>
+                <filter string="General Notes" name="filter_general" domain="[('note_type', '=', 'general')]"/>
+                <separator/>
+                <filter string="Today" name="filter_today" domain="[('date', '=', context_today().strftime('%Y-%m-%d'))]"/>
+                <filter string="Last 30 Days" name="filter_recent" domain="[('date', '&gt;=', (context_today() - datetime.timedelta(days=30)).strftime('%Y-%m-%d'))]"/>
                 <group>
                     <filter string="Patient" name="group_by_patient" domain="[]" context="{'group_by': 'patient_id'}"/>
                     <filter string="Injury" name="group_by_injury" domain="[]" context="{'group_by': 'injury_id'}"/>

--- a/bemade_sports_clinic/views/treatment_note_views.xml
+++ b/bemade_sports_clinic/views/treatment_note_views.xml
@@ -92,10 +92,13 @@
     <!-- Kept off the main menu (owner call, dev-review 2026-07-04 round 2):
          notes are reached from the patient form; this audit-style list lives
          under Admin, visible in debug mode only. -->
+    <!-- The leading '-' entries UNLINK groups a previous revision linked
+         (menuitem groups accumulate across updates — Command.link): without
+         them the menu stays visible outside debug mode on updated DBs. -->
     <menuitem id="sports_clinic_treatment_notes"
               name="Treatment Notes (Audit)"
               parent="sports_clinic_staff_menu"
-              groups="base.group_no_one"
+              groups="-bemade_sports_clinic.group_sports_clinic_user,-base.group_user,base.group_no_one"
               action="action_treatment_notes"
               sequence="7"/>
     </data>

--- a/bemade_sports_clinic/views/treatment_note_views.xml
+++ b/bemade_sports_clinic/views/treatment_note_views.xml
@@ -8,9 +8,9 @@
         <field name="arch" type="xml">
             <list string="Treatment Notes">
                 <field name="date" width="100"/>
+                <field name="author_initials" string="By" width="60" optional="show"/>
                 <field name="patient_id" width="160"/>
                 <field name="injury_id" width="160"/>
-                <field name="author_initials" string="By" width="60" optional="show"/>
                 <field name="note"/>
                 <field name="create_uid" string="Created By" optional="hide"/>
                 <field name="create_date" string="Created On" optional="hide"/>
@@ -88,5 +88,12 @@
             </p>
         </field>
     </record>
+
+    <menuitem id="sports_clinic_treatment_notes"
+              name="Treatment Notes"
+              parent="sports_clinic_root"
+              groups="bemade_sports_clinic.group_sports_clinic_user"
+              action="action_treatment_notes"
+              sequence="20"/>
     </data>
 </odoo>


### PR DESCRIPTION
## Summary

Release of the 19.0 candidate batch for `bemade_sports_clinic`: 15 task branches collected onto `19.0-candidate` (tasks 374, 399, 532, 908, 928, 990, 1155, 1222–1228, 1235), plus three rounds of owner dev-review fixes (2026-07-04).

### Delivered
- Event lifecycle: cancel/delete notifications to assigned staff (assignee-only, per-language subject + bilingual body), cancelled events hidden by default (internal + portal, opt-in facet/toggle), default Upcoming filter, event list date ordering
- Portal events: list quick-filter fixes, sudo-widened filter dropdowns, calendar popover/filters refactor with viewport clamping and show-cancelled toggle
- Portal timesheets: therapist soft-delete of own timesheets, event-detail confidentiality (own timesheets only, tab hidden unless assigned), cancelled-event timesheets stay payable/visible (990 reversal)
- Players/teams portal: player+injury activities tab (1222), team Activities tab (1223), player-search Add-to-Team for out-of-team players (1225), role='other' portal hardening (no 403s)
- Staff lifecycle: archive deletes team-staff rows (no silent restore on unarchive), archived staff stay visible on past events, follower/TP/activity purge
- Treatment notes: patient-centric presentation, author initials with hover bubble, portal notes wrapping/spacing, audit menu (debug-only)
- Backend: Player smart button on injury form, coach portal group reconciliation (908), idempotent patient follower recompute (928)

### Tests
Full module suite green on a fresh install: **476 passing (0 failed, 0 error)**.

Human-tested end-to-end by the owner across two interactive dev-review passes on a neutralized copy of the 2026-06-26 production upgrade.