### PR TITLE
ci: producer auto-tag for per-addon vendoring (#3992) — 18.0 port

### DIFF
--- a/.github/scripts/test_vendor_autotag.py
+++ b/.github/scripts/test_vendor_autotag.py
@@ -1,0 +1,107 @@
+"""Tests for the producer auto-tag script (bemade-addons)."""
+import subprocess
+from pathlib import Path
+
+import pytest
+import vendor_autotag as vt
+
+
+def _git(repo, *args):
+    return subprocess.run(
+        ["git", "-C", str(repo), *args], check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+
+def _repo(tmp_path):
+    repo = tmp_path / "addons"
+    (repo / "my_addon").mkdir(parents=True)
+    (repo / "my_addon" / "__manifest__.py").write_text(
+        "{'name': 'My', 'version': '19.0.1.0.0'}\n"
+    )
+    (repo / "my_addon" / "m.py").write_text("v = 1\n")
+    (repo / "other").mkdir()
+    (repo / "other" / "__manifest__.py").write_text(
+        "{'name': 'Other', 'version': '19.0.2.0.0'}\n"
+    )
+    (repo / "notanaddon").mkdir()
+    (repo / "notanaddon" / "readme.txt").write_text("hi\n")
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "t@t")
+    _git(repo, "config", "user.name", "t")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "v1")
+    return repo
+
+
+def _commit_change(repo, addon, version):
+    (repo / addon / "m.py").write_text("v = 2\n")
+    (repo / addon / "__manifest__.py").write_text(
+        f"{{'name': '{addon}', 'version': '{version}'}}\n"
+    )
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", f"bump {addon} {version}")
+    return _git(repo, "rev-parse", "HEAD")
+
+
+def test_plan_tags_only_changed_bumped_addon(tmp_path):
+    repo = _repo(tmp_path)
+    before = _git(repo, "rev-parse", "HEAD")
+    after = _commit_change(repo, "my_addon", "19.0.1.1.0")
+
+    tags = vt.plan_tags(str(repo), before, after)
+    assert tags == [("my_addon/19.0.1.1.0", after)]
+
+
+def test_plan_tags_skips_existing_tag(tmp_path):
+    repo = _repo(tmp_path)
+    before = _git(repo, "rev-parse", "HEAD")
+    after = _commit_change(repo, "my_addon", "19.0.1.1.0")
+    _git(repo, "tag", "my_addon/19.0.1.1.0")  # already tagged -> immutable
+
+    assert vt.plan_tags(str(repo), before, after) == []
+
+
+def test_plan_tags_ignores_non_addon_dirs(tmp_path):
+    repo = _repo(tmp_path)
+    before = _git(repo, "rev-parse", "HEAD")
+    (repo / "notanaddon" / "readme.txt").write_text("changed\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "touch non-addon")
+    after = _git(repo, "rev-parse", "HEAD")
+
+    assert vt.plan_tags(str(repo), before, after) == []
+
+
+def test_apply_tags_creates_local_tags(tmp_path):
+    repo = _repo(tmp_path)
+    before = _git(repo, "rev-parse", "HEAD")
+    after = _commit_change(repo, "other", "19.0.2.1.0")
+
+    created = vt.apply_tags(
+        str(repo), vt.plan_tags(str(repo), before, after), push=False
+    )
+    assert created == ["other/19.0.2.1.0"]
+    assert "other/19.0.2.1.0" in vt.existing_tags(str(repo))
+
+
+def test_manifest_version_reads_version(tmp_path):
+    repo = _repo(tmp_path)
+    assert vt.manifest_version(str(repo), "my_addon") == "19.0.1.0.0"
+    assert vt.manifest_version(str(repo), "notanaddon") is None
+
+
+def test_two_addons_changed_both_tagged(tmp_path):
+    repo = _repo(tmp_path)
+    before = _git(repo, "rev-parse", "HEAD")
+    (repo / "my_addon" / "__manifest__.py").write_text(
+        "{'name': 'My', 'version': '19.0.1.2.0'}\n"
+    )
+    (repo / "other" / "__manifest__.py").write_text(
+        "{'name': 'Other', 'version': '19.0.2.2.0'}\n"
+    )
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "bump both")
+    after = _git(repo, "rev-parse", "HEAD")
+
+    tags = dict(vt.plan_tags(str(repo), before, after))
+    assert set(tags) == {"my_addon/19.0.1.2.0", "other/19.0.2.2.0"}

--- a/.github/scripts/vendor_autotag.py
+++ b/.github/scripts/vendor_autotag.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# Copyright 2026 Bemade Inc.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+"""Auto-tag changed addons as ``<addon>/<version>`` on a push to a mainline branch.
+
+Runs in bemade-addons GitHub Actions after a merge. For each top-level addon dir
+that changed in the pushed range, it reads the manifest version and creates a tag
+``<addon>/<version>`` at the merge commit — the pin the per-addon vendoring
+lockfile references. Tags are **immutable**: a version is tagged once and never
+moved (matches the lockfile's tag-immutability assumption), so re-runs and
+version-unchanged pushes are no-ops.
+"""
+from __future__ import annotations
+
+import ast
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_MANIFESTS = ("__manifest__.py", "__openerp__.py")
+
+
+def _run(*args: str, cwd: str | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(list(args), cwd=cwd, capture_output=True, text=True)
+
+
+def _git(repo: str, *args: str) -> subprocess.CompletedProcess:
+    return _run("git", "-C", str(repo), *args)
+
+
+def changed_top_dirs(repo: str, before: str, after: str) -> set[str]:
+    """Top-level directory names touched between two commits."""
+    out = _git(repo, "diff", "--name-only", before, after).stdout
+    dirs = set()
+    for line in out.splitlines():
+        head, _, tail = line.partition("/")
+        if tail:  # a file inside a top-level dir
+            dirs.add(head)
+    return dirs
+
+
+def is_addon(repo: str, name: str) -> bool:
+    return any((Path(repo) / name / mf).is_file() for mf in _MANIFESTS)
+
+
+def manifest_version(repo: str, addon: str) -> str | None:
+    for mf in _MANIFESTS:
+        p = Path(repo) / addon / mf
+        if p.is_file():
+            try:
+                data = ast.literal_eval(p.read_text().strip())
+            except (ValueError, SyntaxError):
+                return None
+            if isinstance(data, dict) and data.get("version"):
+                return str(data["version"])
+            return None
+    return None
+
+
+def existing_tags(repo: str) -> set[str]:
+    return set(_git(repo, "tag", "-l").stdout.split())
+
+
+def plan_tags(repo: str, before: str, after: str) -> list[tuple[str, str]]:
+    """Return ``[(tag, commit)]`` to create — only new (addon, version) pairs."""
+    existing = existing_tags(repo)
+    tags: list[tuple[str, str]] = []
+    for d in sorted(changed_top_dirs(repo, before, after)):
+        if not is_addon(repo, d):
+            continue
+        version = manifest_version(repo, d)
+        if not version:
+            continue
+        tag = f"{d}/{version}"
+        if tag in existing:  # immutable — a version is tagged once
+            continue
+        tags.append((tag, after))
+    return tags
+
+
+def apply_tags(repo: str, tags: list[tuple[str, str]], push: bool = True) -> list[str]:
+    created = []
+    for tag, sha in tags:
+        r = _git(repo, "tag", tag, sha)
+        if r.returncode != 0:
+            print(f"tag {tag}: FAILED: {r.stderr.strip()}", file=sys.stderr)
+            continue
+        created.append(tag)
+        print(f"created tag {tag} -> {sha[:12]}")
+    if push and created:
+        refs = [f"refs/tags/{t}" for t in created]
+        r = _git(repo, "push", "origin", *refs)
+        if r.returncode != 0:
+            print(f"push tags FAILED: {r.stderr.strip()}", file=sys.stderr)
+            sys.exit(1)
+    return created
+
+
+def main() -> None:
+    repo = os.environ.get("GITHUB_WORKSPACE", ".")
+    before = os.environ.get("BEFORE_SHA", "")
+    after = os.environ.get("AFTER_SHA", "HEAD")
+    # First push of a new branch: before is all-zeros — nothing to diff, and we do
+    # NOT mass-tag every addon. Skip.
+    if not before or set(before) == {"0"}:
+        print("new-branch or empty before-sha; skipping auto-tag")
+        return
+    tags = plan_tags(repo, before, after)
+    if not tags:
+        print("no new addon version tags to create")
+        return
+    apply_tags(repo, tags, push=os.environ.get("AUTOTAG_PUSH", "1") != "0")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/vendor-tag.yml
+++ b/.github/workflows/vendor-tag.yml
@@ -1,0 +1,33 @@
+name: vendor-tag
+
+# Producer auto-tag for per-addon vendoring (Bemade task #3992): on a merge to a
+# mainline branch, tag each changed addon as <addon>/<version> from its manifest.
+# These tags are the pins the vendoring lockfile (addons.lock) resolves to; a
+# fan-out step (added later) opens vendor-bump MRs in consuming client repos.
+
+on:
+  push:
+    branches:
+      - "17.0"
+      - "18.0"
+      - "19.0"
+
+permissions:
+  contents: write  # create + push tags
+
+concurrency:
+  group: vendor-tag-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history + tags, so plan_tags sees existing tags
+      - name: Auto-tag changed addons <addon>/<version>
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
+        run: python3 .github/scripts/vendor_autotag.py


### PR DESCRIPTION
Port of the auto-tag workflow to **18.0** (merged to 19.0 in #202). A GitHub Actions workflow only runs on the branch it lives on, so 18.0 needs its own copy to tag `<addon>/<version>` on 18.0 pushes.

Identical to the 19.0 files (`vendor-tag.yml` + `vendor_autotag.py` + 6 unit tests). Additive, no addon code touched.