### PR TITLE
[REL] bemade_sports_clinic 19.0.1.3.1: portal paging fix, injury-form layout, portal cards, note history

### DIFF
--- a/bemade_sports_clinic/__manifest__.py
+++ b/bemade_sports_clinic/__manifest__.py
@@ -18,7 +18,7 @@
 #
 {
     'name': 'Sports Clinic Management',
-    'version': "19.0.1.2.0",
+    'version': "19.0.1.2.1",
     'summary': 'Comprehensive sports medicine clinic management with portal access and activity tracking.',
     'description': """
 Sports Clinic Management System

--- a/bemade_sports_clinic/__manifest__.py
+++ b/bemade_sports_clinic/__manifest__.py
@@ -18,7 +18,7 @@
 #
 {
     'name': 'Sports Clinic Management',
-    'version': "19.0.1.2.2",
+    'version': "19.0.1.3.0",
     'summary': 'Comprehensive sports medicine clinic management with portal access and activity tracking.',
     'description': """
 Sports Clinic Management System

--- a/bemade_sports_clinic/__manifest__.py
+++ b/bemade_sports_clinic/__manifest__.py
@@ -18,7 +18,7 @@
 #
 {
     'name': 'Sports Clinic Management',
-    'version': "19.0.1.2.1",
+    'version': "19.0.1.2.2",
     'summary': 'Comprehensive sports medicine clinic management with portal access and activity tracking.',
     'description': """
 Sports Clinic Management System

--- a/bemade_sports_clinic/__manifest__.py
+++ b/bemade_sports_clinic/__manifest__.py
@@ -81,6 +81,7 @@ This module provides a complete sports medicine clinic management solution with 
         "views/sports_patient_injury_portal.xml",
         "views/player_management_portal_templates.xml",
         "views/injury_management_portal_templates.xml",
+        "views/injury_note_history_portal_templates.xml",
         "views/task_management_portal_templates.xml",
         "views/events_portal_templates.xml",
         "views/event_invoicing_wizard_views.xml",

--- a/bemade_sports_clinic/__manifest__.py
+++ b/bemade_sports_clinic/__manifest__.py
@@ -18,7 +18,7 @@
 #
 {
     'name': 'Sports Clinic Management',
-    'version': "19.0.1.3.0",
+    'version': "19.0.1.3.1",
     'summary': 'Comprehensive sports medicine clinic management with portal access and activity tracking.',
     'description': """
 Sports Clinic Management System

--- a/bemade_sports_clinic/controllers/patient_injury_portal.py
+++ b/bemade_sports_clinic/controllers/patient_injury_portal.py
@@ -584,7 +584,7 @@ class PatientInjuryPortal(CustomerPortal, AccessControlMixin):
         return _redirect('success=note_added')
         
     @http.route(['/my/injury/<int:injury_id>/notes/history'], type='http', auth='user', website=True)
-    def view_injury_note_history(self, injury_id, scope=None, **post):
+    def view_injury_note_history(self, injury_id, scope=None, team_id=None, **post):
         """Read-only audit trail of injury note snapshots (task 1241).
 
         Access control is enforced server-side:
@@ -618,6 +618,20 @@ class PatientInjuryPortal(CustomerPortal, AccessControlMixin):
         # coaches even if this controller filter ever regresses.
         histories = request.env['sports.injury.note.history'].search(domain)
 
+        # Optional team navigation context for breadcrumbs (same pattern as
+        # the injury-documents route; access is NOT derived from it).
+        team = None
+        team_context_id = None
+        if team_id:
+            try:
+                team_rec = request.env['sports.team'].browse(int(team_id))
+                if team_rec.exists():
+                    team = team_rec
+                    team_context_id = team_rec.id
+            except Exception:
+                team = None
+                team_context_id = None
+
         values = {
             'injury': injury,
             'patient': injury.patient_id,
@@ -625,6 +639,8 @@ class PatientInjuryPortal(CustomerPortal, AccessControlMixin):
             'scope': requested_scope,
             'is_treatment_prof': is_treatment_prof,
             'page_name': 'injury_note_history',
+            'team': team,
+            'team_context_id': team_context_id,
         }
         return request.render('bemade_sports_clinic.portal_injury_note_history', values)
 

--- a/bemade_sports_clinic/controllers/patient_injury_portal.py
+++ b/bemade_sports_clinic/controllers/patient_injury_portal.py
@@ -583,6 +583,51 @@ class PatientInjuryPortal(CustomerPortal, AccessControlMixin):
         self._add_treatment_note(patient, note_content)
         return _redirect('success=note_added')
         
+    @http.route(['/my/injury/<int:injury_id>/notes/history'], type='http', auth='user', website=True)
+    def view_injury_note_history(self, injury_id, scope=None, **post):
+        """Read-only audit trail of injury note snapshots (task 1241).
+
+        Access control is enforced server-side:
+        - treatment professionals (portal TP group) see internal + external
+          rows with an optional scope filter (?scope=internal/external/all,
+          default all);
+        - coaches (and any other non-TP with injury access) get EXTERNAL
+          rows only, regardless of the query string;
+        - users with no right to the injury get the standard 403/404 from
+          _check_access_to_injury, like the neighboring injury routes.
+        """
+        injury = self._check_access_to_injury(injury_id)
+
+        is_treatment_prof = request.env.user.has_group(
+            'bemade_sports_clinic.group_portal_treatment_professional')
+
+        requested_scope = scope or 'all'
+        if requested_scope not in ('internal', 'external', 'all'):
+            requested_scope = 'all'
+        if not is_treatment_prof:
+            # Coaches only ever see external notes; ignore any tampered
+            # scope parameter outright.
+            requested_scope = 'external'
+
+        domain = [('injury_id', '=', injury.id)]
+        if requested_scope != 'all':
+            domain.append(('scope', '=', requested_scope))
+
+        # Deliberately NOT sudo: the sports.injury.note.history portal record
+        # rules re-enforce the team scoping and hide internal-scope rows from
+        # coaches even if this controller filter ever regresses.
+        histories = request.env['sports.injury.note.history'].search(domain)
+
+        values = {
+            'injury': injury,
+            'patient': injury.patient_id,
+            'histories': histories,
+            'scope': requested_scope,
+            'is_treatment_prof': is_treatment_prof,
+            'page_name': 'injury_note_history',
+        }
+        return request.render('bemade_sports_clinic.portal_injury_note_history', values)
+
     @http.route(['/my/injury/documents'], type='http', auth='user', website=True)
     def view_injury_documents(self, injury_id=None, team_id=None, **post):
         """View documents attached to an injury.

--- a/bemade_sports_clinic/controllers/task_management_portal.py
+++ b/bemade_sports_clinic/controllers/task_management_portal.py
@@ -9,6 +9,20 @@ from datetime import date, timedelta
 _logger = logging.getLogger(__name__)
 
 
+
+def _append_query(url, extra):
+    """Append a query param to a URL WITHOUT breaking a #fragment.
+
+    Tab return-URLs carry an anchor (…?player_id=7#activities); appending
+    ?/&param after the fragment folds the param INTO the fragment, so the
+    browser never activates the tab (candidate human-test finding,
+    2026-07-10: adding an activity dumped the user back on the first tab).
+    """
+    base, _, frag = url.partition('#')
+    sep = '&' if '?' in base else '?'
+    return f'{base}{sep}{extra}' + (f'#{frag}' if frag else '')
+
+
 class TaskManagementPortal(CustomerPortal, AccessControlMixin):
     """Controller for task management functionality in the portal"""
     
@@ -364,8 +378,7 @@ class TaskManagementPortal(CustomerPortal, AccessControlMixin):
 
         if not activity_type_id or not summary or not user_id or not date_deadline:
             return_url = _sanitize_return_url(post.get('return_url'), default_return_url)
-            separator = '&' if '?' in return_url else '?'
-            return request.redirect(f'{return_url}{separator}error=missing_fields')
+            return request.redirect(_append_query(return_url, 'error=missing_fields'))
             
         # Check if the assigned user is valid
         is_treatment_prof = request.env.user.has_group('bemade_sports_clinic.group_portal_treatment_professional')
@@ -374,16 +387,14 @@ class TaskManagementPortal(CustomerPortal, AccessControlMixin):
         # Only treatment professionals can assign to other users
         if not is_treatment_prof and assigned_user.id != request.env.user.id:
             return_url = _sanitize_return_url(post.get('return_url'), default_return_url)
-            separator = '&' if '?' in return_url else '?'
-            return request.redirect(f'{return_url}{separator}error=invalid_user')
+            return request.redirect(_append_query(return_url, 'error=invalid_user'))
             
         # Create the activity
         # Get model ID - portal users now have ACL access to ir.model
         model_id = request.env['ir.model'].search([('model', '=', model)], limit=1).id
         if not model_id:
             return_url = _sanitize_return_url(post.get('return_url'), default_return_url)
-            separator = '&' if '?' in return_url else '?'
-            return request.redirect(f'{return_url}{separator}error=invalid_model')
+            return request.redirect(_append_query(return_url, 'error=invalid_model'))
             
         vals = {
             'activity_type_id': int(activity_type_id),
@@ -408,11 +419,9 @@ class TaskManagementPortal(CustomerPortal, AccessControlMixin):
         if model in ('sports.patient', 'sports.patient.injury'):
             team_id = post.get('team_id')
             if team_id and 'team_id=' not in return_url:
-                sep_team = '&' if '?' in return_url else '?'
-                return_url = f'{return_url}{sep_team}team_id={int(team_id)}'
+                return_url = _append_query(return_url, f'team_id={int(team_id)}')
 
-        separator = '&' if '?' in return_url else '?'
-        return request.redirect(f'{return_url}{separator}success=activity_created')
+        return request.redirect(_append_query(return_url, 'success=activity_created'))
     
     @http.route(['/my/activity/update'], type='http', auth='user', website=True, methods=['POST'], csrf=False)
     def update_activity(self, **post):
@@ -477,8 +486,7 @@ class TaskManagementPortal(CustomerPortal, AccessControlMixin):
         
         # Redirect to activities page or return URL
         return_url = post.get('return_url', '/my/activities')
-        separator = '&' if '?' in return_url else '?'
-        return request.redirect(f'{return_url}{separator}success=activity_updated')
+        return request.redirect(_append_query(return_url, 'success=activity_updated'))
     
     @http.route(['/my/activity/complete'], type='http', auth='user', website=True, methods=['POST'], csrf=False)
     def complete_activity(self, **post):
@@ -637,8 +645,7 @@ class TaskManagementPortal(CustomerPortal, AccessControlMixin):
         
         # Determine return URL based on context
         return_url = post.get('return_url', '/my/activities')
-        separator = '&' if '?' in return_url else '?'
-        return request.redirect(f'{return_url}{separator}success=activity_reassigned')
+        return request.redirect(_append_query(return_url, 'success=activity_reassigned'))
 
     @http.route(['/my/activity/<int:activity_id>/edit'], type='http', auth='user', website=True)
     def edit_activity_form(self, activity_id, **kw):

--- a/bemade_sports_clinic/controllers/team_staff_portal.py
+++ b/bemade_sports_clinic/controllers/team_staff_portal.py
@@ -79,7 +79,7 @@ class TeamStaffPortal(CustomerPortal, AccessControlMixin):
         ]
 
     @http.route(route=['/my/teams', '/my/teams/page/<int:page>'], type='http', auth='user', website=True)
-    def view_teams(self, page=0, search=None, **kw):
+    def view_teams(self, page=1, search=None, **kw):
         """ Display the list of teams that a portal user has access to.
 
         Optional `search` query param does an `ilike` on team name and
@@ -97,12 +97,16 @@ class TeamStaffPortal(CustomerPortal, AccessControlMixin):
             ]
         teams_count = Teams.search_count(domain)
         pgr_url_args = {'search': search_term} if search_term else None
+        step = 10
         pgr = pager(url='/my/teams', total=teams_count,
-                    page=page, step=10, scope=5,
+                    page=page, step=step, scope=5,
                     url_args=pgr_url_args)
+        # limit must be the page size, not the full result count — with the
+        # pager advancing offset by 10 while limit spanned everything, page 2+
+        # re-served the whole remaining list (duplicate teams across pages).
         teams = Teams.search(domain,
                              offset=pgr['offset'],
-                             limit=teams_count)
+                             limit=step)
         return http.request.render(template='bemade_sports_clinic.portal_my_teams',
                                    qcontext={
                                        'teams_count': teams_count,

--- a/bemade_sports_clinic/i18n/fr_CA.po
+++ b/bemade_sports_clinic/i18n/fr_CA.po
@@ -6919,3 +6919,58 @@ msgstr "Équipe(s) :"
 #: code:addons/bemade_sports_clinic/models/sports_event.py:0
 msgid " Reason: %s"
 msgstr " Raison : %s"
+
+#. module: bemade_sports_clinic
+#: model:ir.model,name:bemade_sports_clinic.model_sports_injury_note_history
+msgid "Injury Note History"
+msgstr "Historique des notes de blessure"
+
+#. module: bemade_sports_clinic
+#: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_patient_injury__note_history_ids
+msgid "Note History"
+msgstr "Historique des notes"
+
+#. module: bemade_sports_clinic
+#: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_injury_note_history__scope
+msgid "Scope"
+msgstr "Portée"
+
+#. module: bemade_sports_clinic
+#: model:ir.model.fields,field_description:bemade_sports_clinic.field_sports_injury_note_history__content
+msgid "Content"
+msgstr "Contenu"
+
+#. module: bemade_sports_clinic
+#: model:ir.model.fields.selection,name:bemade_sports_clinic.selection__sports_injury_note_history__scope__internal
+msgid "Internal"
+msgstr "Interne"
+
+#. module: bemade_sports_clinic
+#: model:ir.model.fields.selection,name:bemade_sports_clinic.selection__sports_injury_note_history__scope__external
+msgid "External"
+msgstr "Externe"
+
+#. module: bemade_sports_clinic
+#: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_injury_note_history
+msgid "All"
+msgstr "Tout"
+
+#. module: bemade_sports_clinic
+#: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_injury_note_history
+msgid "No note history available"
+msgstr "Aucun historique de notes disponible"
+
+#. module: bemade_sports_clinic
+#: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_injury_note_history
+msgid "(note cleared)"
+msgstr "(note effacée)"
+
+#. module: bemade_sports_clinic
+#: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_injury_note_history
+msgid "Read-only history of note changes for"
+msgstr "Historique en lecture seule des modifications de notes pour"
+
+#. module: bemade_sports_clinic
+#: model:ir.model.fields,help:bemade_sports_clinic.field_sports_patient_injury__note_history_ids
+msgid "Append-only audit trail of internal/external note changes."
+msgstr "Piste d'audit en ajout seul des modifications de notes internes/externes."

--- a/bemade_sports_clinic/i18n/fr_CA.po
+++ b/bemade_sports_clinic/i18n/fr_CA.po
@@ -6974,3 +6974,33 @@ msgstr "Historique en lecture seule des modifications de notes pour"
 #: model:ir.model.fields,help:bemade_sports_clinic.field_sports_patient_injury__note_history_ids
 msgid "Append-only audit trail of internal/external note changes."
 msgstr "Piste d'audit en ajout seul des modifications de notes internes/externes."
+
+#. module: bemade_sports_clinic
+#: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_player_injuries
+msgid "General"
+msgstr "Général"
+
+#. module: bemade_sports_clinic
+#: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_player_injuries
+msgid "Activity Type"
+msgstr "Type d'activité"
+
+#. module: bemade_sports_clinic
+#: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_player_injuries
+msgid "No activities recorded"
+msgstr "Aucune activité enregistrée"
+
+#. module: bemade_sports_clinic
+#: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_player_injuries
+msgid "Overdue"
+msgstr "En retard"
+
+#. module: bemade_sports_clinic
+#: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_player_injuries
+msgid "Planned"
+msgstr "Planifiée"
+
+#. module: bemade_sports_clinic
+#: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_my_player_injuries
+msgid "Download"
+msgstr "Télécharger"

--- a/bemade_sports_clinic/migrations/19.0.1.3.0/post-migration.py
+++ b/bemade_sports_clinic/migrations/19.0.1.3.0/post-migration.py
@@ -1,0 +1,59 @@
+"""Seed sports.injury.note.history from the live injury note fields (task 1241).
+
+The module is already deployed, so the initial audit rows are created here
+rather than in a post_init_hook: for every injury with a non-empty
+internal_notes (resp. external_notes), create one history row with that
+scope, authored by the superuser and dated with the injury's write_date.
+Live field contents are left untouched.
+
+Idempotent: an injury+scope pair that already has history rows is skipped,
+so re-running the migration (or running it after some rows were captured
+organically) never duplicates entries.
+"""
+import logging
+
+_logger = logging.getLogger(__name__)
+
+_NOTE_FIELDS = (
+    ("internal_notes", "internal"),
+    ("external_notes", "external"),
+)
+
+
+def migrate(cr, version):
+    if not version:
+        # Fresh install — capture hooks handle everything from the start.
+        return
+
+    from odoo.api import Environment, SUPERUSER_ID  # noqa: PLC0415
+
+    env = Environment(cr, SUPERUSER_ID, {})
+    History = env["sports.injury.note.history"]
+    injuries = env["sports.patient.injury"].with_context(active_test=False).search([])
+
+    existing_pairs = {
+        (hist.injury_id.id, hist.scope)
+        for hist in History.search([("injury_id", "in", injuries.ids)])
+    }
+
+    vals_list = []
+    for injury in injuries:
+        for fname, scope in _NOTE_FIELDS:
+            content = injury[fname]
+            if not (content and content.strip()):
+                continue
+            if (injury.id, scope) in existing_pairs:
+                continue
+            vals_list.append({
+                "injury_id": injury.id,
+                "scope": scope,
+                "content": content,
+                "author_id": SUPERUSER_ID,
+                "note_datetime": injury.write_date,
+            })
+
+    if vals_list:
+        History.create(vals_list)
+        _logger.info(
+            "Seeded %s injury note history row(s) from existing notes", len(vals_list)
+        )

--- a/bemade_sports_clinic/models/__init__.py
+++ b/bemade_sports_clinic/models/__init__.py
@@ -1,6 +1,7 @@
 from . import mail_followers
 from . import patient
 from . import patient_injury
+from . import injury_note_history
 from . import patient_contact
 from . import res_partner
 from . import res_users

--- a/bemade_sports_clinic/models/injury_note_history.py
+++ b/bemade_sports_clinic/models/injury_note_history.py
@@ -1,0 +1,49 @@
+from odoo import fields, models
+
+
+class InjuryNoteHistory(models.Model):
+    """Append-only audit snapshots of the injury note fields (task 1241).
+
+    One row is created by server code (sports.patient.injury create/write)
+    every time internal_notes or external_notes actually changes. Rows are
+    never mutated or deleted from the UI — the model is read-only for all
+    groups; creation happens exclusively through sudo() in the capture hooks
+    and the rollout migration.
+    """
+
+    _name = "sports.injury.note.history"
+    _description = "Injury Note History"
+    _order = "note_datetime desc, id desc"
+
+    injury_id = fields.Many2one(
+        comodel_name="sports.patient.injury",
+        string="Injury",
+        required=True,
+        ondelete="cascade",
+        index=True,
+        readonly=True,
+    )
+    patient_id = fields.Many2one(
+        related="injury_id.patient_id",
+        string="Patient",
+        store=True,
+    )
+    note_datetime = fields.Datetime(
+        string="Date",
+        default=fields.Datetime.now,
+        required=True,
+        readonly=True,
+    )
+    author_id = fields.Many2one(
+        comodel_name="res.users",
+        string="Author",
+        default=lambda self: self.env.user,
+        readonly=True,
+    )
+    content = fields.Text(string="Content", readonly=True)
+    scope = fields.Selection(
+        selection=[("internal", "Internal"), ("external", "External")],
+        string="Scope",
+        required=True,
+        readonly=True,
+    )

--- a/bemade_sports_clinic/models/patient_injury.py
+++ b/bemade_sports_clinic/models/patient_injury.py
@@ -1,6 +1,7 @@
 from odoo import models, fields, api, _
 from datetime import datetime, date
 from odoo.exceptions import ValidationError, UserError, AccessError
+from odoo.http import request
 import logging
 
 _logger = logging.getLogger(__name__)
@@ -16,6 +17,13 @@ external_tracking_fields = {
 internal_tracking_fields = {
     "internal_notes",
     "parental_consent",
+}
+
+# Task 1241: note fields snapshotted to the append-only
+# sports.injury.note.history audit model on every real change.
+note_history_scope_by_field = {
+    "internal_notes": "internal",
+    "external_notes": "external",
 }
 
 
@@ -167,6 +175,13 @@ class PatientInjury(models.Model):
         string='Activity Count',
         compute='_compute_activity_count'
     )
+    note_history_ids = fields.One2many(
+        comodel_name='sports.injury.note.history',
+        inverse_name='injury_id',
+        string='Note History',
+        readonly=True,
+        help='Append-only audit trail of internal/external note changes.',
+    )
 
     @api.depends('patient_id', 'patient_id.team_ids')
     def _compute_allowed_team_ids(self):
@@ -279,6 +294,43 @@ class PatientInjury(models.Model):
             rec.patient_id.message_post(body=msg_body, message_type="comment")
         return res
             
+    def _note_history_author_id(self):
+        """Resolve the authenticated author for note-history rows (task 1241).
+
+        Portal saves go through ``injury.sudo().write(vals)``, which rebinds
+        the environment to the superuser; the audit trail must credit the
+        human behind the request, so when running as sudo inside an HTTP
+        request we recover the session uid instead.
+        """
+        if self.env.su and request and request.session and request.session.uid:
+            return request.session.uid
+        return self.env.uid
+
+    def _prepare_note_history_vals(self, vals):
+        """Build sports.injury.note.history vals for note fields that actually
+        change in ``vals``, comparing old vs new per record. A save that
+        doesn't change the field produces no row (task 1241)."""
+        changed_fields = [f for f in note_history_scope_by_field if f in vals]
+        if not changed_fields:
+            return []
+        history_vals = []
+        author_id = self._note_history_author_id()
+        now = fields.Datetime.now()
+        for rec in self:
+            for fname in changed_fields:
+                old_val = rec[fname] or ""
+                new_val = vals.get(fname) or ""
+                if old_val == new_val:
+                    continue
+                history_vals.append({
+                    'injury_id': rec.id,
+                    'scope': note_history_scope_by_field[fname],
+                    'content': vals.get(fname) or False,
+                    'author_id': author_id,
+                    'note_datetime': now,
+                })
+        return history_vals
+
     def write(self, vals):
         """Override write to update subscriptions if treatment professionals change"""
         # Store current treatment professional IDs before update
@@ -286,7 +338,7 @@ class PatientInjury(models.Model):
         if 'treatment_professional_ids' in vals:
             for rec in self:
                 old_treatment_prof_ids[rec.id] = rec.treatment_professional_ids.ids
-        
+
         # Detect suppression context (portal coach flows)
         suppress_followers = bool(
             self.env.context.get('mail_create_nosubscribe')
@@ -294,7 +346,20 @@ class PatientInjury(models.Model):
             or self.env.context.get('suppress_portal_mail')
         )
 
+        # Task 1241: snapshot note changes into the append-only history.
+        # Deliberately NOT gated on suppress_followers — the audit capture
+        # must happen even under mail_notrack/suppress contexts; only the
+        # explicit skip_note_history context disables it.
+        note_history_vals = []
+        if not self.env.context.get('skip_note_history'):
+            note_history_vals = self._prepare_note_history_vals(vals)
+
         res = super().write(vals)
+
+        if note_history_vals:
+            # sudo: history rows are only ever created by server code; no
+            # group holds create rights on the model.
+            self.env['sports.injury.note.history'].sudo().create(note_history_vals)
         
         # If treatment professionals changed, update subscriptions (unless suppressed)
         if not suppress_followers and 'treatment_professional_ids' in vals:
@@ -615,7 +680,28 @@ class PatientInjury(models.Model):
             )).create(vals_list)
         else:
             res = super().create(vals_list)
-        
+
+        # Task 1241: seed the append-only note history for initially
+        # non-empty note fields. Runs under suppression contexts too; only
+        # skip_note_history disables it.
+        if not self.env.context.get('skip_note_history'):
+            history_vals = []
+            author_id = self._note_history_author_id()
+            now = fields.Datetime.now()
+            for record in res:
+                for fname, scope in note_history_scope_by_field.items():
+                    content = record[fname]
+                    if content and content.strip():
+                        history_vals.append({
+                            'injury_id': record.id,
+                            'scope': scope,
+                            'content': content,
+                            'author_id': author_id,
+                            'note_datetime': now,
+                        })
+            if history_vals:
+                self.env['sports.injury.note.history'].sudo().create(history_vals)
+
         for record in res:
             # Creator role checks (re-use computed flags)
             # is_treatment_professional, is_admin, is_internal_user, suppress_notifications defined above

--- a/bemade_sports_clinic/security/ir.model.access.csv
+++ b/bemade_sports_clinic/security/ir.model.access.csv
@@ -70,3 +70,9 @@ access_event_vendor_po_wizard_admin,Clinic Admin Access for Event Vendor PO Wiza
 access_event_recurrence_wizard_user,User Access for Event Recurrence Wizard,model_sports_event_recurrence_wizard,base.group_user,1,1,1,1
 access_event_recurrence_preview_user,User Access for Event Recurrence Preview,model_sports_event_recurrence_preview,base.group_user,1,1,1,1
 access_event_batch_invoicing_wizard_admin,Clinic Admin Access for Event Batch Invoicing Wizard,model_sports_event_batch_invoicing_wizard,bemade_sports_clinic.group_sports_clinic_admin,1,1,1,1
+
+access_injury_note_history_user,User Access for Injury Note History,model_sports_injury_note_history,group_sports_clinic_user,1,0,0,0
+access_injury_note_history_treatment_pro,Treatment Professional Access for Injury Note History,model_sports_injury_note_history,group_sports_clinic_treatment_professional,1,0,0,0
+access_injury_note_history_admin,Admin Access for Injury Note History,model_sports_injury_note_history,group_sports_clinic_admin,1,0,0,0
+access_injury_note_history_portal_tp,Portal Treatment Prof Access for Injury Note History,model_sports_injury_note_history,bemade_sports_clinic.group_portal_treatment_professional,1,0,0,0
+access_injury_note_history_portal_coach,Portal Coach Access for Injury Note History,model_sports_injury_note_history,bemade_sports_clinic.group_portal_team_coach,1,0,0,0

--- a/bemade_sports_clinic/security/sports_clinic_portal_rules.xml
+++ b/bemade_sports_clinic/security/sports_clinic_portal_rules.xml
@@ -118,6 +118,36 @@
             <field name="domain_force">[(1, '=', 1)]</field>
         </record>
 
+        <!-- Injury note history (task 1241): portal TPs read internal +
+             external rows for injuries on patients of teams they staff. -->
+        <record id="portal_medical_professional_injury_note_history_access" model="ir.rule">
+            <field name="name">Portal Medical Professionals Access to Injury Note History</field>
+            <field name="model_id" ref="model_sports_injury_note_history"/>
+            <field name="groups" eval="[(6, 0, [ref('bemade_sports_clinic.group_portal_treatment_professional')])]"/>
+            <field name="perm_create" eval="False"/>
+            <field name="perm_write" eval="False"/>
+            <field name="perm_read" eval="True"/>
+            <field name="perm_unlink" eval="False"/>
+            <field name="domain_force">[('injury_id.patient_id.team_ids.staff_ids.user_ids', 'in', user.id)]</field>
+        </record>
+
+        <!-- Injury note history (task 1241): coaches read EXTERNAL rows only,
+             for non-hidden injuries of their teams' players. Internal-scope
+             rows are excluded at the rule level, not just in the controller
+             or template. -->
+        <record id="portal_coach_injury_note_history_access" model="ir.rule">
+            <field name="name">Portal Coaches Access to Injury Note History</field>
+            <field name="model_id" ref="model_sports_injury_note_history"/>
+            <field name="groups" eval="[(6, 0, [ref('bemade_sports_clinic.group_portal_team_coach')])]"/>
+            <field name="perm_create" eval="False"/>
+            <field name="perm_write" eval="False"/>
+            <field name="perm_read" eval="True"/>
+            <field name="perm_unlink" eval="False"/>
+            <field name="domain_force">[('injury_id.patient_id.team_ids.staff_ids.user_ids', 'in', user.id),
+                                       ('injury_id.hidden_from_coaches', '=', False),
+                                       ('scope', '=', 'external')]</field>
+        </record>
+
         <!-- Portal team coaches can access partners linked to their team's patients -->
         <record id="portal_team_coach_partner_access" model="ir.rule">
             <field name="name">Portal Team Coach Access to Partners</field>

--- a/bemade_sports_clinic/static/src/scss/portal_badges.scss
+++ b/bemade_sports_clinic/static/src/scss/portal_badges.scss
@@ -116,6 +116,14 @@
   pointer-events: none;
 }
 
+/* Inside note CARDS the initials badge sits at the top-RIGHT corner, so
+   the default right-side author bubble would escape the viewport on the
+   last grid column. Flip it to the left of the badge there. */
+.portal-note-card .o_sc_note_author:hover::after {
+  left: auto;
+  right: calc(100% + 6px);
+}
+
 /* Notes tables: fixed layout so the Note column takes the remaining
    width and long lines WRAP instead of growing the table into the
    horizontal scroll region. Also undo o_portal_my_doc_table's

--- a/bemade_sports_clinic/tests/__init__.py
+++ b/bemade_sports_clinic/tests/__init__.py
@@ -56,3 +56,4 @@ from . import test_cov_portal_cross_team
 from . import test_cov_portal_player_search_add_to_team
 from . import test_player_activities_tab
 from . import test_event_detail_timesheet_confidentiality
+from . import test_injury_note_history

--- a/bemade_sports_clinic/tests/__init__.py
+++ b/bemade_sports_clinic/tests/__init__.py
@@ -57,3 +57,4 @@ from . import test_cov_portal_player_search_add_to_team
 from . import test_player_activities_tab
 from . import test_event_detail_timesheet_confidentiality
 from . import test_injury_note_history
+from . import test_append_query

--- a/bemade_sports_clinic/tests/test_append_query.py
+++ b/bemade_sports_clinic/tests/test_append_query.py
@@ -1,0 +1,27 @@
+from odoo.tests import TransactionCase, tagged
+
+from odoo.addons.bemade_sports_clinic.controllers.task_management_portal import (
+    _append_query,
+)
+
+
+@tagged("-at_install", "post_install")
+class TestAppendQuery(TransactionCase):
+    """Fragment-safe redirect params (candidate human-test finding 2026-07-10:
+    '&success=' appended AFTER '#activities' broke the tab anchor, dumping the
+    user on the first tab after adding an activity)."""
+
+    def test_fragment_preserved(self):
+        self.assertEqual(
+            _append_query('/my/player?player_id=7#activities', 'success=activity_created'),
+            '/my/player?player_id=7&success=activity_created#activities')
+
+    def test_no_fragment(self):
+        self.assertEqual(
+            _append_query('/my/activities', 'error=missing_fields'),
+            '/my/activities?error=missing_fields')
+
+    def test_no_query_yet_with_fragment(self):
+        self.assertEqual(
+            _append_query('/my/player#activities', 'team_id=7'),
+            '/my/player?team_id=7#activities')

--- a/bemade_sports_clinic/tests/test_cov_team_staff_portal.py
+++ b/bemade_sports_clinic/tests/test_cov_team_staff_portal.py
@@ -92,6 +92,36 @@ class TestCovTeamStaffPortal(HttpCase):
         self.assertEqual(resp.status_code, 200)
         self.assertIn('TSP Team A', resp.text)
 
+    def test_view_teams_paging_no_duplicates(self):
+        """Paging regression (task 892): the controller searched with
+        limit=teams_count while the pager stepped the offset by 10, so page 2+
+        re-served the remaining full list (22 -> 12 -> 2 with duplicates).
+        Each team must appear on exactly one page."""
+        staff_user = self.env['res.users'].with_context(no_reset_password=True).create({
+            'name': 'TSP Pager', 'login': 'tsp.pager@example.com', 'password': 'tsp-pager',
+            'group_ids': [Command.set([
+                self.env.ref('base.group_portal').id,
+                self.env.ref('bemade_sports_clinic.group_portal_team_coach').id,
+            ])],
+        })
+        names = [f'TSP Page Team {i:02d}' for i in range(1, 13)]
+        for name in names:
+            team = self.env['sports.team'].create({'name': name, 'parent_id': self.org.id})
+            self.env['sports.team.staff'].create({
+                'team_id': team.id, 'partner_id': staff_user.partner_id.id, 'role': 'coach',
+            })
+        self.authenticate('tsp.pager@example.com', 'tsp-pager')
+
+        page1 = self.url_open('/my/teams').text
+        page2 = self.url_open('/my/teams/page/2').text
+        on_page1 = {n for n in names if n in page1}
+        on_page2 = {n for n in names if n in page2}
+
+        self.assertEqual(len(on_page1), 10, "page 1 must hold exactly one page of teams")
+        self.assertEqual(len(on_page2), 2, "page 2 must hold only the remainder")
+        self.assertFalse(on_page1 & on_page2, "no team may appear on both pages")
+        self.assertEqual(on_page1 | on_page2, set(names), "every team appears exactly once")
+
     # ----- /my/team -----
 
     def test_view_team_as_staff(self):

--- a/bemade_sports_clinic/tests/test_injury_note_history.py
+++ b/bemade_sports_clinic/tests/test_injury_note_history.py
@@ -1,0 +1,219 @@
+"""Audited followup-note history on patient injuries (task 1241).
+
+Acceptance criteria:
+- Writing a new internal_notes value on an injury creates exactly one
+  sports.injury.note.history row with scope 'internal', the authenticated
+  user as author and the NEW value as content; same for external_notes with
+  scope 'external'.
+- A save that does not change the note fields creates NO history row, and
+  writes to unrelated fields create NO history row.
+- History rows are never mutated: rewriting a note creates a second row and
+  the earlier row keeps its original content.
+- Capture still happens under the mail suppression contexts
+  (mail_notrack / mail_create_nosubscribe); only the explicit
+  skip_note_history context disables it.
+- Creating an injury with initially non-empty notes seeds one row per
+  non-empty note field.
+- Portal: a coach sees EXTERNAL rows only — both at the record-rule level
+  (ORM search) and over HTTP, including when tampering with the scope GET
+  parameter; a treatment professional sees both scopes; a portal user with
+  no right to the injury gets 403.
+- The portal save flow (injury.sudo().write) credits the authenticated
+  session user as author, not the superuser.
+"""
+from odoo.tests import tagged
+
+from .portal_cov_common import PortalCovCommon
+
+
+@tagged('-at_install', 'post_install')
+class TestInjuryNoteHistory(PortalCovCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.History = cls.env['sports.injury.note.history']
+
+    def _new_injury(self):
+        injury = self.env['sports.patient.injury'].create({
+            'patient_id': self.player.id, 'team_id': self.team_a.id,
+            'diagnosis': 'History Fixture',
+        })
+        return injury
+
+    def _rows(self, injury, scope=None, order='id asc'):
+        domain = [('injury_id', '=', injury.id)]
+        if scope:
+            domain.append(('scope', '=', scope))
+        return self.History.search(domain, order=order)
+
+    # ---- capture on write ----
+
+    def test_internal_change_creates_row(self):
+        injury = self._new_injury()
+        injury.with_user(self.tp).with_context(mail_notrack=True).write({
+            'internal_notes': 'First internal note',
+        })
+        rows = self._rows(injury, scope='internal')
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows.content, 'First internal note')
+        self.assertEqual(rows.scope, 'internal')
+        self.assertEqual(rows.author_id, self.tp)
+        self.assertTrue(rows.note_datetime)
+        self.assertEqual(rows.patient_id, self.player)
+
+    def test_external_change_creates_row(self):
+        injury = self._new_injury()
+        injury.with_user(self.tp).with_context(mail_notrack=True).write({
+            'external_notes': 'First external note',
+        })
+        rows = self._rows(injury, scope='external')
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows.content, 'First external note')
+        self.assertEqual(rows.author_id, self.tp)
+
+    def test_no_row_when_note_unchanged(self):
+        injury = self._new_injury()
+        injury.with_context(mail_notrack=True).write({'internal_notes': 'Same'})
+        before = len(self._rows(injury))
+        # Re-saving the identical value must not create a row.
+        injury.with_context(mail_notrack=True).write({'internal_notes': 'Same'})
+        # Neither must a save where the field is present but empty on both sides.
+        injury.with_context(mail_notrack=True).write({'external_notes': False})
+        self.assertEqual(len(self._rows(injury)), before)
+
+    def test_no_row_on_unrelated_write(self):
+        injury = self._new_injury()
+        before = len(self._rows(injury))
+        injury.with_context(mail_notrack=True).write({
+            'diagnosis': 'Changed diagnosis',
+            'predicted_resolution_date': '2026-08-01',
+        })
+        self.assertEqual(len(self._rows(injury)), before)
+
+    def test_rows_are_append_only(self):
+        injury = self._new_injury()
+        injury.with_context(mail_notrack=True).write({'internal_notes': 'v1'})
+        injury.with_context(mail_notrack=True).write({'internal_notes': 'v2'})
+        rows = self._rows(injury, scope='internal')
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows.mapped('content'), ['v1', 'v2'],
+                         "the first snapshot must keep its original content")
+        # Default _order surfaces the newest snapshot first.
+        ordered = self._rows(injury, scope='internal', order=None)
+        self.assertEqual(ordered[0].content, 'v2')
+
+    def test_skip_note_history_context(self):
+        injury = self._new_injury()
+        injury.with_context(mail_notrack=True, skip_note_history=True).write({
+            'internal_notes': 'Invisible to audit',
+        })
+        self.assertFalse(self._rows(injury))
+
+    # ---- capture on create ----
+
+    def test_create_seeds_initial_notes(self):
+        injury = self.env['sports.patient.injury'].create({
+            'patient_id': self.player.id, 'team_id': self.team_a.id,
+            'diagnosis': 'Created with notes',
+            'internal_notes': 'Initial internal',
+            'external_notes': 'Initial external',
+        })
+        internal = self._rows(injury, scope='internal')
+        external = self._rows(injury, scope='external')
+        self.assertEqual(len(internal), 1)
+        self.assertEqual(internal.content, 'Initial internal')
+        self.assertEqual(len(external), 1)
+        self.assertEqual(external.content, 'Initial external')
+
+    def test_create_without_notes_seeds_nothing(self):
+        injury = self._new_injury()
+        self.assertFalse(self._rows(injury))
+
+    # ---- record rules ----
+
+    def test_coach_record_rule_hides_internal(self):
+        injury = self._new_injury()
+        injury.with_context(mail_notrack=True).write({'internal_notes': 'Secret'})
+        injury.with_context(mail_notrack=True).write({'external_notes': 'Public'})
+        coach_rows = self.History.with_user(self.coach).search(
+            [('injury_id', '=', injury.id)])
+        self.assertTrue(coach_rows, "coach must see the external row")
+        self.assertEqual(set(coach_rows.mapped('scope')), {'external'})
+        tp_rows = self.History.with_user(self.tp).search(
+            [('injury_id', '=', injury.id)])
+        self.assertEqual(set(tp_rows.mapped('scope')), {'internal', 'external'})
+
+    # ---- portal route ----
+
+    def _seed_http_fixture(self):
+        injury = self._new_injury()
+        injury.with_context(mail_notrack=True).write(
+            {'internal_notes': 'SecretInternal1241'})
+        injury.with_context(mail_notrack=True).write(
+            {'external_notes': 'VisibleExternal1241'})
+        return injury
+
+    def test_portal_tp_sees_both_scopes(self):
+        injury = self._seed_http_fixture()
+        self._login_tp()
+        resp = self.url_open(f'/my/injury/{injury.id}/notes/history')
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn('SecretInternal1241', resp.text)
+        self.assertIn('VisibleExternal1241', resp.text)
+
+    def test_portal_tp_scope_filter(self):
+        injury = self._seed_http_fixture()
+        self._login_tp()
+        resp = self.url_open(f'/my/injury/{injury.id}/notes/history?scope=internal')
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn('SecretInternal1241', resp.text)
+        self.assertNotIn('VisibleExternal1241', resp.text)
+        resp = self.url_open(f'/my/injury/{injury.id}/notes/history?scope=external')
+        self.assertEqual(resp.status_code, 200)
+        self.assertNotIn('SecretInternal1241', resp.text)
+        self.assertIn('VisibleExternal1241', resp.text)
+
+    def test_portal_coach_sees_external_only(self):
+        injury = self._seed_http_fixture()
+        self._login_coach()
+        resp = self.url_open(f'/my/injury/{injury.id}/notes/history')
+        self.assertEqual(resp.status_code, 200)
+        self.assertNotIn('SecretInternal1241', resp.text)
+        self.assertIn('VisibleExternal1241', resp.text)
+
+    def test_portal_coach_scope_tampering_denied(self):
+        injury = self._seed_http_fixture()
+        self._login_coach()
+        for tampered in ('internal', 'all', 'bogus'):
+            resp = self.url_open(
+                f'/my/injury/{injury.id}/notes/history?scope={tampered}')
+            self.assertEqual(resp.status_code, 200)
+            self.assertNotIn('SecretInternal1241', resp.text,
+                             f"scope={tampered} must not leak internal notes")
+
+    def test_portal_unrelated_user_denied(self):
+        injury = self._seed_http_fixture()
+        self._login_plain()
+        resp = self.url_open(f'/my/injury/{injury.id}/notes/history')
+        self.assertEqual(resp.status_code, 403)
+        self.assertNotIn('SecretInternal1241', resp.text)
+        self.assertNotIn('VisibleExternal1241', resp.text)
+
+    def test_portal_save_credits_authenticated_author(self):
+        """/my/injury/save writes via injury.sudo(); the history row must
+        still credit the authenticated portal user, not the superuser."""
+        injury = self._new_injury()
+        self._login_tp()
+        resp = self.url_open('/my/injury/save', data={
+            'csrf_token': self._csrf(),
+            'injury_id': injury.id,
+            'diagnosis': injury.diagnosis,
+            'internal_notes': 'Portal-authored internal 1241',
+            'stage': 'active',
+        })
+        self.assertEqual(resp.status_code, 200)
+        rows = self._rows(injury, scope='internal')
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows.content, 'Portal-authored internal 1241')
+        self.assertEqual(rows.author_id, self.tp)

--- a/bemade_sports_clinic/tests/test_injury_note_history.py
+++ b/bemade_sports_clinic/tests/test_injury_note_history.py
@@ -217,3 +217,24 @@ class TestInjuryNoteHistory(PortalCovCommon):
         self.assertEqual(len(rows), 1)
         self.assertEqual(rows.content, 'Portal-authored internal 1241')
         self.assertEqual(rows.author_id, self.tp)
+
+    def test_history_page_breadcrumbs(self):
+        """Candidate human-test finding (2026-07-10): the history page must
+        carry a breadcrumb trail back to where it was reached from — team-aware
+        when a team context is passed, player-centric otherwise."""
+        injury = self._seed_http_fixture()
+        self._login_tp()
+        url = f'/my/injury/{injury.id}/notes/history'
+
+        resp = self.url_open(url)
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn('breadcrumb', resp.text)
+        self.assertIn('Edit Injury', resp.text)
+        self.assertIn('/my/players', resp.text)
+
+        team = injury.patient_id.team_ids[:1]
+        if team:
+            resp = self.url_open(f'{url}?team_id={team.id}')
+            self.assertEqual(resp.status_code, 200)
+            self.assertIn('/my/teams', resp.text)
+            self.assertIn(f'team_id={team.id}', resp.text)

--- a/bemade_sports_clinic/tests/test_portal_injury_cards.py
+++ b/bemade_sports_clinic/tests/test_portal_injury_cards.py
@@ -16,7 +16,9 @@ Acceptance criteria:
   patient has no injuries.
 """
 
-from odoo import Command
+import base64
+
+from odoo import Command, fields
 from odoo.tests import HttpCase, tagged
 
 
@@ -90,7 +92,7 @@ class TestPortalInjuryCards(HttpCase):
     def test_no_legacy_table_for_injuries(self):
         """The injuries tab should no longer render a portal_table —
         any remaining <table> elements on the page belong to other tabs
-        (Patient Info, Documents, Treatment Notes)."""
+        (Patient Info)."""
         resp = self._open_player(self.player_with_injuries)
         body = resp.content.decode("utf-8", errors="replace")
         # The injuries tab markup should NOT contain the column headers
@@ -170,3 +172,72 @@ class TestPortalInjuryCards(HttpCase):
         self.assertIn('action="/my/injury/note/add"', body)
         # Existing note appears.
         self.assertIn("Initial visit summary", body)
+
+    # ------------------------------------------------------------------
+    # Task 1242: Documents / Notes / Activities tabs render as card grids
+    # ------------------------------------------------------------------
+
+    def test_documents_tab_cards(self):
+        """Documents render as cards (portal-document-cards grid), the
+        Download action survives, and the description is ESCAPED (the old
+        table used t-raw on user-entered text)."""
+        doc = self.env["sports.injury.document"].create({
+            "name": "MRI scan",
+            "patient_id": self.player_with_injuries.id,
+            "description": "<b>bold</b> injection attempt",
+            "file_content": base64.b64encode(b"dummy content"),
+            "file_name": "mri.pdf",
+        })
+        resp = self._open_player(self.player_with_injuries)
+        body = resp.content.decode("utf-8", errors="replace")
+        self.assertIn("portal-document-cards", body)
+        self.assertIn("portal-document-card", body)
+        self.assertIn("MRI scan", body)
+        # The download action keeps the same URL.
+        self.assertIn(f"/my/patient/document/download/{doc.id}", body)
+        # Description must be escaped, never rendered raw.
+        self.assertNotIn("<b>bold</b>", body)
+        self.assertIn("&lt;b&gt;bold&lt;/b&gt;", body)
+        # Legacy table header for documents is gone.
+        self.assertNotIn(">Category</th>", body)
+
+    def test_notes_tab_cards(self):
+        """Treatment notes render as cards (portal-note-cards grid) with
+        the author-initials badge, replacing the o_sc_notes_table."""
+        self.env["sports.treatment.note"].create({
+            "patient_id": self.player_with_injuries.id,
+            "note": "Card layout note",
+            "user_id": self.tp_user.id,
+        })
+        resp = self._open_player(self.player_with_injuries)
+        body = resp.content.decode("utf-8", errors="replace")
+        self.assertIn("portal-note-cards", body)
+        self.assertIn("portal-note-card", body)
+        self.assertIn("Card layout note", body)
+        # Author initials badge (CSS-tooltip pattern) survives the move.
+        self.assertIn("o_sc_note_author", body)
+        # Legacy notes table is gone from this page.
+        self.assertNotIn("o_sc_notes_table", body)
+        self.assertNotIn(">Related To</th>", body)
+
+    def test_activities_tab_cards(self):
+        """Activities render as cards (portal-activity-cards grid) with a
+        state badge and the same per-activity detail link."""
+        activity = self.env["mail.activity"].create({
+            "activity_type_id": self.env.ref("mail.mail_activity_data_todo").id,
+            "res_model_id": self.env["ir.model"]._get_id("sports.patient"),
+            "res_id": self.player_with_injuries.id,
+            "summary": "Card layout task",
+            "date_deadline": fields.Date.today(),
+        })
+        resp = self._open_player(self.player_with_injuries)
+        body = resp.content.decode("utf-8", errors="replace")
+        self.assertIn("portal-activity-cards", body)
+        self.assertIn("portal-activity-card", body)
+        self.assertIn("Card layout task", body)
+        # Detail link keeps the same URL.
+        self.assertIn(f"/my/activity/{activity.id}", body)
+        # A deadline of today renders the 'today' state badge.
+        self.assertIn("text-bg-warning", body)
+        # Legacy activities table header is gone.
+        self.assertNotIn(">Due Date</th>", body)

--- a/bemade_sports_clinic/views/injury_management_portal_templates.xml
+++ b/bemade_sports_clinic/views/injury_management_portal_templates.xml
@@ -241,6 +241,11 @@
                                                class="btn bg-o-color-2 text-white">
                                                 <i class="fa fa-file-medical"></i> Documents
                                             </a>
+                                            <!-- Audited note history (task 1241) -->
+                                            <a t-att-href="'/my/injury/%s/notes/history' % injury.id"
+                                               class="btn bg-o-color-2 text-white">
+                                                <i class="fa fa-history"></i> Note History
+                                            </a>
                                             <!-- Delete injury button (only for treatment professionals) -->
                                             <button t-if="is_treatment_prof" type="button" class="btn btn-danger" 
                                                     data-bs-toggle="modal" data-bs-target="#deleteInjuryModal"

--- a/bemade_sports_clinic/views/injury_management_portal_templates.xml
+++ b/bemade_sports_clinic/views/injury_management_portal_templates.xml
@@ -242,7 +242,7 @@
                                                 <i class="fa fa-file-medical"></i> Documents
                                             </a>
                                             <!-- Audited note history (task 1241) -->
-                                            <a t-att-href="'/my/injury/%s/notes/history' % injury.id"
+                                            <a t-att-href="'/my/injury/%s/notes/history%s' % (injury.id, ('?team_id=%s' % team_context_id) if team_context_id else '')"
                                                class="btn bg-o-color-2 text-white">
                                                 <i class="fa fa-history"></i> Note History
                                             </a>

--- a/bemade_sports_clinic/views/injury_note_history_portal_templates.xml
+++ b/bemade_sports_clinic/views/injury_note_history_portal_templates.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Read-only audit trail of injury note changes (task 1241).
+         Scope visibility is enforced server-side (controller + record rules);
+         this template only renders what the route hands it. -->
+    <template id="portal_injury_note_history" name="Injury Note History">
+        <t t-call="portal.portal_layout">
+            <t t-set="breadcrumbs_searchbar" t-value="True"/>
+            <t t-call="portal.portal_searchbar">
+                <t t-set="title">Note History</t>
+            </t>
+            <div class="container pt-3">
+                <div class="row mt-3">
+                    <div class="col-lg-12">
+                        <div class="d-flex justify-content-between align-items-center">
+                            <h2>Note History</h2>
+                            <a t-att-href="'/my/injury/edit?injury_id=%s' % injury.id" class="btn bg-o-color-2 text-white">
+                                <i class="fa fa-edit"></i> Edit Injury
+                            </a>
+                        </div>
+                        <p class="text-muted">
+                            Read-only history of note changes for
+                            <strong t-esc="patient.name"/><t t-if="injury.diagnosis"> — <t t-esc="injury.diagnosis"/></t>.
+                        </p>
+
+                        <!-- Scope filter: treatment professionals only. Coaches
+                             are pinned to external notes by the controller and
+                             record rules, so no filter is offered to them. -->
+                        <div t-if="is_treatment_prof" class="btn-group mb-3" role="group" aria-label="Scope filter">
+                            <a t-att-href="'/my/injury/%s/notes/history?scope=all' % injury.id"
+                               t-attf-class="btn btn-sm {{ 'bg-o-color-1 text-white' if scope == 'all' else 'btn-outline-secondary' }}">All</a>
+                            <a t-att-href="'/my/injury/%s/notes/history?scope=internal' % injury.id"
+                               t-attf-class="btn btn-sm {{ 'bg-o-color-1 text-white' if scope == 'internal' else 'btn-outline-secondary' }}">Internal</a>
+                            <a t-att-href="'/my/injury/%s/notes/history?scope=external' % injury.id"
+                               t-attf-class="btn btn-sm {{ 'bg-o-color-1 text-white' if scope == 'external' else 'btn-outline-secondary' }}">External</a>
+                        </div>
+
+                        <div class="card">
+                            <div class="card-header bg-primary text-white">
+                                <h4 class="mb-0">Note History</h4>
+                            </div>
+                            <div class="card-body p-0">
+                                <div class="table-responsive">
+                                    <table class="table table-striped mb-0">
+                                        <thead>
+                                            <tr>
+                                                <th style="width: 11rem;">Date</th>
+                                                <th style="width: 12rem;">Author</th>
+                                                <th t-if="is_treatment_prof" style="width: 6rem;">Scope</th>
+                                                <th>Content</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            <tr t-if="not histories">
+                                                <td colspan="4" class="text-center">No note history available</td>
+                                            </tr>
+                                            <t t-foreach="histories" t-as="hist">
+                                                <tr>
+                                                    <td><span t-field="hist.note_datetime"/></td>
+                                                    <!-- sudo for the author display: portal viewers can't
+                                                         always read cross-team res.users (mirrors the
+                                                         treatment-notes template's author rendering). -->
+                                                    <td><t t-esc="hist.sudo().author_id.name or ''"/></td>
+                                                    <td t-if="is_treatment_prof">
+                                                        <span t-if="hist.scope == 'internal'" class="badge text-bg-warning">Internal</span>
+                                                        <span t-else="" class="badge text-bg-info">External</span>
+                                                    </td>
+                                                    <td>
+                                                        <t t-foreach="(hist.content or '').splitlines()" t-as="hist_line">
+                                                            <p t-if="hist_line.strip()" style="margin: 0 0 0.5em 0; line-height: 1.35;" t-esc="hist_line"/>
+                                                        </t>
+                                                        <em t-if="not (hist.content or '').strip()" class="text-muted">(note cleared)</em>
+                                                    </td>
+                                                </tr>
+                                            </t>
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </t>
+    </template>
+</odoo>

--- a/bemade_sports_clinic/views/injury_note_history_portal_templates.xml
+++ b/bemade_sports_clinic/views/injury_note_history_portal_templates.xml
@@ -27,11 +27,11 @@
                              are pinned to external notes by the controller and
                              record rules, so no filter is offered to them. -->
                         <div t-if="is_treatment_prof" class="btn-group mb-3" role="group" aria-label="Scope filter">
-                            <a t-att-href="'/my/injury/%s/notes/history?scope=all' % injury.id"
+                            <a t-att-href="'/my/injury/%s/notes/history?scope=all%s' % (injury.id, ('&amp;team_id=%s' % team_context_id) if team_context_id else '')"
                                t-attf-class="btn btn-sm {{ 'bg-o-color-1 text-white' if scope == 'all' else 'btn-outline-secondary' }}">All</a>
-                            <a t-att-href="'/my/injury/%s/notes/history?scope=internal' % injury.id"
+                            <a t-att-href="'/my/injury/%s/notes/history?scope=internal%s' % (injury.id, ('&amp;team_id=%s' % team_context_id) if team_context_id else '')"
                                t-attf-class="btn btn-sm {{ 'bg-o-color-1 text-white' if scope == 'internal' else 'btn-outline-secondary' }}">Internal</a>
-                            <a t-att-href="'/my/injury/%s/notes/history?scope=external' % injury.id"
+                            <a t-att-href="'/my/injury/%s/notes/history?scope=external%s' % (injury.id, ('&amp;team_id=%s' % team_context_id) if team_context_id else '')"
                                t-attf-class="btn btn-sm {{ 'bg-o-color-1 text-white' if scope == 'external' else 'btn-outline-secondary' }}">External</a>
                         </div>
 

--- a/bemade_sports_clinic/views/sports_clinic_portal_views.xml
+++ b/bemade_sports_clinic/views/sports_clinic_portal_views.xml
@@ -410,6 +410,37 @@
                     </t>
 
                     <!-- Edit injury (from player context, optional team context) -->
+                    <!-- Injury note history (task 1241, breadcrumbs per candidate
+                         human-test finding 2026-07-10): trail back to wherever the
+                         history was reached from. -->
+                    <t t-elif="page_name == 'injury_note_history'">
+                        <t t-if="team_context_id and team">
+                            <li class="breadcrumb-item"><a href="/my/teams">Teams</a></li>
+                            <li class="breadcrumb-item">
+                                <a t-att-href="'/my/team?team_id=%s' % team.id"><t t-esc="team.name"/></a>
+                            </li>
+                            <li class="breadcrumb-item">
+                                <a t-att-href="'/my/player?player_id=%s&amp;team_id=%s' % (injury.patient_id.id, team.id)">
+                                    <t t-esc="injury.patient_id.name"/>
+                                </a>
+                            </li>
+                            <li class="breadcrumb-item">
+                                <a t-att-href="'/my/injury/edit?injury_id=%s&amp;team_id=%s' % (injury.id, team.id)">Edit Injury</a>
+                            </li>
+                        </t>
+                        <t t-else="">
+                            <li class="breadcrumb-item"><a href="/my/players">Players</a></li>
+                            <li class="breadcrumb-item">
+                                <a t-att-href="'/my/player?player_id=%s' % injury.patient_id.id">
+                                    <t t-esc="injury.patient_id.name"/>
+                                </a>
+                            </li>
+                            <li class="breadcrumb-item">
+                                <a t-att-href="'/my/injury/edit?injury_id=%s' % injury.id">Edit Injury</a>
+                            </li>
+                        </t>
+                        <li class="breadcrumb-item active" aria-current="page">Note History</li>
+                    </t>
                     <t t-elif="page_name == 'edit_injury'">
                         <!-- Team-aware trail when explicit team context is available -->
                         <t t-if="team_context_id and team">
@@ -1750,7 +1781,10 @@
                                 </div>
 
                                 <t t-if="treatment_notes">
-                                    <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-3 portal-note-cards">
+                                    <!-- Notes: single full-width column, newest first (owner design call,
+                                         candidate human test 2026-07-10) — full note text matters more
+                                         than density; cards just narrow on smaller screens. -->
+                                    <div class="row row-cols-1 g-3 portal-note-cards">
                                         <t t-foreach="treatment_notes" t-as="note">
                                             <div class="col">
                                                 <div class="card h-100 portal-note-card">

--- a/bemade_sports_clinic/views/sports_clinic_portal_views.xml
+++ b/bemade_sports_clinic/views/sports_clinic_portal_views.xml
@@ -1671,34 +1671,40 @@
                                 </t>
 
                                 <t t-if="patient_documents">
-                                    <t t-call="portal.portal_table">
-                                        <thead>
-                                            <tr>
-                                                <th>Name</th>
-                                                <th>Category</th>
-                                                <th>Description</th>
-                                                <th>Created</th>
-                                                <th>By</th>
-                                                <th class="text-end">Actions</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            <t t-foreach="patient_documents" t-as="doc">
-                                                <tr>
-                                                    <td><span t-esc="doc.name"/></td>
-                                                    <td><span t-esc="doc.category"/></td>
-                                                    <td><span t-raw="doc.description or ''"/></td>
-                                                    <td><span t-field="doc.create_date" t-options="{'widget': 'datetime'}"/></td>
-                                                    <td><span t-esc="doc.created_by_id.display_name"/></td>
-                                                    <td class="text-end">
-                                                        <a t-att-href="'/my/patient/document/download/%s' % doc.id" class="btn btn-sm bg-o-color-1 text-white">
-                                                            <i class="fa fa-download"></i> Download
-                                                        </a>
-                                                    </td>
-                                                </tr>
-                                            </t>
-                                        </tbody>
-                                    </t>
+                                    <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-3 portal-document-cards">
+                                        <t t-foreach="patient_documents" t-as="doc">
+                                            <div class="col">
+                                                <div class="card h-100 portal-document-card">
+                                                    <div class="card-body d-flex flex-column">
+                                                        <div class="d-flex justify-content-between align-items-start mb-2">
+                                                            <small class="text-muted">
+                                                                <i class="fa fa-calendar me-1"/>
+                                                                <span t-field="doc.create_date" t-options="{'widget': 'datetime'}"/>
+                                                            </small>
+                                                            <span class="badge text-bg-secondary" t-field="doc.category"/>
+                                                        </div>
+                                                        <h5 class="card-title mb-2">
+                                                            <span t-esc="doc.name"/>
+                                                        </h5>
+                                                        <p class="card-text small text-muted mb-2" t-if="doc.description">
+                                                            <span t-esc="doc.description"/>
+                                                        </p>
+                                                        <div class="mb-2">
+                                                            <small class="text-muted">
+                                                                <i class="fa fa-user me-1"/>
+                                                                <span t-esc="doc.created_by_id.display_name"/>
+                                                            </small>
+                                                        </div>
+                                                        <div class="mt-auto pt-2 d-flex flex-wrap gap-1">
+                                                            <a t-att-href="'/my/patient/document/download/%s' % doc.id" class="btn btn-sm bg-o-color-1 text-white">
+                                                                <i class="fa fa-download me-1"/>Download
+                                                            </a>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </t>
+                                    </div>
                                 </t>
                                 <div t-else="" class="text-center text-muted py-4">
                                     <i class="fa fa-file fa-3x mb-3"></i>
@@ -1744,47 +1750,44 @@
                                 </div>
 
                                 <t t-if="treatment_notes">
-                                    <t t-call="portal.portal_table">
-                                        <t t-set="classes">o_sc_notes_table</t>
-                                        <thead>
-                                            <tr>
-                                                <th style="width: 7rem;">Date</th>
-                                                <th style="width: 4rem;" class="text-center">By</th>
-                                                <th style="width: 12rem;">Related To</th>
-                                                <th>Note</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            <t t-foreach="treatment_notes" t-as="note">
-                                                <tr>
-                                                    <td><span t-field="note.date"/></td>
-                                                    <td class="text-center">
-                                                        <span class="badge text-bg-light border o_sc_note_author"
-                                                              t-att-data-author="note.sudo().user_id.name"
-                                                              t-esc="note.author_initials"/>
-                                                    </td>
-                                                    <td>
-                                                        <t t-if="note.injury_id">
-                                                            <a t-attf-href="/my/injury/edit?injury_id={{ note.injury_id.id }}">
-                                                                <span class="badge text-bg-info me-1">Injury</span>
-                                                                <t t-esc="note.injury_id.diagnosis or 'Unnamed injury'"/>
-                                                            </a>
-                                                        </t>
-                                                        <t t-else="">
-                                                            <span class="badge text-bg-secondary">General</span>
-                                                        </t>
-                                                    </td>
-                                                    <td>
-                                                        <!-- One <p> per line: wraps normally, ~1.5-line
-                                                             gap between paragraphs. -->
-                                                        <t t-foreach="(note.note or '').splitlines()" t-as="note_line">
-                                                            <p t-if="note_line.strip()" style="margin: 0 0 0.5em 0; line-height: 1.35;" t-esc="note_line"/>
-                                                        </t>
-                                                    </td>
-                                                </tr>
-                                            </t>
-                                        </tbody>
-                                    </t>
+                                    <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-3 portal-note-cards">
+                                        <t t-foreach="treatment_notes" t-as="note">
+                                            <div class="col">
+                                                <div class="card h-100 portal-note-card">
+                                                    <div class="card-body d-flex flex-column">
+                                                        <div class="d-flex justify-content-between align-items-start mb-2">
+                                                            <small class="text-muted">
+                                                                <i class="fa fa-calendar me-1"/>
+                                                                <span t-field="note.date"/>
+                                                            </small>
+                                                            <span class="badge text-bg-light border o_sc_note_author"
+                                                                  t-att-data-author="note.sudo().user_id.name"
+                                                                  t-esc="note.author_initials"/>
+                                                        </div>
+                                                        <div class="mb-2">
+                                                            <t t-if="note.injury_id">
+                                                                <a t-attf-href="/my/injury/edit?injury_id={{ note.injury_id.id }}"
+                                                                   class="text-decoration-none">
+                                                                    <span class="badge text-bg-info me-1">Injury</span>
+                                                                    <t t-esc="note.injury_id.diagnosis or 'Unnamed injury'"/>
+                                                                </a>
+                                                            </t>
+                                                            <t t-else="">
+                                                                <span class="badge text-bg-secondary">General</span>
+                                                            </t>
+                                                        </div>
+                                                        <div class="card-text">
+                                                            <!-- One <p> per line: wraps normally, ~1.5-line
+                                                                 gap between paragraphs. -->
+                                                            <t t-foreach="(note.note or '').splitlines()" t-as="note_line">
+                                                                <p t-if="note_line.strip()" style="margin: 0 0 0.5em 0; line-height: 1.35;" t-esc="note_line"/>
+                                                            </t>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </t>
+                                    </div>
                                 </t>
                                 <div t-else="" class="text-center text-muted py-4">
                                     <i class="fa fa-clipboard-list fa-3x mb-3"/>
@@ -1850,45 +1853,50 @@
                                 </div>
 
                                 <t t-if="player_activities">
-                                    <t t-call="portal.portal_table">
-                                        <thead>
-                                            <tr>
-                                                <th>Due Date</th>
-                                                <th>Activity</th>
-                                                <th>Summary</th>
-                                                <th>Injury</th>
-                                                <th>Assigned To</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            <t t-foreach="player_activities" t-as="activity">
-                                                <tr>
-                                                    <td><span t-field="activity.date_deadline" t-options="{'widget': 'date'}"/></td>
-                                                    <td><span t-field="activity.activity_type_id"/></td>
-                                                    <td>
-                                                        <a t-attf-href="/my/activity/{{ activity.id }}">
-                                                            <span t-field="activity.summary"/>
-                                                        </a>
-                                                    </td>
-                                                    <td>
-                                                        <t t-if="activity.res_model == 'sports.patient.injury'">
-                                                            <t t-set="row_injury" t-value="injuries.filtered(lambda i: i.id == activity.res_id)"/>
-                                                            <a t-if="row_injury"
-                                                               t-attf-href="/my/injury/edit?injury_id={{ activity.res_id }}{{ ('&amp;team_id=%s' % team_context_id) if team_context_id else '' }}">
-                                                                <span class="badge text-bg-info me-1">Injury</span>
-                                                                <t t-esc="row_injury.diagnosis or 'Injury'"/>
+                                    <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-3 portal-activity-cards">
+                                        <t t-foreach="player_activities" t-as="activity">
+                                            <div class="col">
+                                                <div t-attf-class="card h-100 portal-activity-card border-{{ {'overdue': 'danger', 'today': 'warning', 'planned': 'success'}.get(activity.state, 'secondary') }}">
+                                                    <div class="card-body d-flex flex-column">
+                                                        <div class="d-flex justify-content-between align-items-start mb-2">
+                                                            <small class="text-muted">
+                                                                <i class="fa fa-calendar me-1"/>
+                                                                <span t-field="activity.date_deadline" t-options="{'widget': 'date'}"/>
+                                                            </small>
+                                                            <span t-attf-class="badge text-bg-{{ {'overdue': 'danger', 'today': 'warning', 'planned': 'success'}.get(activity.state, 'secondary') }}"
+                                                                  t-esc="{'overdue': 'Overdue', 'today': 'Today', 'planned': 'Planned'}.get(activity.state, activity.state or '')"/>
+                                                        </div>
+                                                        <h5 class="card-title mb-2">
+                                                            <a t-attf-href="/my/activity/{{ activity.id }}" class="text-decoration-none">
+                                                                <span t-esc="activity.summary or activity.activity_type_id.name"/>
                                                             </a>
-                                                            <span t-else="" class="text-muted">—</span>
-                                                        </t>
-                                                        <t t-else="">
-                                                            <span class="text-muted">—</span>
-                                                        </t>
-                                                    </td>
-                                                    <td><span t-field="activity.user_id"/></td>
-                                                </tr>
-                                            </t>
-                                        </tbody>
-                                    </t>
+                                                        </h5>
+                                                        <div class="mb-2">
+                                                            <small class="text-muted">
+                                                                <i class="fa fa-tag me-1"/>
+                                                                <span t-field="activity.activity_type_id"/>
+                                                            </small>
+                                                        </div>
+                                                        <div class="mb-2" t-if="activity.res_model == 'sports.patient.injury'">
+                                                            <t t-set="card_injury" t-value="injuries.filtered(lambda i: i.id == activity.res_id)"/>
+                                                            <a t-if="card_injury"
+                                                               t-attf-href="/my/injury/edit?injury_id={{ activity.res_id }}{{ ('&amp;team_id=%s' % team_context_id) if team_context_id else '' }}"
+                                                               class="text-decoration-none">
+                                                                <span class="badge text-bg-info me-1">Injury</span>
+                                                                <t t-esc="card_injury.diagnosis or 'Injury'"/>
+                                                            </a>
+                                                        </div>
+                                                        <div class="mt-auto pt-2">
+                                                            <small class="text-muted">
+                                                                <i class="fa fa-user me-1"/>
+                                                                <span t-field="activity.user_id"/>
+                                                            </small>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </t>
+                                    </div>
                                 </t>
                                 <div t-else="" class="text-center text-muted py-4">
                                     <i class="fa fa-tasks fa-3x mb-3"/>

--- a/bemade_sports_clinic/views/sports_clinic_portal_views.xml
+++ b/bemade_sports_clinic/views/sports_clinic_portal_views.xml
@@ -1897,8 +1897,15 @@
                                                                 <i class="fa fa-calendar me-1"/>
                                                                 <span t-field="activity.date_deadline" t-options="{'widget': 'date'}"/>
                                                             </small>
-                                                            <span t-attf-class="badge text-bg-{{ {'overdue': 'danger', 'today': 'warning', 'planned': 'success'}.get(activity.state, 'secondary') }}"
-                                                                  t-esc="{'overdue': 'Overdue', 'today': 'Today', 'planned': 'Planned'}.get(activity.state, activity.state or '')"/>
+                                                            <!-- Literal text nodes (not a t-esc python dict) so the
+                                                                 state labels are QWeb-translatable (fr_CA finding,
+                                                                 candidate human test 2026-07-10). -->
+                                                            <span t-attf-class="badge text-bg-{{ {'overdue': 'danger', 'today': 'warning', 'planned': 'success'}.get(activity.state, 'secondary') }}">
+                                                                <t t-if="activity.state == 'overdue'">Overdue</t>
+                                                                <t t-elif="activity.state == 'today'">Today</t>
+                                                                <t t-elif="activity.state == 'planned'">Planned</t>
+                                                                <t t-else=""><t t-esc="activity.state or ''"/></t>
+                                                            </span>
                                                         </div>
                                                         <h5 class="card-title mb-2">
                                                             <a t-attf-href="/my/activity/{{ activity.id }}" class="text-decoration-none">

--- a/bemade_sports_clinic/views/sports_patient_injury_views.xml
+++ b/bemade_sports_clinic/views/sports_patient_injury_views.xml
@@ -114,12 +114,16 @@
                             <field name="patient_id" invisible="1"/>
                             <field name="allowed_team_ids" invisible="1"/>
                             <field name="team_id" groups="base.group_no_one"/>
-                            <span colspan="2">
-                                <label for="injury_date"/>
-                                <field name="injury_date" widget="date" class="oe_inline"/>
-                                <field name="injury_date_na" class="oe_inline"/>
+                            <!-- Explicit label + o_row keeps label, date and the N/A
+                                 checkbox visually separated — the previous single inline
+                                 span rendered them concatenated ("Date of InjuryMar 4 N/A")
+                                 and pinched the resolution-date labels below (task 1249). -->
+                            <label for="injury_date"/>
+                            <div class="o_row">
+                                <field name="injury_date" widget="date"/>
+                                <field name="injury_date_na"/>
                                 <label for="injury_date_na"/>
-                            </span>
+                            </div>
                             <field name="predicted_resolution_date"/>
                             <field name="resolution_date"/>
                         </group>

--- a/bemade_sports_clinic/views/sports_patient_injury_views.xml
+++ b/bemade_sports_clinic/views/sports_patient_injury_views.xml
@@ -170,6 +170,18 @@
                                 </form>
                             </field>
                         </page>
+                        <page string="Note History">
+                            <!-- Append-only audit trail (task 1241): rows are
+                                 created by server code only and never edited. -->
+                            <field name="note_history_ids" readonly="1">
+                                <list string="Note History" create="false" edit="false" delete="false">
+                                    <field name="note_datetime"/>
+                                    <field name="author_id"/>
+                                    <field name="scope"/>
+                                    <field name="content"/>
+                                </list>
+                            </field>
+                        </page>
                     </notebook>
                 </sheet>
                 <chatter reload_on_post="True"/>


### PR DESCRIPTION
19.0-candidate release batch (2026-07-10), built serially on the candidate and human-tested on a prod-copy DB (owner candidate-testing pass, all areas passed after the fix round).

## Tasks
- **#892** — /my/teams paging duplicated teams across pages (limit=count vs pager step). One-line fix + per-page slicing regression test.
- **#1249** — injury form date fields squished (label+date+N/A checkbox in one inline span). Standard label + o_row markup.
- **#1242** — portal documents/notes/activities tabs from portal_table to card grids matching the injuries pattern. Includes a t-raw→t-esc escape fix on document descriptions (with regression test).
- **#1241** — append-only injury note history: change-only capture with authenticated-author recovery through portal sudo, idempotent seeding migration, read-only backend tab, portal page with coach/TP scoping enforced at controller AND record-rule level.

## Human-test fix round (same session)
Notes tab single-column full-width; fragment-safe redirect params (add-activity now returns to the Activities tab); team-aware breadcrumbs on the note-history page; fr_CA gap fill incl. moving activity state badges out of an untranslatable t-esc dict.

## Verification
Full module suite **495 tests green** on the combined candidate; fix-round slice 49 green; seeding migration exercised live on a prod copy (idempotent). Known follow-up (separate task): patient_injury.py carries a dead duplicate create() definition.

Squash-merge per release convention (matches #186/#198).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmfKwsrmtrdRc89K6pguiz