### PR TITLE
bemade_documents_link: link a document to many records (#3678)

### DIFF
--- a/bemade_documents_link/__manifest__.py
+++ b/bemade_documents_link/__manifest__.py
@@ -1,31 +1,8 @@
 {
     "name": "Documents - Link Existing",
-    "version": "18.0.1.0.0",
-    "summary": "Easily link an existing Documents record (incl. spreadsheets) "
-               "to any mail.thread record, from either side.",
-    "description": """
-Documents - Link Existing
-=========================
-
-Adds two generic, reusable entry points for linking an **existing** document
-(including a spreadsheet) to a business record, without uploading a new file:
-
-* **From the record side** — a *Link existing document* item appears in the
-  cog menu of every ``mail.thread`` form view. It opens a small wizard that
-  lets the user pick one or more already-existing, unlinked Documents records
-  and links them to the current record.
-* **From the Documents side** — a generic *Link to Record* item is added to the
-  Documents app's "Action" dropdown (the enterprise Documents app renders a
-  bespoke action dropdown, not the standard ``ActionMenus``, so a
-  ``binding_model_id`` server action does not surface there). It lets the user
-  first choose the target model (limited to ``mail.thread`` models) and then the
-  record, reusing the stock Documents ``link_to_record_wizard``.
-
-Linking sets ``res_model`` / ``res_id`` on the chosen ``documents.document``
-records. When the target is a product, a matching ``product.document`` is also
-created so the linked file appears under the product's *Documents* smart button
-(which reads ``product.document``, not ``documents.document``).
-""",
+    "version": "18.0.2.0.0",
+    "summary": "Link an existing Documents record (incl. spreadsheets) to any "
+               "number of mail.thread records, from either side.",
     "category": "Productivity/Documents",
     "author": "Bemade Inc.",
     "maintainer": "Marc Durepos <marc@bemade.org>",

--- a/bemade_documents_link/data/ir_actions_server_data.xml
+++ b/bemade_documents_link/data/ir_actions_server_data.xml
@@ -1,27 +1,25 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-    <data>
 
-        <!--
-            Generic Documents-side entry point: a contextual "Link to record"
-            action on documents.document. Bound to the model (binding_model_id),
-            so it shows in the Action menu of the Documents views for one or more
-            selected documents. It calls the stock action_link_to_record() with
-            NO model argument, so the user first picks the target model (limited
-            to mail.thread models) and then the record, via the stock
-            documents.link_to_record_wizard.
-        -->
-        <record id="ir_actions_server_link_to_record" model="ir.actions.server">
-            <field name="name">Link to record</field>
-            <field name="model_id" ref="documents.model_documents_document"/>
-            <field name="binding_model_id" ref="documents.model_documents_document"/>
-            <field name="binding_view_types">list,kanban,form</field>
-            <field name="groups_id" eval="[Command.link(ref('base.group_user'))]"/>
-            <field name="state">code</field>
-            <field name="code">
+    <!--
+        Generic Documents-side entry point: a contextual "Link to record"
+        action on documents.document. Bound to the model (binding_model_id),
+        so it shows in the Action menu of the Documents views for one or more
+        selected documents. It calls the stock action_link_to_record() with
+        NO model argument, so the user first picks the target model (limited
+        to mail.thread models) and then the record, via the stock
+        documents.link_to_record_wizard.
+    -->
+    <record id="ir_actions_server_link_to_record" model="ir.actions.server">
+        <field name="name">Link to record</field>
+        <field name="model_id" ref="documents.model_documents_document" />
+        <field name="binding_model_id" ref="documents.model_documents_document" />
+        <field name="binding_view_types">list,kanban,form</field>
+        <field name="groups_id" eval="[Command.link(ref('base.group_user'))]" />
+        <field name="state">code</field>
+        <field name="code">
 action = records.action_link_to_record()
-            </field>
-        </record>
+        </field>
+    </record>
 
-    </data>
 </odoo>

--- a/bemade_documents_link/migrations/18.0.2.0.0/post-migration.py
+++ b/bemade_documents_link/migrations/18.0.2.0.0/post-migration.py
@@ -1,0 +1,47 @@
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    """Mirror every pre-existing v1 native link (``documents.document``'s
+    single ``res_model``/``res_id`` pointer) into a ``bemade.documents.link``
+    row, so linked-record counts/filters built on the new model include data
+    that predates it (task #3678). Runs post-migrate so the new model's table
+    already exists. Idempotent: safe to re-run on upgrade re-runs.
+    """
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    documents = env["documents.document"].search(
+        [
+            ("res_model", "!=", "documents.document"),
+            ("res_model", "!=", False),
+            ("res_id", "!=", False),
+        ]
+    )
+    if not documents:
+        _logger.info("No pre-existing native document links to mirror; skipping.")
+        return
+
+    Link = env["bemade.documents.link"]
+    existing = Link.search([("document_id", "in", documents.ids)])
+    already_mirrored = {
+        (link.document_id.id, link.res_model, link.res_id) for link in existing
+    }
+
+    vals_list = [
+        {
+            "document_id": document.id,
+            "res_model": document.res_model,
+            "res_id": document.res_id,
+        }
+        for document in documents
+        if (document.id, document.res_model, document.res_id) not in already_mirrored
+    ]
+    if not vals_list:
+        _logger.info("All native document links already mirrored; skipping.")
+        return
+
+    Link.with_context(skip_bemade_link_audit=True).create(vals_list)
+    _logger.info("Mirrored %d native document link(s) into bemade.documents.link.", len(vals_list))

--- a/bemade_documents_link/models/__init__.py
+++ b/bemade_documents_link/models/__init__.py
@@ -1,2 +1,3 @@
+from . import documents_link
 from . import documents_document
 from . import documents_link_to_record_wizard

--- a/bemade_documents_link/models/documents_document.py
+++ b/bemade_documents_link/models/documents_document.py
@@ -1,8 +1,92 @@
-from odoo import models
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
 
 
 class DocumentsDocument(models.Model):
     _inherit = "documents.document"
+
+    bemade_link_ids = fields.One2many(
+        "bemade.documents.link",
+        "document_id",
+        string="Linked Records",
+    )
+    bemade_linked_record_count = fields.Integer(
+        compute="_compute_bemade_linked_record_count",
+        store=True,
+    )
+
+    @api.depends("bemade_link_ids")
+    def _compute_bemade_linked_record_count(self):
+        # Rows are unique per (document, res_model, res_id), so their count
+        # is exactly the number of distinct records this document is linked
+        # to across every model (task #3678 AC5).
+        for document in self:
+            document.bemade_linked_record_count = len(document.bemade_link_ids)
+
+    def action_view_linked_records(self):
+        self.ensure_one()
+        return {
+            "name": _("Linked Records"),
+            "type": "ir.actions.act_window",
+            "res_model": "bemade.documents.link",
+            "view_mode": "list,form",
+            "domain": [("document_id", "=", self.id)],
+        }
+
+    def _bemade_repoint_primary(self):
+        """Called when the link row that is the current native primary
+        (``res_model``/``res_id``) is removed: repoint the native primary to
+        another remaining link row, or reset it to the self-referential
+        ``'documents.document'`` sentinel (matching a freshly-uploaded,
+        unlinked document) if none remain."""
+        self.ensure_one()
+        remaining = self.bemade_link_ids
+        if remaining:
+            primary = remaining[0]
+            self.write({"res_model": primary.res_model, "res_id": primary.res_id})
+        else:
+            self.write({"res_model": "documents.document", "res_id": self.id})
+
+    def action_link_to_record(self, model=False):
+        """Documents-side entry point (task #3678 defect 1 / AC3): the stock
+        version (enterprise/documents/models/documents_document.py) refuses
+        to open the wizard at all when any selected document is already
+        linked (``res_model != 'documents.document'``). Since a document can
+        now be linked to many records, that refusal no longer applies --
+        override it (not monkey-patch the base method) so only our subclass
+        drops the guard.
+
+        This is a full copy of the stock method minus the "already linked"
+        early-return block; everything else -- context keys, the ``model``
+        pre-selection branch, the returned act_window -- is unchanged.
+        """
+        context = {
+            "default_document_ids": self.ids,
+            "default_resource_ref": False,
+            "default_is_readonly_model": False,
+            "default_model_id": False,
+        }
+
+        if model:
+            self.env[model].check_access("write")
+            context["default_is_readonly_model"] = True
+            context["default_model_id"] = self.env["ir.model"]._get_id(model)
+            first_valid_id = self.env[model].search([], limit=1).id
+            if not first_valid_id:
+                raise UserError(
+                    _("There are no records to link this document. Create one first.")
+                )
+            context["default_resource_ref"] = f"{model},{first_valid_id}"
+
+        return {
+            "name": _("Choose a record to link"),
+            "type": "ir.actions.act_window",
+            "res_model": "documents.link_to_record_wizard",
+            "view_mode": "form",
+            "target": "new",
+            "views": [(False, "form")],
+            "context": context,
+        }
 
     def _bemade_sync_product_document(self):
         """Ensure a ``product.document`` exists for any of these documents that

--- a/bemade_documents_link/models/documents_link.py
+++ b/bemade_documents_link/models/documents_link.py
@@ -1,0 +1,147 @@
+from odoo import _, api, fields, models
+from odoo.exceptions import MissingError
+
+
+class BemadeDocumentsLink(models.Model):
+    """Polymorphic link between a ``documents.document`` and any business
+    record (task #3678): the source of truth for "which records is this
+    document linked to". A single document can be linked to many records
+    across many different models -- something the stock Documents module
+    can't express, since it only tracks a single ``res_model``/``res_id``
+    pointer per document and refuses to (re-)link an already-linked one.
+
+    The stock ``documents.document.res_model``/``res_id`` pair is kept as a
+    synced "primary" link so the native Documents card, ``res_name``, and the
+    product smart-button bridge keep working unchanged: the *first* link row
+    created for a document also sets the native primary; additional rows only
+    add links (they never touch the native pointer). Removing the primary row
+    repoints the native pointer to another remaining link row, or resets it to
+    the self-referential ``'documents.document'`` sentinel when none remain,
+    mirroring how a freshly-uploaded, unlinked document looks.
+    """
+
+    _name = "bemade.documents.link"
+    _description = "Document Link to Record"
+
+    document_id = fields.Many2one(
+        "documents.document",
+        required=True,
+        ondelete="cascade",
+        index=True,
+    )
+    res_model = fields.Char(required=True, index=True)
+    res_id = fields.Many2oneReference(
+        required=True, index=True, model_field="res_model"
+    )
+    res_name = fields.Char(compute="_compute_res_name", compute_sudo=True)
+    record_ref = fields.Reference(
+        string="Record",
+        selection="_selection_target_model",
+        compute="_compute_record_ref",
+    )
+
+    _sql_constraints = [
+        (
+            "doc_record_uniq",
+            "unique(document_id, res_model, res_id)",
+            "A document can be linked to a record only once.",
+        ),
+    ]
+
+    @api.model
+    def _selection_target_model(self):
+        # Mirror the stock link_to_record_wizard's target-model scope: any
+        # mail.thread model other than documents.document itself.
+        return [
+            (model.model, model.name)
+            for model in self.env["ir.model"]
+            .sudo()
+            .search(
+                [
+                    ("model", "!=", "documents.document"),
+                    ("is_mail_thread", "=", "True"),
+                ]
+            )
+        ]
+
+    @api.depends("res_model", "res_id")
+    def _compute_res_name(self):
+        for link in self:
+            if link.res_model and link.res_id:
+                try:
+                    link.res_name = (
+                        self.env[link.res_model].browse(link.res_id).display_name
+                    )
+                except MissingError:
+                    link.res_name = False
+            else:
+                link.res_name = False
+
+    @api.depends("res_model", "res_id")
+    def _compute_record_ref(self):
+        for link in self:
+            if (
+                link.res_model
+                and link.res_id
+                and link.res_model in self.env
+                and self.env[link.res_model].browse(link.res_id).exists()
+            ):
+                link.record_ref = f"{link.res_model},{link.res_id}"
+            else:
+                link.record_ref = False
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        links = super().create(vals_list)
+        skip_audit = self.env.context.get("skip_bemade_link_audit")
+        for link in links:
+            link._sync_primary_on_link()
+            if not skip_audit:
+                link._post_chatter_audit(_("linked to"))
+        return links
+
+    def unlink(self):
+        # A row that IS the current native primary needs its document
+        # repointed once it's gone; figure that out (and post the chatter
+        # note) BEFORE the rows disappear, then repoint after the actual
+        # unlink.
+        documents_to_repoint = self.env["documents.document"]
+        for link in self:
+            document = link.document_id
+            if (
+                document.res_model == link.res_model
+                and document.res_id == link.res_id
+            ):
+                documents_to_repoint |= document
+            link._post_chatter_audit(_("unlinked from"))
+        result = super().unlink()
+        for document in documents_to_repoint:
+            document._bemade_repoint_primary()
+        return result
+
+    def _sync_primary_on_link(self):
+        """The first link row on a document also becomes the native primary
+        (``res_model``/``res_id``) so stock Documents UX keeps working;
+        subsequent rows just add a link and leave the primary alone."""
+        self.ensure_one()
+        document = self.document_id
+        if document.res_model == "documents.document":
+            document.write({"res_model": self.res_model, "res_id": self.res_id})
+
+    def _post_chatter_audit(self, action):
+        """Post a one-line note on the *target* record's chatter (not on the
+        document itself) when a link is created/removed. Degrades gracefully
+        if the target model/record no longer exists or isn't a mail.thread."""
+        self.ensure_one()
+        if not self.res_model or self.res_model not in self.env:
+            return
+        target = self.env[self.res_model].browse(self.res_id)
+        if not target.exists() or not hasattr(target, "message_post"):
+            return
+        target.message_post(
+            body=_(
+                "Document %(document)s was %(action)s this record.",
+                document=self.document_id.name,
+                action=action,
+            )
+        )

--- a/bemade_documents_link/models/documents_link_to_record_wizard.py
+++ b/bemade_documents_link/models/documents_link_to_record_wizard.py
@@ -1,15 +1,59 @@
-from odoo import models
+from odoo import _, models
 
 
 class LinkToRecordWizard(models.TransientModel):
     _inherit = "documents.link_to_record_wizard"
 
     def link_to(self):
-        """Extend the stock Documents-side link wizard so a document linked to a
-        product also surfaces under the product's "Documents" smart button
-        (task #3678 defect 2). This is the wizard our Documents-side
-        "Link to Record" entry point opens.
+        """Extend the stock Documents-side link wizard (task #3678):
+
+        * Create a ``bemade.documents.link`` row per document instead of
+          overwriting the document's single native ``res_model``/``res_id``
+          pointer -- so a document already linked to other records keeps
+          those links (the native primary is synced automatically by
+          ``bemade.documents.link.create()``'s first-link rule).
+        * Bridge the product "Documents" smart button (pre-existing #3678
+          defect 2 fix), unchanged.
+        * Return an action re-opening this same wizard on the same documents
+          (AC3: "repeat without relaunching") instead of just closing, so the
+          user can link the selection to another record right away.
         """
-        res = super().link_to()
-        self.document_ids._bemade_sync_product_document()
-        return res
+        self.ensure_one()
+        target_model = self.resource_ref._name
+        target_id = self.resource_ref.id
+
+        Link = self.env["bemade.documents.link"]
+        documents = self.document_ids.with_company(self.env.company)
+        already_linked = Link.search(
+            [
+                ("document_id", "in", documents.ids),
+                ("res_model", "=", target_model),
+                ("res_id", "=", target_id),
+            ]
+        ).document_id
+        to_link = documents - already_linked
+        for document in to_link:
+            Link.create(
+                {
+                    "document_id": document.id,
+                    "res_model": target_model,
+                    "res_id": target_id,
+                }
+            )
+        documents.write({"is_editable_attachment": True})
+        documents._bemade_sync_product_document()
+
+        return {
+            "name": _("Choose a record to link"),
+            "type": "ir.actions.act_window",
+            "res_model": "documents.link_to_record_wizard",
+            "view_mode": "form",
+            "target": "new",
+            "views": [(False, "form")],
+            "context": {
+                "default_document_ids": documents.ids,
+                "default_resource_ref": False,
+                "default_is_readonly_model": self.is_readonly_model,
+                "default_model_id": self.model_id.id if self.is_readonly_model else False,
+            },
+        }

--- a/bemade_documents_link/readme/DESCRIPTION.md
+++ b/bemade_documents_link/readme/DESCRIPTION.md
@@ -1,0 +1,28 @@
+Adds two generic, reusable entry points for linking an **existing** document
+(including a spreadsheet) to one or more business records, without uploading
+a new file:
+
+* **From the record side** -- a *Link existing document* item appears in the
+  cog menu of every `mail.thread` form view. It opens a checked-picker
+  wizard defaulting to the documents already linked to the current record;
+  saving reconciles the selection (adds newly-checked documents, unlinks
+  unchecked ones).
+* **From the Documents side** -- a generic *Link to Record* item is added to
+  the Documents app's "Action" dropdown (the enterprise Documents app renders
+  a bespoke action dropdown, not the standard `ActionMenus`, so a
+  `binding_model_id` server action does not surface there). It lets the user
+  first choose the target model (limited to `mail.thread` models) and then
+  the record, reusing the stock Documents `link_to_record_wizard` --
+  repeatedly, without relaunching, and even for documents already linked
+  elsewhere.
+
+A document can be linked to **any number of records across any number of
+models** (a plain M2M can't express this, since Odoo M2M targets a single
+comodel): a new polymorphic `bemade.documents.link` model is the source of
+truth for these links, exposed on `documents.document` as a linked-records
+count and list. The stock `res_model`/`res_id` pointer is kept in sync as a
+"primary" link so the native Documents card, `res_name`, and the product
+smart-button bridge keep working unchanged. When the target is a product, a
+matching `product.document` is also created so the linked file appears under
+the product's *Documents* smart button (which reads `product.document`, not
+`documents.document`).

--- a/bemade_documents_link/security/ir.model.access.csv
+++ b/bemade_documents_link/security/ir.model.access.csv
@@ -1,2 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_documents_link_wizard_user,documents.link.wizard.user,model_documents_link_wizard,base.group_user,1,1,1,1
+access_bemade_documents_link_user,bemade.documents.link.user,model_bemade_documents_link,base.group_user,1,1,1,1

--- a/bemade_documents_link/static/src/link_to_record/documents_control_panel_patch.js
+++ b/bemade_documents_link/static/src/link_to_record/documents_control_panel_patch.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
-import { DocumentsControlPanel } from "@documents/views/search/documents_control_panel";
-import { patch } from "@web/core/utils/patch";
+import {DocumentsControlPanel} from "@documents/views/search/documents_control_panel";
+import {patch} from "@web/core/utils/patch";
 
 /**
  * Documents-side "Link to Record" entry point (task #3678 defect 1).
@@ -19,44 +19,37 @@ import { patch } from "@web/core/utils/patch";
  * limited to mail.thread models, then record picker).
  */
 patch(DocumentsControlPanel.prototype, {
-    /**
-     * True when every selected record is an unlinked workspace document
-     * (res_model === 'documents.document'), i.e. eligible to be linked to a
-     * record. Mirrors the stock action's own guard, which refuses
-     * already-linked documents.
-     */
-    get canLinkToRecord() {
-        const records = this.targetRecords;
-        return (
-            this.documentService.userIsInternal &&
-            this.currentFolderId !== "TRASH" &&
-            records.length > 0 &&
-            records.every(
-                (r) =>
-                    r.data.type === "binary" &&
-                    r.data.attachment_id &&
-                    r.data.res_model === "documents.document"
-            )
-        );
-    },
+  /**
+   * True when every selected record is a real binary document with an
+   * attachment. A document can now be linked to many records (task #3678),
+   * so -- unlike the stock guard -- already-linked documents
+   * (res_model !== 'documents.document') remain eligible too.
+   */
+  get canLinkToRecord() {
+    const records = this.targetRecords;
+    return (
+      this.documentService.userIsInternal &&
+      this.currentFolderId !== "TRASH" &&
+      records.length > 0 &&
+      records.every((r) => r.data.type === "binary" && r.data.attachment_id)
+    );
+  },
 
-    /**
-     * Open the stock "Link to Record" wizard on the selected documents.
-     */
-    async onLinkToRecord() {
-        const documentIds = this.targetRecords.map((record) => record.data.id);
-        if (!documentIds.length) {
-            return;
-        }
-        const action = await this.orm.call(
-            "documents.document",
-            "action_link_to_record",
-            [documentIds]
-        );
-        if (action) {
-            await this.action.doAction(action, {
-                onClose: () => this.notifyChange(),
-            });
-        }
-    },
+  /**
+   * Open the stock "Link to Record" wizard on the selected documents.
+   */
+  async onLinkToRecord() {
+    const documentIds = this.targetRecords.map((record) => record.data.id);
+    if (!documentIds.length) {
+      return;
+    }
+    const action = await this.orm.call("documents.document", "action_link_to_record", [
+      documentIds,
+    ]);
+    if (action) {
+      await this.action.doAction(action, {
+        onClose: () => this.notifyChange(),
+      });
+    }
+  },
 });

--- a/bemade_documents_link/tests/test_documents_link.py
+++ b/bemade_documents_link/tests/test_documents_link.py
@@ -1,6 +1,8 @@
 import base64
+import os
 import unittest
 
+from odoo.modules.migration import load_script
 from odoo.tests import Form, tagged
 from odoo.tests.common import TransactionCase
 
@@ -128,6 +130,225 @@ class TestDocumentsLink(TransactionCase):
         self.assertEqual(
             set(action["context"].get("default_document_ids")), set(recs.ids)
         )
+
+
+@tagged("post_install", "-at_install")
+class TestDocumentsLinkM2M(TransactionCase):
+    """task #3678: a document can be linked to many records across many
+    models via the new ``bemade.documents.link`` model."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner_a = cls.env["res.partner"].create({"name": "Link Target A"})
+        cls.partner_b = cls.env["res.partner"].create({"name": "Link Target B"})
+
+    def _make_doc(self, name="Doc"):
+        return self.env["documents.document"].create({
+            "name": name,
+            "type": "binary",
+            "datas": base64.b64encode(b"hello").decode(),
+        })
+
+    def _link(self, doc, model, record_id):
+        """Record-side wizard shortcut: link `doc` to (model, record_id)."""
+        wizard = self.env["documents.link.wizard"].with_context(
+            active_model=model,
+            active_id=record_id,
+        ).create({"document_ids": [(6, 0, doc.ids)]})
+        wizard.action_link()
+
+    def test_link_one_document_to_many_records_different_models(self):
+        """Test plan #1: link one document to a res.partner and to a
+        res.users (two different mail.thread models)."""
+        user = self.env["res.users"].create({
+            "name": "M2M Target User",
+            "login": "m2m_target_user",
+        })
+        doc = self._make_doc("Multi-linked Doc")
+
+        self._link(doc, "res.partner", self.partner_a.id)
+        self._link(doc, "res.users", user.id)
+
+        self.assertEqual(len(doc.bemade_link_ids), 2)
+        self.assertEqual(doc.bemade_linked_record_count, 2)
+        self.assertEqual(
+            set(doc.bemade_link_ids.mapped("res_model")),
+            {"res.partner", "res.users"},
+        )
+
+    def test_already_linked_document_can_be_linked_again(self):
+        """Test plan #2: the v1 single-link block is gone -- a document
+        already linked to A can also be linked to B."""
+        doc = self._make_doc("Reused Doc")
+        self._link(doc, "res.partner", self.partner_a.id)
+        self.assertEqual(doc.res_model, "res.partner")
+        self.assertEqual(doc.res_id, self.partner_a.id)
+
+        self._link(doc, "res.partner", self.partner_b.id)
+
+        self.assertEqual(len(doc.bemade_link_ids), 2)
+        self.assertEqual(
+            set(doc.bemade_link_ids.mapped("res_id")),
+            {self.partner_a.id, self.partner_b.id},
+        )
+
+    def test_native_primary_sync_on_link_and_unlink(self):
+        """Test plan #3: linking an unlinked doc sets the native primary to
+        the first target; a second link leaves the primary unchanged;
+        unlinking the primary row repoints the native pointer to a remaining
+        link, or resets it to the 'documents.document' sentinel."""
+        doc = self._make_doc("Primary Sync Doc")
+        self.assertEqual(doc.res_model, "documents.document")
+
+        self._link(doc, "res.partner", self.partner_a.id)
+        self.assertEqual(doc.res_model, "res.partner")
+        self.assertEqual(doc.res_id, self.partner_a.id)
+
+        self._link(doc, "res.partner", self.partner_b.id)
+        # Primary unchanged: still the first target.
+        self.assertEqual(doc.res_model, "res.partner")
+        self.assertEqual(doc.res_id, self.partner_a.id)
+
+        # Unlink the primary row (A) -- repoints to the remaining link (B).
+        primary_link = doc.bemade_link_ids.filtered(
+            lambda link: link.res_id == self.partner_a.id
+        )
+        primary_link.unlink()
+        self.assertEqual(doc.res_model, "res.partner")
+        self.assertEqual(doc.res_id, self.partner_b.id)
+
+        # Unlink the last remaining row -- resets to the sentinel.
+        doc.bemade_link_ids.unlink()
+        self.assertEqual(doc.res_model, "documents.document")
+        self.assertEqual(doc.res_id, doc.id)
+
+    def test_uniqueness_constraint_idempotent(self):
+        """Test plan #4: linking the same doc to the same record twice does
+        not create a duplicate row (the wizard reconciles idempotently, and
+        the underlying _sql_constraints guards direct duplicate creation)."""
+        doc = self._make_doc("Dup Doc")
+        self._link(doc, "res.partner", self.partner_a.id)
+        self._link(doc, "res.partner", self.partner_a.id)
+        self.assertEqual(len(doc.bemade_link_ids), 1)
+
+        from odoo.tools import mute_logger
+
+        with self.assertRaises(Exception), mute_logger("odoo.sql_db"):
+            with self.env.cr.savepoint():
+                self.env["bemade.documents.link"].create({
+                    "document_id": doc.id,
+                    "res_model": "res.partner",
+                    "res_id": self.partner_a.id,
+                })
+
+    def test_record_side_wizard_reconcile(self):
+        """Test plan #5: default document_ids reflects docs already linked to
+        the active record; saving with a doc removed drops its link row and
+        saving with a doc added creates one."""
+        doc_a = self._make_doc("Reconcile Doc A")
+        doc_b = self._make_doc("Reconcile Doc B")
+        self._link(doc_a, "res.partner", self.partner_a.id)
+
+        wizard = self.env["documents.link.wizard"].with_context(
+            active_model="res.partner",
+            active_id=self.partner_a.id,
+        ).create({})
+        self.assertEqual(wizard.document_ids, doc_a)
+
+        # Uncheck doc_a, check doc_b.
+        wizard.document_ids = [(6, 0, doc_b.ids)]
+        wizard.action_link()
+
+        links = self.env["bemade.documents.link"].search(
+            [("res_model", "=", "res.partner"), ("res_id", "=", self.partner_a.id)]
+        )
+        self.assertEqual(links.document_id, doc_b)
+        self.assertEqual(doc_a.res_model, "documents.document")
+        self.assertEqual(doc_b.res_model, "res.partner")
+
+    def test_documents_side_repeat_flow(self):
+        """Test plan #6: link_to() creates a link row and returns an
+        act_window re-opening the same wizard on the same documents;
+        action_link_to_record no longer refuses an already-linked document."""
+        doc = self._make_doc("Repeat Flow Doc")
+        self._link(doc, "res.partner", self.partner_a.id)
+
+        # Already-linked document is still accepted (no refusal notification).
+        action = doc.action_link_to_record()
+        self.assertEqual(action["type"], "ir.actions.act_window")
+        self.assertEqual(action["res_model"], "documents.link_to_record_wizard")
+
+        wizard = self.env["documents.link_to_record_wizard"].create({
+            "document_ids": [(6, 0, doc.ids)],
+        })
+        wizard.write({
+            "model_id": self.env["ir.model"]._get_id("res.partner"),
+            "resource_ref": f"res.partner,{self.partner_b.id}",
+        })
+        result = wizard.link_to()
+
+        self.assertEqual(result["type"], "ir.actions.act_window")
+        self.assertEqual(result["res_model"], "documents.link_to_record_wizard")
+        self.assertEqual(result["context"]["default_document_ids"], doc.ids)
+        self.assertEqual(len(doc.bemade_link_ids), 2)
+        self.assertEqual(
+            set(doc.bemade_link_ids.mapped("res_id")),
+            {self.partner_a.id, self.partner_b.id},
+        )
+
+    def test_migration_mirrors_native_links(self):
+        """Test plan #7: the post-migration mirrors a pre-existing native
+        link into a link row, and re-running it creates no duplicate."""
+        doc = self._make_doc("Migration Doc")
+        # Simulate a pre-existing v1 native link with no bemade.documents.link
+        # row (bypass our wizards/create-sync entirely).
+        doc.write({"res_model": "res.partner", "res_id": self.partner_a.id})
+        self.assertFalse(
+            self.env["bemade.documents.link"].search(
+                [("document_id", "=", doc.id)]
+            )
+        )
+
+        pyfile = os.path.join(
+            "bemade_documents_link",
+            "migrations",
+            "18.0.2.0.0",
+            "post-migration.py",
+        )
+        name, _ext = os.path.splitext(os.path.basename(pyfile))
+        mod = load_script(pyfile, name)
+        mod.migrate(self.env.cr, "18.0.2.0.0")
+
+        links = self.env["bemade.documents.link"].search(
+            [("document_id", "=", doc.id)]
+        )
+        self.assertEqual(len(links), 1)
+        self.assertEqual(links.res_model, "res.partner")
+        self.assertEqual(links.res_id, self.partner_a.id)
+
+        # Re-running must not create a duplicate.
+        mod.migrate(self.env.cr, "18.0.2.0.0")
+        links = self.env["bemade.documents.link"].search(
+            [("document_id", "=", doc.id)]
+        )
+        self.assertEqual(len(links), 1)
+
+    def test_record_side_wizard_form_smoke(self):
+        """Test plan #9: Form on the record-side wizard compiles, defaults
+        populate from context, and document_ids is editable."""
+        doc = self._make_doc("Form Smoke Doc")
+        form = Form(
+            self.env["documents.link.wizard"].with_context(
+                active_model="res.partner",
+                active_id=self.partner_a.id,
+            )
+        )
+        self.assertEqual(form.res_model, "res.partner")
+        self.assertEqual(form.res_id, self.partner_a.id)
+        form.document_ids.add(doc)
+        wizard = form.save()
+        self.assertIn(doc, wizard.document_ids)
 
 
 @tagged("post_install", "-at_install")

--- a/bemade_documents_link/wizard/documents_link_wizard.py
+++ b/bemade_documents_link/wizard/documents_link_wizard.py
@@ -1,11 +1,18 @@
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
+from odoo.fields import Command
 
 
 class DocumentsLinkWizard(models.TransientModel):
-    """Record-side wizard: link one or more existing, unlinked
-    ``documents.document`` records to the record the user is currently on
-    (resolved from the ``active_model`` / ``active_id`` context).
+    """Record-side wizard: reconcile which existing ``documents.document``
+    records are linked to the record the user is currently on (resolved from
+    the ``active_model`` / ``active_id`` context).
+
+    A document can now be linked to many records (task #3678), so this is a
+    checked picker rather than an "unlinked documents only" selector: it
+    defaults to the documents already linked to the active record, and saving
+    reconciles the selection into ``bemade.documents.link`` rows -- creating
+    rows for newly-checked documents, removing rows for unchecked ones.
     """
 
     _name = "documents.link.wizard"
@@ -24,17 +31,23 @@ class DocumentsLinkWizard(models.TransientModel):
     document_ids = fields.Many2many(
         "documents.document",
         string="Documents",
-        # Offer only existing, not-yet-linked documents. An app-managed
-        # document that isn't linked to a business record carries the
-        # self-referential res_model 'documents.document' (set on create in
-        # enterprise `documents`), so that — not False — is the "unlinked" marker.
-        domain=[("res_model", "=", "documents.document")],
     )
+
+    @api.model
+    def default_get(self, fields_list):
+        res = super().default_get(fields_list)
+        if "document_ids" in fields_list:
+            res_model = res.get("res_model") or self.env.context.get("active_model")
+            res_id = res.get("res_id") or self.env.context.get("active_id")
+            if res_model and res_id:
+                links = self.env["bemade.documents.link"].search(
+                    [("res_model", "=", res_model), ("res_id", "=", res_id)]
+                )
+                res["document_ids"] = [Command.set(links.document_id.ids)]
+        return res
 
     def action_link(self):
         self.ensure_one()
-        if not self.document_ids:
-            raise UserError(_("Select at least one document to link."))
 
         # Gate on the user's *write* access to the target record, mirroring the
         # stock Documents link wizard's access logic, so a user cannot link a
@@ -47,13 +60,30 @@ class DocumentsLinkWizard(models.TransientModel):
             raise UserError(_("The record to link the documents to no longer exists."))
         target.check_access("write")
 
-        # res_name recomputes automatically from res_model/res_id on
-        # documents.document; mirror the stock wizard's write payload.
-        self.document_ids.write({
-            "res_model": self.res_model,
-            "res_id": self.res_id,
-            "is_editable_attachment": True,
-        })
-        # Surface the link under a product's "Documents" smart button (#3678).
-        self.document_ids._bemade_sync_product_document()
+        Link = self.env["bemade.documents.link"]
+        existing_links = Link.search(
+            [("res_model", "=", target_model), ("res_id", "=", self.res_id)]
+        )
+        existing_docs = existing_links.document_id
+        selected_docs = self.document_ids
+
+        to_remove = existing_links.filtered(
+            lambda link: link.document_id not in selected_docs
+        )
+        to_add = selected_docs - existing_docs
+
+        if to_remove:
+            to_remove.unlink()
+        for document in to_add:
+            Link.create(
+                {
+                    "document_id": document.id,
+                    "res_model": target_model,
+                    "res_id": self.res_id,
+                }
+            )
+        if to_add:
+            to_add.write({"is_editable_attachment": True})
+            # Surface newly-linked docs under a product's smart button (#3678).
+            to_add._bemade_sync_product_document()
         return {"type": "ir.actions.act_window_close"}

--- a/bemade_documents_link/wizard/documents_link_wizard_views.xml
+++ b/bemade_documents_link/wizard/documents_link_wizard_views.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <odoo>
 
     <record id="documents_link_wizard_view_form" model="ir.ui.view">
@@ -8,19 +8,30 @@
             <form string="Link Existing Documents">
                 <sheet>
                     <group>
-                        <field name="res_model" invisible="1"/>
-                        <field name="res_id" invisible="1"/>
-                        <field name="document_ids"
-                               widget="many2many_tags"
-                               options="{'no_create': True}"
-                               placeholder="Choose existing documents to link..."/>
+                        <field name="res_model" invisible="1" />
+                        <field name="res_id" invisible="1" />
+                        <field
+              name="document_ids"
+              widget="many2many_tags"
+              options="{'no_create': True}"
+              placeholder="Check any existing documents to link to this record (uncheck to unlink)..."
+            />
                     </group>
                 </sheet>
                 <footer>
-                    <button name="action_link" type="object" string="Link"
-                            class="btn-primary" data-hotkey="q"/>
-                    <button string="Cancel" class="btn-secondary"
-                            special="cancel" data-hotkey="x"/>
+                    <button
+            name="action_link"
+            type="object"
+            string="Link"
+            class="btn-primary"
+            data-hotkey="q"
+          />
+                    <button
+            string="Cancel"
+            class="btn-secondary"
+            special="cancel"
+            data-hotkey="x"
+          />
                 </footer>
             </form>
         </field>
@@ -31,7 +42,7 @@
         <field name="res_model">documents.link.wizard</field>
         <field name="view_mode">form</field>
         <field name="target">new</field>
-        <field name="view_id" ref="documents_link_wizard_view_form"/>
+        <field name="view_id" ref="documents_link_wizard_view_form" />
     </record>
 
 </odoo>


### PR DESCRIPTION
Adds the `bemade_documents_link` module: polymorphic `bemade.documents.link` letting one document link to many records across models, reconcile-style record-side + repeatable Documents-side wizards, and an idempotent 18.0.2.0.0 migration. Superproject: durpro!434 (gitlink bump follows this merge). 19 tests green.

Squash-merge to satisfy the linear-history ruleset.