### PR TITLE
chore(bemade_user_password_bundle): retire la mention Odoo 15 du manifest

### DIFF
--- a/bemade_user_password_bundle/__manifest__.py
+++ b/bemade_user_password_bundle/__manifest__.py
@@ -7,7 +7,7 @@
     """,
 
     'description': """
-        This module automate the creation of a password bundle for new users in Odoo 15 and changes the default admin 
+        This module automates the creation of a password bundle for new users and changes the default admin 
         ownership of bundle to admin/setting group instead of the bundle creator.
     """,
 


### PR DESCRIPTION
Dépoussiérage manifest (item de dette technique du runbook de migration DurPro 19) : la description mentionnait « Odoo 15 ».

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZxVGypsFJUEUs2bgWZ8ot