### PR TITLE
npo_fundraising_crm: bilingual NPO fundraising vocabulary for CRM

### DIFF
--- a/npo_fundraising_crm/__init__.py
+++ b/npo_fundraising_crm/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from .hooks import post_init_hook

--- a/npo_fundraising_crm/__manifest__.py
+++ b/npo_fundraising_crm/__manifest__.py
@@ -1,0 +1,72 @@
+#
+#    Bemade Inc.
+#
+#    Copyright (C) 2026-July Bemade Inc. (<https://www.bemade.org>).
+#    Author: Marc Durepos (Contact : marc@bemade.org)
+#
+#    This program is under the terms of the GNU Lesser General Public License,
+#    version 3.
+#
+#    For full license details, see https://www.gnu.org/licenses/lgpl-3.0.en.html.
+#
+{
+    "name": "NPO Fundraising CRM Vocabulary",
+    "version": "19.0.1.0.0",
+    "summary": "Relabels the Sales/CRM vocabulary into fundraising terms "
+    "(donations, prospects, donors, solicitors) in English and Quebec French.",
+    "description": """
+NPO Fundraising CRM Vocabulary
+==============================
+
+Re-labels the standard Odoo Sales/CRM vocabulary into non-profit fundraising
+terms, so the CRM app reads as a development/fundraising pipeline rather than a
+sales pipeline. A reusable base for Quebec non-profits.
+
+The relabel is **bilingual**: it changes the English (``en_US``) base language
+*and* ships a Quebec French (``fr_CA``) translation, so the pack is useful both
+for a French Quebec instance and, unchanged, for an English NPO.
+
+Mapping (English → French):
+
+- Opportunity → Donation / Don
+- Lead → Prospect / Prospect
+- Salesperson → Solicitor / Solliciteur
+- Sales Team → Development Team / Équipe de développement
+- Customer → Donor / Donateur
+- Expected Revenue → Expected Amount / Montant attendu
+- Won / Lost → Secured / Declined — Réalisé / Refusé
+- Stages: New → Qualified → Proposition → Won become
+  Identification → Qualification → Solicitation → Secured
+  (Identification → Qualification → Sollicitation → Réalisé)
+
+Mechanism
+---------
+
+Because Odoo 16+ stores translations as per-record JSONB, the visible French
+labels come from translations already loaded by ``crm``. Changing the English
+source alone does not change the French UI, so this module:
+
+1. overrides the English source (field ``string``/selection labels via
+   ``_inherit``; menu/action/stage record names via data; a couple of
+   hard-coded search-view strings via view inheritance), and
+2. ships an ``fr_CA`` translation loaded on install with ``overwrite=True``
+   (``post_init_hook``) so it wins over the terms ``crm`` already translated.
+""",
+    "category": "Sales/CRM",
+    "author": "Bemade Inc.",
+    "website": "https://www.bemade.org",
+    "license": "LGPL-3",
+    "depends": [
+        "crm",
+        "contacts",
+    ],
+    "data": [
+        "data/crm_stage.xml",
+        "data/crm_menu.xml",
+        "data/crm_action.xml",
+        "views/crm_lead_views.xml",
+    ],
+    "post_init_hook": "post_init_hook",
+    "installable": True,
+    "application": False,
+}

--- a/npo_fundraising_crm/data/crm_action.xml
+++ b/npo_fundraising_crm/data/crm_action.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!--
+        Relabel the window actions that carry sales vocabulary (English source;
+        French from i18n/fr_CA.po).
+    -->
+    <record id="crm.crm_lead_opportunities" model="ir.actions.act_window">
+        <field name="name">Donations</field>
+    </record>
+    <record id="crm.crm_lead_all_leads" model="ir.actions.act_window">
+        <field name="name">Prospects</field>
+    </record>
+    <record id="sales_team.crm_team_action_config" model="ir.actions.act_window">
+        <field name="name">Development Teams</field>
+    </record>
+    <record id="sales_team.crm_team_action_sales" model="ir.actions.act_window">
+        <field name="name">Development Teams</field>
+    </record>
+
+</odoo>

--- a/npo_fundraising_crm/data/crm_menu.xml
+++ b/npo_fundraising_crm/data/crm_menu.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!--
+        Relabel the CRM app menus to fundraising terms (English source; French
+        from i18n/fr_CA.po). Only the user-facing "sales" wording is changed;
+        the menu structure/actions are left intact.
+    -->
+    <record id="crm.crm_menu_root" model="ir.ui.menu">
+        <field name="name">Fundraising</field>
+    </record>
+    <record id="crm.crm_menu_sales" model="ir.ui.menu">
+        <field name="name">Donations</field>
+    </record>
+    <record id="crm.crm_menu_leads" model="ir.ui.menu">
+        <field name="name">Prospects</field>
+    </record>
+    <record id="crm.res_partner_menu_customer" model="ir.ui.menu">
+        <field name="name">Donors</field>
+    </record>
+    <record id="crm.crm_team_config" model="ir.ui.menu">
+        <field name="name">Development Teams</field>
+    </record>
+
+</odoo>

--- a/npo_fundraising_crm/data/crm_stage.xml
+++ b/npo_fundraising_crm/data/crm_stage.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!--
+        Relabel the default pipeline stages (English source). The French names
+        come from i18n/fr_CA.po. These override the crm.stage records defined
+        (noupdate) by crm; our data is applied on install/upgrade of this
+        module. Note: the "Secured" stage keeps is_won=True, so won donations
+        stay correctly classified.
+    -->
+    <record id="crm.stage_lead1" model="crm.stage">
+        <field name="name">Identification</field>
+    </record>
+    <record id="crm.stage_lead2" model="crm.stage">
+        <field name="name">Qualification</field>
+    </record>
+    <record id="crm.stage_lead3" model="crm.stage">
+        <field name="name">Solicitation</field>
+    </record>
+    <record id="crm.stage_lead4" model="crm.stage">
+        <field name="name">Secured</field>
+    </record>
+
+</odoo>

--- a/npo_fundraising_crm/hooks.py
+++ b/npo_fundraising_crm/hooks.py
@@ -1,0 +1,20 @@
+# Copyright 2026 Bemade Inc. (https://www.bemade.org)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0).
+
+
+def post_init_hook(env):
+    """Re-load this module's translations with ``overwrite=True``.
+
+    The default translation load uses ``overwrite=False``, which *skips* any
+    term that already has a value in the target language. Since ``crm`` has
+    already translated "Opportunity" -> "Opportunité", "Salesperson" ->
+    "Vendeur", etc. into ``fr_CA``, our ``fr_CA.po`` overrides would silently
+    do nothing. Forcing an overwrite here makes the fundraising vocabulary win
+    deterministically on install/upgrade (mirror ``--i18n-overwrite`` for CI
+    redeploys).
+    """
+    module = env["ir.module.module"].search(
+        [("name", "=", "npo_fundraising_crm")], limit=1
+    )
+    if module:
+        module._update_translations(overwrite=True)

--- a/npo_fundraising_crm/i18n/fr_CA.po
+++ b/npo_fundraising_crm/i18n/fr_CA.po
@@ -1,0 +1,121 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* npo_fundraising_crm
+#
+# Quebec French (fr_CA) fundraising vocabulary. Authored against this module's
+# English source terms (msgid = the new English label), loaded on install with
+# overwrite=True (see hooks.post_init_hook) so it wins over crm's own fr_CA.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0\n"
+"Report-Msgid-Bugs-To: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: fr_CA\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: npo_fundraising_crm
+#: model:ir.model.fields,field_description:crm.field_crm_lead__name
+#: model:ir.model.fields.selection,name:crm.selection__crm_lead__type__opportunity
+#: model_terms:ir.ui.view,arch_db:npo_fundraising_crm.view_crm_case_opportunities_filter_npo
+msgid "Donation"
+msgstr "Don"
+
+#. module: npo_fundraising_crm
+#: model:ir.model.fields.selection,name:crm.selection__crm_lead__type__lead
+msgid "Prospect"
+msgstr "Prospect"
+
+#. module: npo_fundraising_crm
+#: model:ir.model.fields,field_description:crm.field_crm_lead__user_id
+#: model_terms:ir.ui.view,arch_db:npo_fundraising_crm.view_crm_case_opportunities_filter_npo
+msgid "Solicitor"
+msgstr "Solliciteur"
+
+#. module: npo_fundraising_crm
+#: model:ir.model.fields,field_description:crm.field_crm_lead__team_id
+#: model:ir.model.fields,field_description:sales_team.field_crm_team__name
+#: model:ir.actions.act_window,name:sales_team.crm_team_action_config
+#: model:ir.actions.act_window,name:sales_team.crm_team_action_sales
+#: model:ir.ui.menu,name:crm.crm_team_config
+#: model_terms:ir.ui.view,arch_db:npo_fundraising_crm.view_crm_case_opportunities_filter_npo
+msgid "Development Team"
+msgstr "Équipe de développement"
+
+#. module: npo_fundraising_crm
+#: model:ir.ui.menu,name:crm.crm_team_config
+msgid "Development Teams"
+msgstr "Équipes de développement"
+
+#. module: npo_fundraising_crm
+#: model:ir.model.fields,field_description:crm.field_crm_lead__expected_revenue
+msgid "Expected Amount"
+msgstr "Montant attendu"
+
+#. module: npo_fundraising_crm
+#: model:ir.model.fields,field_description:crm.field_crm_lead__partner_id
+#: model_terms:ir.ui.view,arch_db:npo_fundraising_crm.view_crm_case_opportunities_filter_npo
+msgid "Donor"
+msgstr "Donateur"
+
+#. module: npo_fundraising_crm
+#: model:ir.ui.menu,name:crm.res_partner_menu_customer
+msgid "Donors"
+msgstr "Donateurs"
+
+#. module: npo_fundraising_crm
+#: model:ir.model.fields,field_description:crm.field_crm_lead__lost_reason_id
+msgid "Decline Reason"
+msgstr "Motif de refus"
+
+#. module: npo_fundraising_crm
+#: model:ir.model.fields.selection,name:crm.selection__crm_lead__won_status__won
+#: model:crm.stage,name:crm.stage_lead4
+msgid "Secured"
+msgstr "Réalisé"
+
+#. module: npo_fundraising_crm
+#: model:ir.model.fields.selection,name:crm.selection__crm_lead__won_status__lost
+msgid "Declined"
+msgstr "Refusé"
+
+#. module: npo_fundraising_crm
+#: model:ir.model.fields.selection,name:crm.selection__crm_lead__won_status__pending
+msgid "Pending"
+msgstr "En cours"
+
+#. module: npo_fundraising_crm
+#: model:crm.stage,name:crm.stage_lead1
+msgid "Identification"
+msgstr "Identification"
+
+#. module: npo_fundraising_crm
+#: model:crm.stage,name:crm.stage_lead2
+msgid "Qualification"
+msgstr "Qualification"
+
+#. module: npo_fundraising_crm
+#: model:crm.stage,name:crm.stage_lead3
+msgid "Solicitation"
+msgstr "Sollicitation"
+
+#. module: npo_fundraising_crm
+#: model:ir.ui.menu,name:crm.crm_menu_root
+msgid "Fundraising"
+msgstr "Développement philanthropique"
+
+#. module: npo_fundraising_crm
+#: model:ir.ui.menu,name:crm.crm_menu_sales
+#: model:ir.actions.act_window,name:crm.crm_lead_opportunities
+msgid "Donations"
+msgstr "Dons"
+
+#. module: npo_fundraising_crm
+#: model:ir.ui.menu,name:crm.crm_menu_leads
+#: model:ir.actions.act_window,name:crm.crm_lead_all_leads
+msgid "Prospects"
+msgstr "Prospects"

--- a/npo_fundraising_crm/models/__init__.py
+++ b/npo_fundraising_crm/models/__init__.py
@@ -1,0 +1,2 @@
+from . import crm_lead
+from . import crm_team

--- a/npo_fundraising_crm/models/crm_lead.py
+++ b/npo_fundraising_crm/models/crm_lead.py
@@ -1,0 +1,27 @@
+# Copyright 2026 Bemade Inc. (https://www.bemade.org)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0).
+from odoo import fields, models
+
+
+class CrmLead(models.Model):
+    """Relabel the opportunity's sales vocabulary to fundraising terms.
+
+    Only the ``string``/``selection`` labels (the English source) are
+    overridden here; all other field behaviour is inherited unchanged. The
+    French labels are supplied by ``i18n/fr_CA.po``.
+    """
+
+    _inherit = "crm.lead"
+
+    name = fields.Char(string="Donation")
+    user_id = fields.Many2one(string="Solicitor")
+    team_id = fields.Many2one(string="Development Team")
+    expected_revenue = fields.Monetary(string="Expected Amount")
+    partner_id = fields.Many2one(string="Donor")
+    lost_reason_id = fields.Many2one(string="Decline Reason")
+    type = fields.Selection(
+        selection=[("lead", "Prospect"), ("opportunity", "Donation")]
+    )
+    won_status = fields.Selection(
+        selection=[("won", "Secured"), ("lost", "Declined"), ("pending", "Pending")]
+    )

--- a/npo_fundraising_crm/models/crm_team.py
+++ b/npo_fundraising_crm/models/crm_team.py
@@ -1,0 +1,11 @@
+# Copyright 2026 Bemade Inc. (https://www.bemade.org)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0).
+from odoo import fields, models
+
+
+class CrmTeam(models.Model):
+    """A "Sales Team" is a fundraising "Development Team"."""
+
+    _inherit = "crm.team"
+
+    name = fields.Char(string="Development Team")

--- a/npo_fundraising_crm/tests/__init__.py
+++ b/npo_fundraising_crm/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_vocabulary

--- a/npo_fundraising_crm/tests/test_vocabulary.py
+++ b/npo_fundraising_crm/tests/test_vocabulary.py
@@ -1,0 +1,117 @@
+# Copyright 2026 Bemade Inc. (https://www.bemade.org)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0).
+"""Acceptance criteria for the NPO fundraising vocabulary pack.
+
+The module must relabel the Sales/CRM vocabulary in BOTH languages:
+
+1. English (``en_US`` base) — the field ``string`` labels, the Lead/Opportunity
+   and Won/Lost selection labels, and the menu / stage record names must read
+   as fundraising terms (Donation, Solicitor, Development Team, Donor, Secured,
+   Solicitation, Donors, Fundraising…). This is the reusable base and must hold
+   with no language installed.
+
+2. Quebec French (``fr_CA``) — after the fr_CA translation is loaded with
+   overwrite=True (as the post_init_hook does on the live instance), the same
+   surfaces must read as Don / Solliciteur / Équipe de développement / Donateur
+   / Réalisé / Sollicitation / Donateurs / Développement philanthropique,
+   overriding crm's own French terms. This is the load-bearing risk (default
+   translation load is overwrite=False and would silently skip already-French
+   terms), so it is asserted directly.
+
+The "Secured" stage must keep is_won=True so won donations stay classified.
+"""
+from odoo.tests import TransactionCase, tagged
+
+_FIELDS = [
+    "name",
+    "user_id",
+    "team_id",
+    "expected_revenue",
+    "partner_id",
+    "lost_reason_id",
+    "type",
+    "won_status",
+]
+
+
+@tagged("post_install", "-at_install")
+class TestNpoVocabulary(TransactionCase):
+    def _labels(self, lang):
+        return self.env["crm.lead"].with_context(lang=lang).fields_get(_FIELDS)
+
+    def test_english_source_relabelled(self):
+        f = self._labels("en_US")
+        self.assertEqual(f["name"]["string"], "Donation")
+        self.assertEqual(f["user_id"]["string"], "Solicitor")
+        self.assertEqual(f["team_id"]["string"], "Development Team")
+        self.assertEqual(f["expected_revenue"]["string"], "Expected Amount")
+        self.assertEqual(f["partner_id"]["string"], "Donor")
+        self.assertEqual(f["lost_reason_id"]["string"], "Decline Reason")
+
+        type_sel = dict(f["type"]["selection"])
+        self.assertEqual(type_sel["opportunity"], "Donation")
+        self.assertEqual(type_sel["lead"], "Prospect")
+        won_sel = dict(f["won_status"]["selection"])
+        self.assertEqual(won_sel["won"], "Secured")
+        self.assertEqual(won_sel["lost"], "Declined")
+
+        # crm.team field label
+        team_fields = self.env["crm.team"].with_context(lang="en_US").fields_get(["name"])
+        self.assertEqual(team_fields["name"]["string"], "Development Team")
+
+        # Stage / menu record names (English source).
+        self.assertEqual(
+            self.env.ref("crm.stage_lead3").with_context(lang="en_US").name,
+            "Solicitation",
+        )
+        secured = self.env.ref("crm.stage_lead4").with_context(lang="en_US")
+        self.assertEqual(secured.name, "Secured")
+        self.assertTrue(secured.is_won)  # still a won stage
+        self.assertEqual(
+            self.env.ref("crm.res_partner_menu_customer").with_context(lang="en_US").name,
+            "Donors",
+        )
+        self.assertEqual(
+            self.env.ref("crm.crm_menu_root").with_context(lang="en_US").name,
+            "Fundraising",
+        )
+
+    def test_french_translation_relabelled(self):
+        # Reproduce what the live (French) instance does: activate fr_CA and
+        # load this module's fr_CA.po with overwrite=True.
+        self.env["res.lang"]._activate_lang("fr_CA")
+        self.env.ref("base.module_npo_fundraising_crm")._update_translations(
+            overwrite=True
+        )
+        self.env.registry.clear_cache()
+
+        f = self._labels("fr_CA")
+        self.assertEqual(f["name"]["string"], "Don")
+        self.assertEqual(f["user_id"]["string"], "Solliciteur")
+        self.assertEqual(f["team_id"]["string"], "Équipe de développement")
+        self.assertEqual(f["expected_revenue"]["string"], "Montant attendu")
+        self.assertEqual(f["partner_id"]["string"], "Donateur")
+        self.assertEqual(f["lost_reason_id"]["string"], "Motif de refus")
+
+        type_sel = dict(f["type"]["selection"])
+        self.assertEqual(type_sel["opportunity"], "Don")
+        won_sel = dict(f["won_status"]["selection"])
+        self.assertEqual(won_sel["won"], "Réalisé")
+        self.assertEqual(won_sel["lost"], "Refusé")
+
+        self.assertEqual(
+            self.env.ref("crm.stage_lead3").with_context(lang="fr_CA").name,
+            "Sollicitation",
+        )
+        self.assertEqual(
+            self.env.ref("crm.stage_lead4").with_context(lang="fr_CA").name,
+            "Réalisé",
+        )
+        self.assertEqual(
+            self.env.ref("crm.res_partner_menu_customer").with_context(lang="fr_CA").name,
+            "Donateurs",
+        )
+        self.assertEqual(
+            self.env.ref("crm.crm_menu_root").with_context(lang="fr_CA").name,
+            "Développement philanthropique",
+        )

--- a/npo_fundraising_crm/views/crm_lead_views.xml
+++ b/npo_fundraising_crm/views/crm_lead_views.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!--
+        The opportunity search view hard-codes a few sales labels as element
+        attributes (not field labels), so a Python string= override can't reach
+        them. Relabel them here (English source); the French comes from
+        i18n/fr_CA.po, which references this view's arch terms.
+    -->
+    <record id="view_crm_case_opportunities_filter_npo" model="ir.ui.view">
+        <field name="name">crm.lead.search.opportunity.npo</field>
+        <field name="model">crm.lead</field>
+        <field name="inherit_id" ref="crm.view_crm_case_opportunities_filter"/>
+        <field name="arch" type="xml">
+            <field name="name" position="attributes">
+                <attribute name="string">Donation</attribute>
+            </field>
+            <field name="partner_id" position="attributes">
+                <attribute name="string">Donor</attribute>
+            </field>
+            <filter name="salesperson" position="attributes">
+                <attribute name="string">Solicitor</attribute>
+            </filter>
+            <filter name="saleschannel" position="attributes">
+                <attribute name="string">Development Team</attribute>
+            </filter>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
## What

New reusable module that relabels the standard **Sales/CRM** vocabulary into **non-profit fundraising** terms, in **both `en_US` (base) and `fr_CA`** — a base for NPOs (Quebec-French-first, but usable English-only unchanged).

| English (source) | Français (fr_CA) |
|---|---|
| Opportunity → **Donation** | **Don** |
| Lead → **Prospect** | **Prospect** |
| Salesperson → **Solicitor** | **Solliciteur** |
| Sales Team → **Development Team** | **Équipe de développement** |
| Customer → **Donor** | **Donateur** |
| Expected Revenue → **Expected Amount** | **Montant attendu** |
| Won / Lost → **Secured / Declined** | **Réalisé / Refusé** |
| Stages → **Identification / Qualification / Solicitation / Secured** | Identification / Qualification / Sollicitation / Réalisé |

## How

Because Odoo 16+ stores translations as per-record JSONB, changing the English source alone doesn't move the French UI. So the module works in two layers:

- **English source** — `_inherit` field `string=`/selection overrides, menu/action/stage record-name data, and search-view inheritance.
- **French** — `i18n/fr_CA.po` loaded with `overwrite=True` from a `post_init_hook` (the default load is `overwrite=False` and silently skips terms `crm` already translated).

The "Secured" stage keeps `is_won=True`, so won donations stay classified.

## Tests

`tests/test_vocabulary.py` asserts the relabel in **both** languages (field labels, selection labels, stage names, menu names), including the force-overwrite of the French terms. 2/2 passing.