### PR TITLE
fix(bemade_sale_price_rounding): formula pricelist in consistency tests

### DIFF
--- a/bemade_sale_price_rounding/__manifest__.py
+++ b/bemade_sale_price_rounding/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     "name": "Bemade Sale Price Rounding",
-    "version": "19.0.2.0.0",
+    "version": "19.0.2.0.1",
     "category": "Sales",
     "summary": (
         "Round sale order line unit prices and cost to Product Price precision "

--- a/bemade_sale_price_rounding/tests/test_price_subtotal_consistency.py
+++ b/bemade_sale_price_rounding/tests/test_price_subtotal_consistency.py
@@ -55,15 +55,26 @@ class TestPriceSubtotalConsistency(SaleCommon):
     # ------------------------------------------------------------------
 
     def _make_supplierinfo_pricelist(self, name="Supplierinfo Pricelist"):
-        """Create a percentage-discount pricelist that yields a non-terminating
+        """Create a formula-discount pricelist that yields a non-terminating
         decimal from our product's lst_price (375.024 * (1 - 0.2307) ≈ 288.48).
+
+        We use a ``formula`` rule with ``price_discount`` (base = list_price)
+        rather than a ``percentage`` rule on purpose: a ``percentage`` rule is
+        surfaced as a separate ``discount`` field on the sale line whenever the
+        "Discounts" feature (``sale.group_discount_per_so_line``) is enabled,
+        which leaves ``price_unit`` at the un-discounted list price and the raw
+        value in ``discount`` — so the unrounded-``price_unit`` bug this module
+        fixes never materialises. A ``formula`` rule bakes the reduction into
+        ``price_unit`` regardless of that feature, reproducing Bug 1 in every
+        company configuration.
         """
         pricelist = self.env["product.pricelist"].create({
             "name": name,
             "currency_id": self.env.company.currency_id.id,
             "item_ids": [Command.create({
-                "compute_price": "percentage",
-                "percent_price": 23.07,
+                "compute_price": "formula",
+                "base": "list_price",
+                "price_discount": 23.07,
                 "applied_on": "3_global",
             })],
         })
@@ -189,8 +200,9 @@ class TestPriceSubtotalConsistency(SaleCommon):
             "name": "Pricelist 10.03%",
             "currency_id": self.env.company.currency_id.id,
             "item_ids": [Command.create({
-                "compute_price": "percentage",
-                "percent_price": 10.03,
+                "compute_price": "formula",
+                "base": "list_price",
+                "price_discount": 10.03,
                 "applied_on": "3_global",
             })],
         })


### PR DESCRIPTION
`TestPriceSubtotalConsistency` built its pricelists with `compute_price='percentage'`. When the **Discounts** feature (`sale.group_discount_per_so_line`) is enabled — as it is on RWI — a percentage rule is surfaced as a separate `discount` field on the sale line (`_show_discount()` is only true for percentage rules), leaving `price_unit` at the un-discounted list price. The line is then internally consistent (`price_subtotal = price_unit * (1 - discount%)`), but the test asserts `price_subtotal == round(price_unit) * qty`, ignoring `discount`, so it fails (subtotal 288.5 vs price_unit 375.02, **diff 86.52**).

The module's Bug 1 (unrounded `price_unit`) only occurs when the pricelist bakes a non-terminating value into `price_unit`. A `formula` rule with `price_discount` (base = list_price) does exactly that regardless of the Discounts feature — matching the test's own docstring. Both pricelists switched to formula so the tests reproduce Bug 1 and pass in every company configuration.

**Verified locally**: reproduced the failure with the feature enabled (percentage → diff 86.52); suite passes with the fix both feature-on and feature-off (0 failed, 0 errors of 15 tests).