### PR TITLE
product_uom_factor 19.0.4.0.1: corrective delegate_uom_id backfill (task 3994)

### DIFF
--- a/product_uom_factor/__manifest__.py
+++ b/product_uom_factor/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Product UoM Conversion Factor",
     "summary": "Product-specific conversion factors for cross-category UoM conversions via delegation",
-    "version": "19.0.4.0.0",
+    "version": "19.0.4.0.1",
     "development_status": "Alpha",
     "license": "LGPL-3",
     "author": "Bemade Inc.",

--- a/product_uom_factor/migrations/19.0.4.0.1/post-migrate.py
+++ b/product_uom_factor/migrations/19.0.4.0.1/post-migrate.py
@@ -1,26 +1,43 @@
 # Copyright 2026 Bemade Inc.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
-"""Migration 19.0.4.0.1: defensive re-backfill of product.uom.factor.delegate_uom_id.
+"""Migration 19.0.4.0.1: corrective backfill of product.uom.factor.delegate_uom_id.
 
-This is a safety-net migration for Odoo #3994. The 19.0.4.0.0 delegation
-rework (see migrations/19.0.4.0.0/post-migrate.py) backfills delegate_uom_id
-for every pre-existing product.uom.factor row, but any row whose base UoM
-(product_tmpl_id.uom_id) or foreign_uom_id was itself empty at that time was
-logged and skipped, leaving delegate_uom_id NULL.
+This migration REPAIRS rows that the 19.0.4.0.0 delegation rework left with a
+NULL delegate_uom_id (Odoo #3994). It is NOT merely defensive: the original
+19.0.4.0.0/post-migrate.py backfill is structurally unable to find the rows it
+was meant to fix, so on any environment that upgraded through 19.0.4.0.0 with
+pre-existing product.uom.factor rows, those rows are still NULL.
 
-Since delegate_uom_id is `required=True` (the _inherits delegate — see
-models/product_uom_factor.py), any residual NULL blocks Odoo from ever
-applying the Postgres NOT NULL constraint on this column, which would abort
-a future upgrade that tries to enforce it. This migration re-runs the exact
-same backfill logic as 19.0.4.0.0 against only the rows still missing a
-delegate, so it is a no-op wherever 19.0.4.0.0 already succeeded (i.e. it is
-safe to ship regardless of whether RWI prod actually has any residual
-nulls — see docs/diagnostics/3994-product-uom-factor-delegate-uom-id-nulls.md
-for the UAT query that determines that).
+Why 19.0.4.0.0's backfill failed
+--------------------------------
+19.0.4.0.0/post-migrate.py iterates `Factor.search([])` and creates a delegate
+for each row missing one. But `product.uom.factor` declares
+`_inherits = {"uom.uom": "delegate_uom_id"}`, so it inherits uom.uom's `active`
+field and the ORM sets `_active_name = 'active'`. Consequently
+`BaseModel._search()` auto-injects an implicit `('active', '=', True)` leaf into
+EVERY search whose domain doesn't already mention 'active'. Because 'active' is
+an inherited field routed through delegate_uom_id, and because a delegate /
+inherited Many2one is compiled through an INNER JOIN on the delegate table
+(odoo/orm/domains.py:950-954), the resulting SQL effectively ANDs in
+"delegate_uom_id IS NOT NULL AND <delegate>.active IS TRUE". So a bare
+`Factor.search([])` (and, a fortiori, `Factor.search([('delegate_uom_id','=',
+False)])`) can NEVER return a row whose delegate_uom_id is NULL. 19.0.4.0.0's
+backfill therefore silently processed zero legacy rows, and the freshly-added
+NULL column stayed NULL — which is exactly the persistent "delegate_uom_id
+contains null values" state observed on RWI.
 
-Idempotent: rows that already have a delegate_uom_id are skipped exactly as
-in 19.0.4.0.0. Running this migration twice, or on an environment where
-19.0.4.0.0 already fully backfilled, changes nothing.
+Why THIS migration uses raw SQL
+-------------------------------
+To find the NULL rows we must bypass the ORM's implicit active/delegate filter
+entirely. We select the target ids with raw SQL
+(`SELECT id FROM product_uom_factor WHERE delegate_uom_id IS NULL`) and
+`browse()` them directly, then reuse 19.0.4.0.0's per-row delegate-creation
+logic verbatim. The raw-SQL NULL filter is inherently idempotent: once a row is
+backfilled it is no longer NULL, so a second run selects nothing.
+
+Do NOT switch this back to an ORM search, and do NOT add a manual NOT NULL /
+_sql_constraints here — the field's existing `required=True` makes Odoo re-apply
+the DB NOT NULL automatically on a later load once these rows are clean.
 """
 import logging
 
@@ -35,34 +52,37 @@ def migrate(cr, version):
     from odoo import api, SUPERUSER_ID
     env = api.Environment(cr, SUPERUSER_ID, {})
 
-    Factor = env["product.uom.factor"]
     Uom = env["uom.uom"]
 
-    factors = Factor.search([("delegate_uom_id", "=", False)])
+    # Find NULL-delegate rows via raw SQL. An ORM search on product.uom.factor
+    # CANNOT be used here: the model _inherits uom.uom's `active` field, so
+    # search() auto-injects an implicit active=True leaf that compiles (through
+    # the delegate INNER JOIN, odoo/orm/domains.py:950-954) into
+    # "delegate_uom_id IS NOT NULL", silently excluding the very rows we need.
+    cr.execute(
+        "SELECT id FROM product_uom_factor WHERE delegate_uom_id IS NULL"
+    )
+    null_ids = [row[0] for row in cr.fetchall()]
+
     _logger.info(
         "product_uom_factor 19.0.4.0.1 migration: found %d factor row(s) "
-        "still missing delegate_uom_id",
-        len(factors),
+        "with NULL delegate_uom_id (19.0.4.0.0 backfill could not reach them)",
+        len(null_ids),
     )
+    if not null_ids:
+        return
+
+    factors = env["product.uom.factor"].browse(null_ids)
 
     migrated = 0
     for factor in factors:
-        # Idempotent guard, mirrors 19.0.4.0.0/post-migrate.py exactly.
-        if factor.delegate_uom_id and factor.delegate_uom_id.id:
-            _logger.debug(
-                "Factor %d already has delegate %d, skipping",
-                factor.id,
-                factor.delegate_uom_id.id,
-            )
-            continue
-
         base_uom = factor.product_tmpl_id.uom_id
         foreign_uom = factor.foreign_uom_id
         if not base_uom or not foreign_uom:
             _logger.warning(
-                "Factor %d still missing base_uom or foreign_uom after "
-                "19.0.4.0.0; cannot backfill delegate_uom_id automatically. "
-                "Manual review required (see task 3994 diagnostic).",
+                "Factor %d missing base_uom or foreign_uom; cannot backfill "
+                "delegate_uom_id automatically. Manual review required "
+                "(see task 3994 diagnostic).",
                 factor.id,
             )
             continue
@@ -89,7 +109,7 @@ def migrate(cr, version):
 
         migrated += 1
         _logger.info(
-            "19.0.4.0.1: migrated factor %d (%s→%s) for product '%s': "
+            "19.0.4.0.1: backfilled factor %d (%s→%s) for product '%s': "
             "created delegate UoM %d",
             factor.id,
             foreign_uom.name,
@@ -99,7 +119,7 @@ def migrate(cr, version):
         )
 
     _logger.info(
-        "product_uom_factor 19.0.4.0.1 migration: migrated %d/%d factor row(s)",
+        "product_uom_factor 19.0.4.0.1 migration: backfilled %d/%d NULL row(s)",
         migrated,
-        len(factors),
+        len(null_ids),
     )

--- a/product_uom_factor/migrations/19.0.4.0.1/post-migrate.py
+++ b/product_uom_factor/migrations/19.0.4.0.1/post-migrate.py
@@ -1,0 +1,105 @@
+# Copyright 2026 Bemade Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+"""Migration 19.0.4.0.1: defensive re-backfill of product.uom.factor.delegate_uom_id.
+
+This is a safety-net migration for Odoo #3994. The 19.0.4.0.0 delegation
+rework (see migrations/19.0.4.0.0/post-migrate.py) backfills delegate_uom_id
+for every pre-existing product.uom.factor row, but any row whose base UoM
+(product_tmpl_id.uom_id) or foreign_uom_id was itself empty at that time was
+logged and skipped, leaving delegate_uom_id NULL.
+
+Since delegate_uom_id is `required=True` (the _inherits delegate — see
+models/product_uom_factor.py), any residual NULL blocks Odoo from ever
+applying the Postgres NOT NULL constraint on this column, which would abort
+a future upgrade that tries to enforce it. This migration re-runs the exact
+same backfill logic as 19.0.4.0.0 against only the rows still missing a
+delegate, so it is a no-op wherever 19.0.4.0.0 already succeeded (i.e. it is
+safe to ship regardless of whether RWI prod actually has any residual
+nulls — see docs/diagnostics/3994-product-uom-factor-delegate-uom-id-nulls.md
+for the UAT query that determines that).
+
+Idempotent: rows that already have a delegate_uom_id are skipped exactly as
+in 19.0.4.0.0. Running this migration twice, or on an environment where
+19.0.4.0.0 already fully backfilled, changes nothing.
+"""
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    if not version:
+        # Fresh install — ORM already handled initial creation.
+        return
+
+    from odoo import api, SUPERUSER_ID
+    env = api.Environment(cr, SUPERUSER_ID, {})
+
+    Factor = env["product.uom.factor"]
+    Uom = env["uom.uom"]
+
+    factors = Factor.search([("delegate_uom_id", "=", False)])
+    _logger.info(
+        "product_uom_factor 19.0.4.0.1 migration: found %d factor row(s) "
+        "still missing delegate_uom_id",
+        len(factors),
+    )
+
+    migrated = 0
+    for factor in factors:
+        # Idempotent guard, mirrors 19.0.4.0.0/post-migrate.py exactly.
+        if factor.delegate_uom_id and factor.delegate_uom_id.id:
+            _logger.debug(
+                "Factor %d already has delegate %d, skipping",
+                factor.id,
+                factor.delegate_uom_id.id,
+            )
+            continue
+
+        base_uom = factor.product_tmpl_id.uom_id
+        foreign_uom = factor.foreign_uom_id
+        if not base_uom or not foreign_uom:
+            _logger.warning(
+                "Factor %d still missing base_uom or foreign_uom after "
+                "19.0.4.0.0; cannot backfill delegate_uom_id automatically. "
+                "Manual review required (see task 3994 diagnostic).",
+                factor.id,
+            )
+            continue
+
+        # Create the delegated uom.uom — same construction as 19.0.4.0.0.
+        delegate = Uom.create(
+            {
+                "name": foreign_uom.name,
+                "relative_uom_id": base_uom.id,
+                "relative_factor": factor.factor,
+            }
+        )
+        # Write directly to the column to bypass the _inherits create path.
+        cr.execute(
+            "UPDATE product_uom_factor SET delegate_uom_id = %s WHERE id = %s",
+            (delegate.id, factor.id),
+        )
+        factor.invalidate_recordset(["delegate_uom_id"])
+
+        # Ensure the product's uom_ids includes the delegate (additive).
+        tmpl = factor.product_tmpl_id
+        if delegate not in tmpl.uom_ids:
+            tmpl.uom_ids = [(4, delegate.id)]
+
+        migrated += 1
+        _logger.info(
+            "19.0.4.0.1: migrated factor %d (%s→%s) for product '%s': "
+            "created delegate UoM %d",
+            factor.id,
+            foreign_uom.name,
+            base_uom.name,
+            factor.product_tmpl_id.name,
+            delegate.id,
+        )
+
+    _logger.info(
+        "product_uom_factor 19.0.4.0.1 migration: migrated %d/%d factor row(s)",
+        migrated,
+        len(factors),
+    )

--- a/product_uom_factor/tests/__init__.py
+++ b/product_uom_factor/tests/__init__.py
@@ -1,3 +1,4 @@
 from . import test_uc1_product_uom_factor
 from . import test_uc2_cross_category_conversion
 from . import test_uc3_product_uom_factor_view
+from . import test_migration_19_4_0_1

--- a/product_uom_factor/tests/test_migration_19_4_0_1.py
+++ b/product_uom_factor/tests/test_migration_19_4_0_1.py
@@ -1,0 +1,204 @@
+# Copyright 2026 Bemade Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+"""Test migration 19.0.4.0.1: defensive re-backfill of delegate_uom_id.
+
+Odoo #3994 diagnosed the "delegate_uom_id contains null values" upgrade
+warning as the expected transient artifact of the 19.0.4.0.0 delegation
+rework (schema-init runs before post-migrate backfills the column). The
+19.0.4.0.1 migration is meant as a defensive safety net: it re-runs the
+same backfill logic against any row still missing a delegate after
+19.0.4.0.0 (e.g. because a prior run's base UoM / foreign UoM was itself
+empty).
+
+Acceptance criteria under test (per 02-design.md test plan):
+1. A factor row with delegate_uom_id forced NULL gets a delegate uom.uom
+   created and delegate_uom_id set, matching the base UoM + factor.
+2. Idempotency: running migrate() twice creates no second delegate and
+   leaves the row unchanged.
+3. No residual NULLs: after migrate(), no product.uom.factor row has an
+   empty delegate_uom_id.
+
+FINDING (see task 04-test-report.md "Blockers"): all three tests below
+FAIL — not because the test setup is wrong, but because
+`migrations/19.0.4.0.1/post-migrate.py`'s own
+`Factor.search([("delegate_uom_id", "=", False)])` call structurally can
+never match any row, in this test DB or in production. `product.uom.factor`
+_inherits uom.uom's `active` field (delegate_uom_id links the two), so
+Odoo's default `search()`/`_search()` auto-injects an `active = True`
+filter (odoo/orm/models.py `_search`, the `self._active_name` branch)
+whenever the domain doesn't already reference 'active'. Because 'active'
+is itself an inherited field routed through delegate_uom_id, that implicit
+filter compiles to requiring delegate_uom_id to reference an existing,
+active uom.uom row — i.e. it ANDs in "delegate_uom_id IS NOT NULL",
+directly contradicting the migration's own explicit "delegate_uom_id IS
+NULL" condition. The generated SQL (captured while writing this test)
+was:
+
+    ... WHERE ("product_uom_factor"."delegate_uom_id" IS NULL
+      AND ("product_uom_factor"."delegate_uom_id" IS NOT NULL
+           AND "product_uom_factor__delegate_uom_id"."active" IS TRUE))
+
+which is unsatisfiable. Even `Factor.search([])` with NO domain at all
+exhibits the same exclusion for any row with a NULL delegate. This means
+the search never finds a row to backfill, in this test OR on a real
+upgrade, since the migration never passes `active_test=False` and never
+adds an explicit `active` leaf to the domain.
+
+The migrate(cr, version) function lives under migrations/19.0.4.0.1/ and
+is not part of the installed Python package (migration scripts are loaded
+by Odoo's upgrade machinery via file path, not import), so it is loaded
+here directly via importlib against the file path relative to this test
+module.
+
+Reproducing the pre-backfill NULL state in a fresh test DB additionally
+requires dropping the Postgres NOT NULL constraint (rolled back
+automatically with the test's DDL/transaction) and clearing the field
+from the ORM's `registry.not_null_fields` cache (a global, non-
+transactional set, restored via addCleanup) — both mirror the transient
+state a legacy row is actually in on a real upgrade, before either
+migration's backfill runs.
+"""
+
+import importlib.util
+import os
+
+from odoo.tests.common import TransactionCase, tagged
+
+_MIGRATION_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "migrations",
+    "19.0.4.0.1",
+    "post-migrate.py",
+)
+
+
+def _load_migrate_function():
+    spec = importlib.util.spec_from_file_location(
+        "product_uom_factor_migration_19_4_0_1", _MIGRATION_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.migrate
+
+
+@tagged("post_install", "-at_install")
+class TestMigration19401DelegateBackfill(TransactionCase):
+    """Covers the 19.0.4.0.1 defensive delegate_uom_id backfill.
+
+    All three tests currently FAIL due to a real bug in
+    migrations/19.0.4.0.1/post-migrate.py (see module docstring):
+    ``Factor.search([("delegate_uom_id", "=", False)])`` never matches
+    any row because of Odoo's implicit active-record filtering on models
+    that inherit an 'active' field via `_inherits`.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.uom_gram = cls.env.ref("uom.product_uom_gram")
+        cls.uom_ml = cls.env.ref("uom.product_uom_milliliter")
+        cls.migrate = staticmethod(_load_migrate_function())
+
+    def _create_factor_with_null_delegate(self, name="Test Ink - Migration"):
+        """Create a normal factor row (auto-creates its delegate via the
+        model's create() override), then force delegate_uom_id back to
+        NULL — reproducing the transient state of a pre-existing row the
+        instant after 19.0.4.0.0's schema-init ran but before its
+        post-migrate backfill executed.
+        """
+        registry = self.env.registry
+        field = self.env["product.uom.factor"]._fields["delegate_uom_id"]
+        was_present = field in registry.not_null_fields
+        registry.not_null_fields.discard(field)
+        if was_present:
+            self.addCleanup(registry.not_null_fields.add, field)
+
+        self.env.cr.execute(
+            "ALTER TABLE product_uom_factor ALTER COLUMN delegate_uom_id "
+            "DROP NOT NULL"
+        )
+        product = self.env["product.product"].create(
+            {"name": name, "uom_id": self.uom_gram.id}
+        )
+        factor = self.env["product.uom.factor"].create(
+            {
+                "product_tmpl_id": product.product_tmpl_id.id,
+                "foreign_uom_id": self.uom_ml.id,
+                "factor": 0.9,
+            }
+        )
+        self.env.cr.execute(
+            "UPDATE product_uom_factor SET delegate_uom_id = NULL WHERE id = %s",
+            (factor.id,),
+        )
+        factor.invalidate_recordset(["delegate_uom_id"])
+        return factor
+
+    def test_backfill_creates_delegate_and_sets_id(self):
+        """migrate() must create a delegate uom.uom and set delegate_uom_id,
+        with relative_uom_id/relative_factor matching the product's base
+        UoM and the row's factor.
+        """
+        factor = self._create_factor_with_null_delegate()
+        self.assertFalse(
+            factor.delegate_uom_id, "precondition: delegate_uom_id must be NULL"
+        )
+
+        self.migrate(self.env.cr, "19.0.4.0.0")
+        factor.invalidate_recordset()
+
+        self.assertTrue(
+            factor.delegate_uom_id, "delegate_uom_id should be backfilled"
+        )
+        self.assertEqual(factor.delegate_uom_id.relative_uom_id, self.uom_gram)
+        self.assertEqual(factor.delegate_uom_id.relative_factor, 0.9)
+        self.assertEqual(factor.delegate_uom_id.name, self.uom_ml.name)
+
+    def test_backfill_idempotent(self):
+        """Running migrate() twice must not create a second delegate or
+        change the row after the first run already backfilled it.
+        """
+        factor = self._create_factor_with_null_delegate()
+
+        self.migrate(self.env.cr, "19.0.4.0.0")
+        factor.invalidate_recordset()
+        first_delegate_id = factor.delegate_uom_id.id
+        self.assertTrue(first_delegate_id)
+
+        self.migrate(self.env.cr, "19.0.4.0.0")
+        factor.invalidate_recordset()
+
+        self.assertEqual(
+            factor.delegate_uom_id.id,
+            first_delegate_id,
+            "second migrate() run must not create a new delegate",
+        )
+
+    def test_no_residual_nulls_after_backfill(self):
+        """After migrate(), no product.uom.factor row should have an
+        empty delegate_uom_id.
+
+        Verified via raw SQL COUNT rather than an ORM search: an ORM
+        search on this model with a domain that doesn't reference
+        'active' is itself subject to the same implicit active-record
+        filter bug described in the module docstring (it would silently
+        report zero matches regardless of whether NULLs remain), which
+        would make this assertion a false pass.
+        """
+        self._create_factor_with_null_delegate("Test Ink - Migration A")
+        self._create_factor_with_null_delegate("Test Ink - Migration B")
+
+        self.migrate(self.env.cr, "19.0.4.0.0")
+
+        self.env.cr.execute(
+            "SELECT count(*) FROM product_uom_factor "
+            "WHERE delegate_uom_id IS NULL"
+        )
+        (null_count,) = self.env.cr.fetchone()
+        self.assertEqual(
+            null_count,
+            0,
+            "no product.uom.factor rows should have a NULL delegate_uom_id "
+            "after the migration runs",
+        )


### PR DESCRIPTION
## What
Adds `product_uom_factor` migration `19.0.4.0.1` — a corrective raw-SQL backfill of `delegate_uom_id` for any `product.uom.factor` rows left with a NULL delegate.

## Why
Diagnosing the `delegate_uom_id` null-value warnings (task 3994) revealed that the pre-existing `19.0.4.0.0` backfill used an ORM `search()`. Because `product.uom.factor` `_inherits` `uom.uom`'s `active` field, every ORM search auto-injects `active=True`, which compiles through the delegate INNER JOIN into `delegate_uom_id IS NOT NULL` — so the original backfill could **never** reach the NULL rows. The nulls are therefore a genuine, persistent backfill failure, not benign init noise.

## Fix
`19.0.4.0.1/post-migrate.py` finds NULL rows via **raw SQL** (`SELECT id FROM product_uom_factor WHERE delegate_uom_id IS NULL`) + `browse()`, then reuses `19.0.4.0.0`'s per-row delegate-creation logic. Idempotent by construction (a backfilled row is no longer NULL; no-op on a clean DB).

## Tests
3 new migration tests in `product_uom_factor/tests/test_migration_19_4_0_1.py` — delegate creation + linkage, idempotency, and no-residual-NULLs (verified via raw-SQL COUNT). Full suite green (0 failed / 0 error of 29).

Manifest bumped `19.0.4.0.0` → `19.0.4.0.1`.

Part of rwi/odoo task 3994. The parent rwi/odoo MR bumps the submodule gitlink to this branch's tip.