### PR TITLE
fix(bemade_fsm): preserve template order in created subtasks

### DIFF
--- a/bemade_fsm/__manifest__.py
+++ b/bemade_fsm/__manifest__.py
@@ -20,7 +20,7 @@
 ########################################################################################
 {
     "name": "Improved Field Service Management",
-    "version": "19.0.0.4.5",
+    "version": "19.0.0.4.6",
     "summary": (
         "Adds functionality necessary for managing field service operations at Durpro."
     ),

--- a/bemade_fsm/models/sale_order_line.py
+++ b/bemade_fsm/models/sale_order_line.py
@@ -96,20 +96,25 @@ class SaleOrderLine(models.Model):
         Override to add the logic needed to implement task templates and equipment linkages.
         """
 
-        def _create_task_from_template(project, template, parent):
+        def _create_task_from_template(project, template, parent, sequence=0):
             """Recursively generates the task and any subtasks from a project.task.template.
 
             :param project: project.project record to set on the task's project_id field.
             :param template: project.task.template to use to create the task.
             :param parent: project.task to set as the parent to this task.
+            :param sequence: ordinal among siblings, used so the created child_ids
+                preserve template order (project.task._order ends in "id desc", so
+                siblings sharing the template's default 0 sequence would otherwise
+                come back reversed).
             """
             values = _timesheet_create_task_prepare_values_from_template(
                 project, template, parent
             )
+            values["sequence"] = sequence
             task = self.env["project.task"].sudo().create(values)
             subtasks = []
-            for t in template.subtasks:
-                subtask = _create_task_from_template(project, t, task)
+            for seq, t in enumerate(template.subtasks):
+                subtask = _create_task_from_template(project, t, task, sequence=seq)
                 subtasks.append(subtask)
 
             # We don't want to see the sub-tasks on the SO

--- a/bemade_fsm/models/task_template.py
+++ b/bemade_fsm/models/task_template.py
@@ -4,6 +4,7 @@ from odoo import models, fields, api, Command
 class TaskTemplate(models.Model):
     _name = "project.task.template"
     _description = "Template for new project tasks"
+    _order = "sequence, id"
 
     @api.model
     def _current_company(self):
@@ -114,8 +115,13 @@ class TaskTemplate(models.Model):
         :return: project.task record created from this template
         """
         tasks = self.env["project.task"]
-        for rec in self:
+        for seq, rec in enumerate(self):
             vals = rec._prepare_new_task_values_from_self(project, name, parent_id)
+            # Assign an explicit ascending sequence per sibling so the created
+            # child_ids preserve template order. project.task._order ends in
+            # "id desc", so siblings that all share the template's (usually 0)
+            # sequence would otherwise come back in reverse creation order.
+            vals["sequence"] = seq
             task = rec.env["project.task"].create(vals)
             rec.subtasks.create_task_from_self(project, name=False, parent_id=task.id)
             tasks |= task


### PR DESCRIPTION
## Problem

Three `bemade_fsm` tests went red on the 19.0 pipeline with **no addon change**:

- `TestSalesOrder.test_task_template_tree_order_confirmation`
- `TestSalesOrder.test_subtask_templates_no_description_if_blank_on_template`
- `TestTaskTemplate.test_task_creation_directly_from_template`

All three fail for one reason: a task's created `child_ids` came back **reversed** relative to `template.subtasks`.

## Root cause

- `project.task._order` ends in `id desc`.
- `project.task.template` had no `_order` (defaulted to `id` asc), and `create_task_from_self` copied each template's `sequence` — which is `0` for every sibling when unset.
- With equal priority/sequence/deadline, the created siblings tie on everything but `id`, so `child_ids` fell back to `id desc` = reverse creation order.

These tests passed at merge time (PR #144, 2026-06-20, green — the tests actually ran). CI builds its Odoo base from `odoo/odoo` `19.0` **HEAD, rebuilt nightly**, so an upstream change to how a freshly-created one2many is re-read exposed this latent ordering assumption. Green-at-merge, red-at-next-base-bump.

## Fix

Make subtask order explicit and independent of the core `id desc` tiebreaker:

- `project.task.template`: add `_order = "sequence, id"`.
- `create_task_from_self`: assign an ascending `sequence` per sibling so created `child_ids` preserve template order.

This is also a genuine UI-correctness fix (subtasks should render in template order, not reversed).

## Verification

Local validation isn't meaningful here — the only local dev env is 18.0 core, whereas the regression is driven by 19.0-HEAD core. The authoritative check is this PR's `tests` job, which runs against the same nightly `19.0` base that currently reproduces the failure.