### PR TITLE
[ADD] sale_rfq_workflow + purchase_quote_ai_analysis: generic supply workflow (fitcrew task 1250)

### DIFF
--- a/purchase_quote_ai_analysis/__init__.py
+++ b/purchase_quote_ai_analysis/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizard

--- a/purchase_quote_ai_analysis/__manifest__.py
+++ b/purchase_quote_ai_analysis/__manifest__.py
@@ -1,0 +1,55 @@
+{
+    'name': 'Purchase Quote AI Analysis',
+    'version': '19.0.1.0.0',
+    'category': 'Inventory/Purchase',
+    'license': 'LGPL-3',
+    'author': 'Bemade Inc.',
+    'website': 'https://www.bemade.org',
+    'depends': ['purchase'],
+    'description': """
+Purchase Quote AI Analysis
+==========================
+
+Analyse a vendor's quote against an RFQ: upload or paste the quote, let
+DeepSeek parse the line items, then review and apply.
+
+- **Price apply**: quoted net unit prices (after any discount) are written to
+  the RFQ lines — rounded to the Product Price precision — and to the
+  product's supplier info for that vendor.
+
+- **Landed costs on the purchase order**: detected freight/handling/surcharge
+  amounts are added as service lines on the RFQ itself, so the RFQ total
+  matches the vendor quote. Re-analysing is idempotent — existing fee lines
+  (including manually added ones) are updated in place, never duplicated.
+  A landed cost left unmapped while marked to apply raises an error instead
+  of being silently dropped.
+
+- **Discrepancy review**: products missing from the quote, extra quote lines,
+  and quantity mismatches are surfaced before anything is applied.
+
+- **Total sanity check**: when the quote's untaxed total can be extracted, it
+  is compared to the RFQ total after apply and the difference is posted to
+  the RFQ chatter.
+
+Extension hook: ``_post_apply_landed_costs`` runs after fee lines are applied,
+letting downstream modules mirror the charges elsewhere (e.g. onto a linked
+sales order).
+
+Setup
+-----
+Set the DeepSeek API key under Settings → Technical → System Parameters:
+key ``purchase_quote_ai_analysis.deepseek_api_key``.
+
+For PDF quote uploads, install ``pypdf`` in the Odoo virtualenv::
+
+    pip install pypdf
+    """,
+    'data': [
+        'security/ir.model.access.csv',
+        'views/purchase_order_views.xml',
+        'wizard/quote_analysis_wizard_views.xml',
+    ],
+    'installable': True,
+    'auto_install': False,
+    'application': False,
+}

--- a/purchase_quote_ai_analysis/models/__init__.py
+++ b/purchase_quote_ai_analysis/models/__init__.py
@@ -1,0 +1,1 @@
+from . import purchase_order

--- a/purchase_quote_ai_analysis/models/purchase_order.py
+++ b/purchase_quote_ai_analysis/models/purchase_order.py
@@ -1,0 +1,15 @@
+from odoo import models
+
+
+class PurchaseOrder(models.Model):
+    _inherit = 'purchase.order'
+
+    def action_analyse_quote(self):
+        self.ensure_one()
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': 'purchase.quote.analysis.wizard',
+            'view_mode': 'form',
+            'target': 'new',
+            'context': {'default_purchase_order_id': self.id},
+        }

--- a/purchase_quote_ai_analysis/security/ir.model.access.csv
+++ b/purchase_quote_ai_analysis/security/ir.model.access.csv
@@ -1,0 +1,5 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_purchase_quote_analysis_wizard,purchase.quote.analysis.wizard,model_purchase_quote_analysis_wizard,base.group_user,1,1,1,1
+access_purchase_quote_price_line,purchase.quote.price.line,model_purchase_quote_price_line,base.group_user,1,1,1,1
+access_purchase_quote_landed_cost,purchase.quote.landed.cost,model_purchase_quote_landed_cost,base.group_user,1,1,1,1
+access_purchase_quote_discrepancy,purchase.quote.discrepancy,model_purchase_quote_discrepancy,base.group_user,1,1,1,1

--- a/purchase_quote_ai_analysis/tests/__init__.py
+++ b/purchase_quote_ai_analysis/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_quote_analysis

--- a/purchase_quote_ai_analysis/tests/test_quote_analysis.py
+++ b/purchase_quote_ai_analysis/tests/test_quote_analysis.py
@@ -271,6 +271,24 @@ class TestQuoteAnalysis(TransactionCase):
             missing.filtered(lambda d: 'Transport' in (d.description or '')),
             "service fee lines must not be reported missing-from-quote")
 
+    def test_reanalysis_prefills_fee_products(self):
+        """Round 2 (owner feedback 2026-07-10): re-analysing after fees were
+        applied must pre-fill each charge's fee product from the existing PO
+        fee lines, so the user neither re-looks them up nor accidentally maps
+        to a different product (which would duplicate the line)."""
+        self._run_wizard()
+        wizard = self.env['purchase.quote.analysis.wizard'].create({
+            'purchase_order_id': self.po.id, 'input_mode': 'text', 'quote_text': 'x',
+        })
+        with patch.object(
+            PurchaseQuoteAnalysisWizard, '_call_deepseek',
+            return_value=json.dumps(self.RESPONSE),
+        ):
+            wizard.action_analyse()
+        by_desc = {lc.description: lc.product_id for lc in wizard.landed_cost_ids}
+        self.assertEqual(by_desc.get('Transport'), self.fee_transport)
+        self.assertEqual(by_desc.get('Surcharge de carburant'), self.fee_surcharge)
+
     def test_discrepancies_detected(self):
         """Missing / extra / qty-mismatch discrepancies are surfaced."""
         response = {

--- a/purchase_quote_ai_analysis/tests/test_quote_analysis.py
+++ b/purchase_quote_ai_analysis/tests/test_quote_analysis.py
@@ -1,0 +1,209 @@
+import json
+from unittest.mock import patch
+
+from odoo import Command
+from odoo.exceptions import UserError
+from odoo.tests import TransactionCase, tagged
+
+from odoo.addons.purchase_quote_ai_analysis.wizard.quote_analysis_wizard import (
+    PurchaseQuoteAnalysisWizard,
+)
+
+
+@tagged("-at_install", "post_install")
+class TestQuoteAnalysis(TransactionCase):
+    """Quote-analysis wizard against a mocked DeepSeek response, modelled on a
+    real vendor quote (net prices after discount, a fuel-surcharge fee line,
+    and a transport amount in the footer)."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        env = cls.env
+        cls.vendor = env['res.partner'].create({
+            'name': 'Quote Vendor', 'is_company': True,
+        })
+        cls.product_a = env['product.product'].create({
+            'name': 'QA Product A', 'type': 'consu',
+        })
+        cls.product_b = env['product.product'].create({
+            'name': 'QA Product B', 'type': 'consu',
+        })
+        cls.fee_transport = env['product.product'].create({
+            'name': 'QA Transport', 'type': 'service',
+        })
+        cls.fee_surcharge = env['product.product'].create({
+            'name': 'QA Fuel Surcharge', 'type': 'service',
+        })
+        cls.po = env['purchase.order'].create({
+            'partner_id': cls.vendor.id,
+            'order_line': [
+                Command.create({
+                    'product_id': cls.product_a.id, 'product_qty': 2, 'price_unit': 0.0,
+                }),
+                Command.create({
+                    'product_id': cls.product_b.id, 'product_qty': 1, 'price_unit': 0.0,
+                }),
+            ],
+        })
+
+    RESPONSE = {
+        'line_items': [
+            {'po_line_index': 0, 'description': 'Product A', 'qty': 2.0, 'unit_price': 12.334},
+            {'po_line_index': 1, 'description': 'Product B', 'qty': 1.0, 'unit_price': 66.6},
+        ],
+        'landed_costs': [
+            {'description': 'Surcharge de carburant', 'amount': 1.0},
+            {'description': 'Transport', 'amount': 16.25},
+        ],
+        'untaxed_total': 108.518,
+    }
+
+    def _run_wizard(self, response=None, apply_landed=True, map_products=True):
+        wizard = self.env['purchase.quote.analysis.wizard'].create({
+            'purchase_order_id': self.po.id,
+            'input_mode': 'text',
+            'quote_text': 'mocked quote text',
+        })
+        with patch.object(
+            PurchaseQuoteAnalysisWizard, '_call_deepseek',
+            return_value=json.dumps(response or self.RESPONSE),
+        ):
+            wizard.action_analyse()
+        wizard.action_apply_prices()
+        if wizard.state == 'review_landed' and apply_landed:
+            if map_products:
+                for lc in wizard.landed_cost_ids:
+                    lc.product_id = (
+                        self.fee_surcharge if 'urcharge' in lc.description else self.fee_transport
+                    )
+            wizard.action_apply_landed_costs()
+        return wizard
+
+    def test_prices_applied_rounded(self):
+        """Quoted prices land on the PO lines and supplierinfo rounded to the
+        Product Price precision."""
+        self._run_wizard()
+        line_a = self.po.order_line.filtered(lambda l: l.product_id == self.product_a)
+        self.assertEqual(line_a.price_unit, 12.33, "12.334 must round to 12.33")
+        line_b = self.po.order_line.filtered(lambda l: l.product_id == self.product_b)
+        self.assertEqual(line_b.price_unit, 66.6)
+        seller = self.product_a.product_tmpl_id.seller_ids.filtered(
+            lambda s: s.partner_id == self.vendor)
+        self.assertEqual(seller.price, 12.33)
+
+    def test_landed_costs_added_to_po(self):
+        """Fee lines are created on the PO so its total matches the quote."""
+        self._run_wizard()
+        fee_lines = self.po.order_line.filtered(
+            lambda l: l.product_id in (self.fee_transport | self.fee_surcharge))
+        self.assertEqual(len(fee_lines), 2)
+        by_product = {l.product_id: l for l in fee_lines}
+        self.assertEqual(by_product[self.fee_surcharge].price_unit, 1.0)
+        self.assertEqual(by_product[self.fee_transport].price_unit, 16.25)
+        self.assertEqual(by_product[self.fee_transport].product_qty, 1)
+
+    def test_reanalysis_is_idempotent(self):
+        """Running the analysis twice must not duplicate fee lines; amounts
+        are updated in place."""
+        self._run_wizard()
+        n_lines = len(self.po.order_line)
+        updated = dict(self.RESPONSE)
+        updated['landed_costs'] = [
+            {'description': 'Surcharge de carburant', 'amount': 2.0},
+            {'description': 'Transport', 'amount': 18.0},
+        ]
+        self._run_wizard(response=updated)
+        self.assertEqual(len(self.po.order_line), n_lines,
+                         "re-analysis must not append duplicate fee lines")
+        transport = self.po.order_line.filtered(lambda l: l.product_id == self.fee_transport)
+        self.assertEqual(transport.price_unit, 18.0)
+
+    def test_manual_fee_line_adopted(self):
+        """A fee line the buyer already added by hand is updated, not doubled."""
+        self.env['purchase.order.line'].create({
+            'order_id': self.po.id,
+            'product_id': self.fee_transport.id,
+            'name': 'Transport (manual)',
+            'product_qty': 1,
+            'product_uom_id': self.fee_transport.uom_id.id,
+            'price_unit': 99.0,
+        })
+        self._run_wizard()
+        transport_lines = self.po.order_line.filtered(
+            lambda l: l.product_id == self.fee_transport)
+        self.assertEqual(len(transport_lines), 1)
+        self.assertEqual(transport_lines.price_unit, 16.25)
+
+    def test_unmapped_landed_cost_raises(self):
+        """An applied landed cost without a product must raise, not vanish."""
+        with self.assertRaises(UserError):
+            self._run_wizard(map_products=False)
+
+    def test_unapplied_landed_cost_ignored_and_logged(self):
+        """Unticked landed costs are skipped and listed in the chatter."""
+        wizard = self.env['purchase.quote.analysis.wizard'].create({
+            'purchase_order_id': self.po.id,
+            'input_mode': 'text',
+            'quote_text': 'mocked',
+        })
+        with patch.object(
+            PurchaseQuoteAnalysisWizard, '_call_deepseek',
+            return_value=json.dumps(self.RESPONSE),
+        ):
+            wizard.action_analyse()
+        wizard.action_apply_prices()
+        surcharge_lc = wizard.landed_cost_ids.filtered(
+            lambda l: 'urcharge' in l.description)
+        surcharge_lc.apply = False
+        transport_lc = wizard.landed_cost_ids - surcharge_lc
+        transport_lc.product_id = self.fee_transport
+        wizard.action_apply_landed_costs()
+
+        self.assertFalse(self.po.order_line.filtered(
+            lambda l: l.product_id == self.fee_surcharge))
+        note = self.po.message_ids.filtered(
+            lambda m: 'Ignored' in (m.body or ''))
+        self.assertTrue(note, "ignored landed costs must be listed in chatter")
+
+    def test_total_sanity_check_mismatch_flagged(self):
+        """A quote total that doesn't match the PO after apply posts a warning."""
+        bad_total = dict(self.RESPONSE, untaxed_total=999.99)
+        self._run_wizard(response=bad_total)
+        warning = self.po.message_ids.filtered(
+            lambda m: 'differs from the vendor' in (m.body or ''))
+        self.assertTrue(warning)
+
+    def test_total_sanity_check_match(self):
+        """A matching total posts the confirmation note. PO total after apply:
+        2×12.33 + 66.60 + 1.00 + 16.25 = 108.51."""
+        good_total = dict(self.RESPONSE, untaxed_total=108.51)
+        self._run_wizard(response=good_total)
+        ok_note = self.po.message_ids.filtered(
+            lambda m: 'matches the vendor quote' in (m.body or ''))
+        self.assertTrue(ok_note)
+
+    def test_discrepancies_detected(self):
+        """Missing / extra / qty-mismatch discrepancies are surfaced."""
+        response = {
+            'line_items': [
+                {'po_line_index': 0, 'description': 'Product A', 'qty': 5.0, 'unit_price': 12.0},
+                {'po_line_index': -1, 'description': 'Unknown thing', 'qty': 1.0, 'unit_price': 3.0},
+            ],
+            'landed_costs': [],
+            'untaxed_total': 0.0,
+        }
+        wizard = self.env['purchase.quote.analysis.wizard'].create({
+            'purchase_order_id': self.po.id,
+            'input_mode': 'text',
+            'quote_text': 'mocked',
+        })
+        with patch.object(
+            PurchaseQuoteAnalysisWizard, '_call_deepseek',
+            return_value=json.dumps(response),
+        ):
+            wizard.action_analyse()
+        types = wizard.discrepancy_ids.mapped('discrepancy_type')
+        self.assertIn('missing', types)   # product_b absent from quote
+        self.assertIn('extra', types)     # unmatched quote line
+        self.assertIn('qty_mismatch', types)  # 5 quoted vs 2 on RFQ

--- a/purchase_quote_ai_analysis/tests/test_quote_analysis.py
+++ b/purchase_quote_ai_analysis/tests/test_quote_analysis.py
@@ -183,6 +183,94 @@ class TestQuoteAnalysis(TransactionCase):
             lambda m: 'matches the vendor quote' in (m.body or ''))
         self.assertTrue(ok_note)
 
+    def test_fee_line_item_promoted_to_landed_cost(self):
+        """A fee that appears as an unmatched quote LINE ITEM (the T3-00 case)
+        must be promoted to landed costs deterministically — LLM classification
+        of fee lines is nondeterministic — and not flagged 'extra in quote'."""
+        response = {
+            'line_items': [
+                {'po_line_index': 0, 'description': 'Product A', 'qty': 2.0, 'unit_price': 12.33},
+                {'po_line_index': -1, 'description': 'T3-00 Surcharge de carburant',
+                 'qty': 1.0, 'unit_price': 1.0},
+            ],
+            'landed_costs': [{'description': 'Transport', 'amount': 16.25}],
+            'untaxed_total': 0.0,
+        }
+        wizard = self.env['purchase.quote.analysis.wizard'].create({
+            'purchase_order_id': self.po.id, 'input_mode': 'text', 'quote_text': 'x',
+        })
+        with patch.object(
+            PurchaseQuoteAnalysisWizard, '_call_deepseek',
+            return_value=json.dumps(response),
+        ):
+            wizard.action_analyse()
+        lc_descriptions = wizard.landed_cost_ids.mapped('description')
+        self.assertIn('T3-00 Surcharge de carburant', lc_descriptions)
+        surcharge_lc = wizard.landed_cost_ids.filtered(
+            lambda l: 'urcharge' in l.description)
+        self.assertEqual(surcharge_lc.amount, 1.0)
+        extras = wizard.discrepancy_ids.filtered(
+            lambda d: d.discrepancy_type == 'extra')
+        self.assertFalse(extras.filtered(lambda d: 'urcharge' in d.description),
+                         "promoted fee must not also appear as an 'extra' discrepancy")
+
+    def test_two_charges_same_product_no_clobber(self):
+        """Two charges mapped to the SAME fee product must not overwrite each
+        other (live finding 2026-07-10: 'Surcharge' clobbered the 16.25
+        Transport line). Description-matched line updates; the other charge
+        gets its own line."""
+        self.env['purchase.order.line'].create({
+            'order_id': self.po.id,
+            'product_id': self.fee_transport.id,
+            'name': 'Transport',
+            'product_qty': 1,
+            'product_uom_id': self.fee_transport.uom_id.id,
+            'price_unit': 16.25,
+        })
+        wizard = self.env['purchase.quote.analysis.wizard'].create({
+            'purchase_order_id': self.po.id, 'input_mode': 'text', 'quote_text': 'x',
+        })
+        with patch.object(
+            PurchaseQuoteAnalysisWizard, '_call_deepseek',
+            return_value=json.dumps(self.RESPONSE),
+        ):
+            wizard.action_analyse()
+        wizard.action_apply_prices()
+        # Map BOTH charges to the same product (the foot-gun).
+        wizard.landed_cost_ids.write({'product_id': self.fee_transport.id})
+        wizard.action_apply_landed_costs()
+
+        fee_lines = self.po.order_line.filtered(
+            lambda l: l.product_id == self.fee_transport)
+        self.assertEqual(len(fee_lines), 2,
+                         "surcharge must land on its own line, not clobber transport")
+        self.assertEqual(sorted(fee_lines.mapped('price_unit')), [1.0, 16.25])
+
+    def test_service_lines_excluded_from_matching(self):
+        """Fee/service lines on the PO must not be sent to the matcher nor
+        flagged 'missing from quote' on re-analysis (live finding 2026-07-10)."""
+        self.env['purchase.order.line'].create({
+            'order_id': self.po.id,
+            'product_id': self.fee_transport.id,
+            'name': 'Transport',
+            'product_qty': 1,
+            'product_uom_id': self.fee_transport.uom_id.id,
+            'price_unit': 16.25,
+        })
+        wizard = self.env['purchase.quote.analysis.wizard'].create({
+            'purchase_order_id': self.po.id, 'input_mode': 'text', 'quote_text': 'x',
+        })
+        with patch.object(
+            PurchaseQuoteAnalysisWizard, '_call_deepseek',
+            return_value=json.dumps(self.RESPONSE),
+        ):
+            wizard.action_analyse()
+        missing = wizard.discrepancy_ids.filtered(
+            lambda d: d.discrepancy_type == 'missing')
+        self.assertFalse(
+            missing.filtered(lambda d: 'Transport' in (d.description or '')),
+            "service fee lines must not be reported missing-from-quote")
+
     def test_discrepancies_detected(self):
         """Missing / extra / qty-mismatch discrepancies are surfaced."""
         response = {

--- a/purchase_quote_ai_analysis/views/purchase_order_views.xml
+++ b/purchase_quote_ai_analysis/views/purchase_order_views.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_purchase_order_form_quote_analysis" model="ir.ui.view">
+        <field name="name">purchase.quote.ai.analysis.purchase.order.form</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.purchase_order_form"/>
+        <field name="arch" type="xml">
+
+            <!-- Analyse Quote button in header, before the statusbar field -->
+            <xpath expr="//header/field[@name='state']" position="before">
+                <button name="action_analyse_quote"
+                        type="object"
+                        string="Analyse Quote"
+                        class="btn-secondary"
+                        invisible="state not in ('draft', 'sent')"/>
+            </xpath>
+
+        </field>
+    </record>
+</odoo>

--- a/purchase_quote_ai_analysis/wizard/__init__.py
+++ b/purchase_quote_ai_analysis/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import quote_analysis_wizard

--- a/purchase_quote_ai_analysis/wizard/quote_analysis_wizard.py
+++ b/purchase_quote_ai_analysis/wizard/quote_analysis_wizard.py
@@ -1,0 +1,475 @@
+import io
+import json
+
+import requests
+
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError
+from odoo.tools import float_compare, float_round
+
+
+def _extract_pdf_text(pdf_bytes):
+    if not pdf_bytes:
+        raise UserError(_(
+            "The selected PDF attachment is empty or could not be read. "
+            "Re-upload the file and try again."
+        ))
+    try:
+        import pypdf
+    except ImportError:
+        raise UserError(_(
+            "PDF text extraction requires the 'pypdf' library. "
+            "Install it with: pip install pypdf"
+        ))
+    reader = pypdf.PdfReader(io.BytesIO(pdf_bytes))
+    return '\n'.join(page.extract_text() or '' for page in reader.pages)
+
+
+class PurchaseQuoteAnalysisWizard(models.TransientModel):
+    _name = 'purchase.quote.analysis.wizard'
+    _description = 'AI Vendor Quote Analysis'
+
+    purchase_order_id = fields.Many2one('purchase.order', required=True, readonly=True)
+    input_mode = fields.Selection([
+        ('file', 'PDF Attachment'),
+        ('text', 'Paste Text'),
+    ], default='file', required=True, string='Input Method')
+    quote_attachment_id = fields.Many2one(
+        'ir.attachment',
+        string='Quote PDF',
+        domain="[('res_model', '=', 'purchase.order'), ('res_id', '=', purchase_order_id),"
+               " '|', ('mimetype', '=', 'application/pdf'), ('name', 'ilike', '.pdf')]",
+    )
+    quote_text = fields.Text(string='Quote Text')
+    state = fields.Selection([
+        ('input', 'Select Quote'),
+        ('review_prices', 'Review Prices'),
+        ('review_landed', 'Review & Finalise'),
+    ], default='input', required=True)
+
+    price_line_ids = fields.One2many(
+        'purchase.quote.price.line', 'wizard_id', string='Quoted Prices',
+    )
+    landed_cost_ids = fields.One2many(
+        'purchase.quote.landed.cost', 'wizard_id', string='Landed Costs',
+    )
+    discrepancy_ids = fields.One2many(
+        'purchase.quote.discrepancy', 'wizard_id', string='Discrepancies',
+    )
+    quote_untaxed_total = fields.Float(
+        string='Quote Untaxed Total', digits='Product Price', readonly=True,
+        help="Untaxed total extracted from the vendor quote (products + fees,"
+             " before taxes); used for the post-apply sanity check.",
+    )
+    has_landed_costs = fields.Boolean(compute='_compute_has_landed_costs')
+    has_discrepancies = fields.Boolean(compute='_compute_has_discrepancies')
+
+    @api.depends('landed_cost_ids')
+    def _compute_has_landed_costs(self):
+        for wiz in self:
+            wiz.has_landed_costs = bool(wiz.landed_cost_ids)
+
+    @api.depends('discrepancy_ids')
+    def _compute_has_discrepancies(self):
+        for wiz in self:
+            wiz.has_discrepancies = bool(wiz.discrepancy_ids)
+
+    @api.model
+    def default_get(self, fields_list):
+        res = super().default_get(fields_list)
+        po_id = self.env.context.get('default_purchase_order_id')
+        if po_id:
+            attachments = self.env['ir.attachment'].search([
+                ('res_model', '=', 'purchase.order'),
+                ('res_id', '=', po_id),
+                '|',
+                ('mimetype', '=', 'application/pdf'),
+                ('name', 'ilike', '.pdf'),
+            ])
+            if len(attachments) == 1:
+                res['quote_attachment_id'] = attachments.id
+        return res
+
+    def _price_precision(self):
+        return self.env['decimal.precision'].precision_get('Product Price')
+
+    def _get_api_key(self):
+        icp = self.env['ir.config_parameter'].sudo()
+        key = (
+            icp.get_param('purchase_quote_ai_analysis.deepseek_api_key')
+            # Backward compatibility: the key under the original client-module
+            # name keeps working after the migration to this module.
+            or icp.get_param('fitcrew_supply_workflow.deepseek_api_key')
+        )
+        if not key:
+            raise UserError(_(
+                "DeepSeek API key not configured. "
+                "Go to Settings → Technical → System Parameters and add "
+                "'purchase_quote_ai_analysis.deepseek_api_key'."
+            ))
+        return key
+
+    def _call_deepseek(self, quote_text):
+        api_key = self._get_api_key()
+        system_prompt = (
+            "You are a procurement assistant extracting pricing from vendor quotes.\n"
+            "Quotes may be in French or English.\n\n"
+            "CRITICAL PRICING RULE — always use the net unit price after any discount:\n"
+            "  - If the quote has a discount column (Esc., Discount, Rabais, %) AND a net price "
+            "column (Prix net, Net, Prix unitaire net), use the NET price, never the gross/list price.\n"
+            "  - If there is no discount column, use the unit price as shown.\n"
+            "  - Common French column names: Articles=SKU, Qté=qty, Prix=list price, "
+            "Esc.=discount, Prix net=net unit price, Total=line total.\n"
+            "  - Do NOT derive the net price yourself from list price and discount percentage; "
+            "read it directly from the net price column.\n\n"
+            "Return ONLY valid JSON matching this schema — no markdown, no explanation:\n"
+            '{"line_items": [{"po_line_index": 0, "description": "...", "qty": 1.0, "unit_price": 0.0}], '
+            '"landed_costs": [{"description": "...", "amount": 0.0}], '
+            '"untaxed_total": 0.0}\n\n'
+            "line_items MUST include EVERY product line from the vendor quote — do not omit any.\n"
+            "po_line_index is the 0-based index into the PO lines list provided. "
+            "Match by SKU/article code first, then by description if no code match. "
+            "Use -1 for any quote line that cannot be matched to a PO product — "
+            "these are still required in the output so discrepancies can be flagged to the user.\n\n"
+            "landed_costs: include shipping, freight, transport, handling, duties, fuel "
+            "surcharges and similar fees — even if the amount is 0, and EVEN IF the fee appears "
+            "as a regular line item in the quote body (e.g. a 'Surcharge de carburant' article "
+            "line): a fee is a landed cost, not a product line_item, unless it matches an "
+            "existing PO line in the list provided. Do NOT include taxes (TPS, TVQ, GST, QST, "
+            "HST) as landed costs.\n\n"
+            "untaxed_total: the quote's total before taxes, INCLUDING landed costs/fees "
+            "(e.g. 'Sous-total' plus 'Transport'). Omit or use 0.0 if it cannot be determined."
+        )
+        payload = {
+            'model': 'deepseek-chat',
+            'messages': [
+                {'role': 'system', 'content': system_prompt},
+                {'role': 'user', 'content': quote_text},
+            ],
+            'response_format': {'type': 'json_object'},
+            'max_tokens': 4096,
+        }
+        headers = {
+            'Authorization': f'Bearer {api_key}',
+            'Content-Type': 'application/json',
+        }
+        try:
+            resp = requests.post(
+                'https://api.deepseek.com/chat/completions',
+                json=payload,
+                headers=headers,
+                timeout=60,
+            )
+        except requests.RequestException as e:
+            raise UserError(_("Network error calling DeepSeek API: %s", e))
+
+        if not resp.ok:
+            raise UserError(_("DeepSeek API error %s: %s", resp.status_code, resp.text))
+
+        return resp.json()['choices'][0]['message']['content']
+
+    def action_analyse(self):
+        self.ensure_one()
+        po = self.purchase_order_id
+        po_lines = po.order_line.filtered(lambda l: not l.display_type and l.product_id)
+
+        if not po_lines:
+            raise UserError(_("The RFQ has no product lines to match against."))
+
+        po_summary = '\n'.join(
+            f"  Line {i}: {l.product_id.display_name} — qty {l.product_qty} {l.product_uom_id.name}"
+            for i, l in enumerate(po_lines)
+        )
+        intro = (
+            f"RFQ lines to match (0-based index):\n{po_summary}\n\n"
+            "Extract the pricing from the vendor quote that follows."
+        )
+
+        if self.input_mode == 'file':
+            if not self.quote_attachment_id:
+                raise UserError(_("Please select a PDF attachment."))
+            pdf_text = _extract_pdf_text(self.quote_attachment_id.sudo().raw)
+            if not pdf_text.strip():
+                raise UserError(_(
+                    "Could not extract text from the selected PDF. "
+                    "Try using 'Paste Text' instead."
+                ))
+            user_content = f"{intro}\n\n{pdf_text}"
+        else:
+            if not self.quote_text:
+                raise UserError(_("Please paste the quote text."))
+            user_content = f"{intro}\n\n{self.quote_text}"
+
+        raw = self._call_deepseek(user_content)
+
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise UserError(_(
+                "Could not parse AI response as JSON: %(err)s\n\nResponse was:\n%(raw)s",
+                err=exc,
+                raw=raw,
+            ))
+
+        po_lines_list = list(po_lines)
+        line_items = data.get('line_items', [])
+
+        price_vals = []
+        matched_indices = set()
+        for item in line_items:
+            idx = item.get('po_line_index', -1)
+            po_line = po_lines_list[idx] if 0 <= idx < len(po_lines_list) else False
+            if po_line:
+                matched_indices.add(idx)
+            price_vals.append((0, 0, {
+                'po_line_id': po_line.id if po_line else False,
+                'description': item.get('description', ''),
+                'quoted_qty': float(item.get('qty', 0.0)),
+                'quoted_unit_price': float(item.get('unit_price', 0.0)),
+                'apply': bool(po_line),
+            }))
+
+        landed_vals = []
+        for lc in data.get('landed_costs', []):
+            landed_vals.append((0, 0, {
+                'description': lc.get('description', ''),
+                'amount': float(lc.get('amount', 0.0)),
+                'apply': True,
+            }))
+
+        discrepancy_vals = []
+        # Products on RFQ that the quote didn't mention
+        for i, pol in enumerate(po_lines_list):
+            if i not in matched_indices:
+                discrepancy_vals.append((0, 0, {
+                    'discrepancy_type': 'missing',
+                    'po_line_id': pol.id,
+                    'description': pol.product_id.display_name,
+                    'rfq_qty': pol.product_qty,
+                    'quoted_qty': 0.0,
+                }))
+        # Items in the quote that don't match any RFQ line
+        for item in line_items:
+            if item.get('po_line_index', -1) == -1:
+                discrepancy_vals.append((0, 0, {
+                    'discrepancy_type': 'extra',
+                    'po_line_id': False,
+                    'description': item.get('description', ''),
+                    'rfq_qty': 0.0,
+                    'quoted_qty': float(item.get('qty', 0.0)),
+                }))
+        # Matched lines where the quoted qty differs from the RFQ qty
+        for item in line_items:
+            idx = item.get('po_line_index', -1)
+            if 0 <= idx < len(po_lines_list):
+                pol = po_lines_list[idx]
+                quoted_qty = float(item.get('qty', 0.0))
+                if round(quoted_qty, 4) != round(pol.product_qty, 4):
+                    discrepancy_vals.append((0, 0, {
+                        'discrepancy_type': 'qty_mismatch',
+                        'po_line_id': pol.id,
+                        'description': item.get('description', ''),
+                        'rfq_qty': pol.product_qty,
+                        'quoted_qty': quoted_qty,
+                    }))
+
+        self.write({
+            'price_line_ids': price_vals,
+            'landed_cost_ids': landed_vals,
+            'discrepancy_ids': discrepancy_vals,
+            'quote_untaxed_total': float(data.get('untaxed_total') or 0.0),
+            'state': 'review_prices',
+        })
+        return self._reopen()
+
+    def action_apply_prices(self):
+        """Write quoted prices to PO lines and update product supplier info."""
+        self.ensure_one()
+        po = self.purchase_order_id
+        vendor = po.partner_id
+        precision = self._price_precision()
+
+        for pline in self.price_line_ids.filtered(lambda l: l.apply and l.po_line_id):
+            po_line = pline.po_line_id
+            quoted_price = float_round(pline.quoted_unit_price, precision_digits=precision)
+            po_line.price_unit = quoted_price
+
+            tmpl = po_line.product_id.product_tmpl_id
+            seller = tmpl.seller_ids.filtered(lambda s: s.partner_id == vendor)[:1]
+            if seller:
+                seller.price = quoted_price
+            else:
+                self.env['product.supplierinfo'].create({
+                    'partner_id': vendor.id,
+                    'product_tmpl_id': tmpl.id,
+                    # 19.0: product.supplierinfo.product_uom_id is now required.
+                    'product_uom_id': tmpl.uom_id.id,
+                    'price': quoted_price,
+                    'min_qty': 0.0,
+                })
+
+        po.message_post(body=_(
+            "Quote analysed by %(user)s. RFQ prices and vendor pricelists updated.",
+            user=self.env.user.name,
+        ))
+
+        if self.landed_cost_ids or self.discrepancy_ids:
+            self.write({'state': 'review_landed'})
+            return self._reopen()
+
+        self._post_total_sanity_check()
+        return {'type': 'ir.actions.act_window_close'}
+
+    def action_apply_landed_costs(self):
+        """Add or update the selected landed cost lines on the purchase order.
+
+        Idempotent: an existing PO line for the same service product — whether
+        from a previous analysis or added manually — is updated in place, never
+        duplicated.
+        """
+        self.ensure_one()
+        po = self.purchase_order_id
+        precision = self._price_precision()
+
+        to_apply = self.landed_cost_ids.filtered('apply')
+        unmapped = to_apply.filtered(lambda l: not l.product_id)
+        if unmapped:
+            raise UserError(_(
+                "No product selected for the following charges: %(lines)s.\n"
+                "Pick a service product for each, or untick 'Apply' to ignore them.",
+                lines=', '.join(unmapped.mapped('description')),
+            ))
+
+        fee_lines_by_lc = {}
+        for lc in to_apply:
+            amount = float_round(lc.amount, precision_digits=precision)
+            po_line = po.order_line.filtered(
+                lambda l: l.product_id == lc.product_id and not l.display_type
+            )[:1]
+            if po_line:
+                po_line.write({'price_unit': amount, 'product_qty': 1})
+            else:
+                taxes = lc.product_id.supplier_taxes_id.filtered(
+                    lambda t: t.company_id == po.company_id
+                )
+                po_line = self.env['purchase.order.line'].create({
+                    'order_id': po.id,
+                    'product_id': lc.product_id.id,
+                    'name': lc.description or lc.product_id.name,
+                    'product_qty': 1,
+                    'product_uom_id': lc.product_id.uom_id.id,
+                    'price_unit': amount,
+                    'date_planned': fields.Datetime.now(),
+                    'tax_ids': [fields.Command.set(taxes.ids)],
+                })
+            fee_lines_by_lc[lc] = po_line
+
+        ignored = self.landed_cost_ids.filtered(lambda l: not l.apply)
+        if fee_lines_by_lc or ignored:
+            parts = []
+            if fee_lines_by_lc:
+                parts.append(_(
+                    "Landed costs applied to this RFQ from the vendor quote: %(lines)s.",
+                    lines=', '.join(lc.description for lc in fee_lines_by_lc),
+                ))
+            if ignored:
+                parts.append(_(
+                    "Ignored (not applied): %(lines)s.",
+                    lines=', '.join(ignored.mapped('description')),
+                ))
+            po.message_post(body=' '.join(parts))
+
+        self._post_apply_landed_costs(fee_lines_by_lc)
+        self._post_total_sanity_check()
+        return {'type': 'ir.actions.act_window_close'}
+
+    def _post_apply_landed_costs(self, fee_lines_by_lc):
+        """Extension hook, called after landed-cost lines are written to the
+        purchase order.
+
+        :param fee_lines_by_lc: dict mapping each applied
+            ``purchase.quote.landed.cost`` wizard line to the
+            ``purchase.order.line`` created or updated for it.
+        """
+        return True
+
+    def _post_total_sanity_check(self):
+        """Compare the quote's extracted untaxed total to the PO's and post
+        the verdict — catches lines the extraction missed."""
+        self.ensure_one()
+        if not self.quote_untaxed_total:
+            return
+        po = self.purchase_order_id
+        if float_compare(
+            po.amount_untaxed, self.quote_untaxed_total,
+            precision_rounding=po.currency_id.rounding,
+        ) == 0:
+            po.message_post(body=_(
+                "✅ RFQ untaxed total (%(po_total)s) matches the vendor quote.",
+                po_total=po.amount_untaxed,
+            ))
+        else:
+            po.message_post(body=_(
+                "⚠️ RFQ untaxed total (%(po_total)s) differs from the vendor "
+                "quote (%(quote_total)s) — review for missed or extra lines.",
+                po_total=po.amount_untaxed,
+                quote_total=self.quote_untaxed_total,
+            ))
+
+    def action_skip_landed_costs(self):
+        self._post_total_sanity_check()
+        return {'type': 'ir.actions.act_window_close'}
+
+    def _reopen(self):
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': self._name,
+            'res_id': self.id,
+            'view_mode': 'form',
+            'target': 'new',
+        }
+
+
+class PurchaseQuotePriceLine(models.TransientModel):
+    _name = 'purchase.quote.price.line'
+    _description = 'AI-Extracted Quote Price Line'
+
+    wizard_id = fields.Many2one('purchase.quote.analysis.wizard', required=True)
+    po_line_id = fields.Many2one('purchase.order.line', string='RFQ Line')
+    product_id = fields.Many2one(related='po_line_id.product_id', string='Product', readonly=True)
+    description = fields.Char(string='Quote Description', readonly=True)
+    quoted_qty = fields.Float(string='Qty', digits='Product Unit of Measure', readonly=True)
+    quoted_unit_price = fields.Float(string='Unit Price', digits='Product Price')
+    apply = fields.Boolean(string='Apply', default=True)
+
+
+class PurchaseQuoteLandedCost(models.TransientModel):
+    _name = 'purchase.quote.landed.cost'
+    _description = 'AI-Detected Landed Cost Line'
+
+    wizard_id = fields.Many2one('purchase.quote.analysis.wizard', required=True)
+    description = fields.Char(string='Description from Quote', readonly=True)
+    amount = fields.Float(string='Amount', digits='Product Price')
+    product_id = fields.Many2one(
+        'product.product',
+        string='Fee Product',
+        domain=[('type', 'in', ['service', 'consu'])],
+        help="Service product used for this charge's line on the purchase order.",
+    )
+    apply = fields.Boolean(string='Apply', default=True)
+
+
+class PurchaseQuoteDiscrepancy(models.TransientModel):
+    _name = 'purchase.quote.discrepancy'
+    _description = 'Quote vs RFQ Discrepancy'
+
+    wizard_id = fields.Many2one('purchase.quote.analysis.wizard', required=True)
+    discrepancy_type = fields.Selection([
+        ('missing', 'Missing from Quote'),
+        ('extra', 'Extra in Quote'),
+        ('qty_mismatch', 'Quantity Mismatch'),
+    ], string='Issue', readonly=True)
+    po_line_id = fields.Many2one('purchase.order.line', string='RFQ Line', readonly=True)
+    description = fields.Char(string='Description', readonly=True)
+    rfq_qty = fields.Float(string='RFQ Qty', digits='Product Unit of Measure', readonly=True)
+    quoted_qty = fields.Float(string='Quoted Qty', digits='Product Unit of Measure', readonly=True)

--- a/purchase_quote_ai_analysis/wizard/quote_analysis_wizard.py
+++ b/purchase_quote_ai_analysis/wizard/quote_analysis_wizard.py
@@ -275,11 +275,28 @@ class PurchaseQuoteAnalysisWizard(models.TransientModel):
                 'apply': bool(po_line),
             }))
 
+        # Pre-fill each charge's fee product from the PO's existing fee lines
+        # (re-analysis case): saves the lookup and prevents accidentally
+        # mapping the same charge to a different product, which would create
+        # a duplicate line (owner feedback 2026-07-10).
+        fee_po_lines = po.order_line.filtered(
+            lambda l: not l.display_type and l.product_id
+            and l.product_id.type == 'service'
+        )
         landed_vals = []
         for lc in landed_costs:
+            description = lc.get('description', '')
+            tokens = {t for t in re.findall(r'\w{4,}', description.lower())}
+            product_id = False
+            if tokens:
+                for line in fee_po_lines:
+                    if tokens & set(re.findall(r'\w{4,}', (line.name or '').lower())):
+                        product_id = line.product_id.id
+                        break
             landed_vals.append((0, 0, {
-                'description': lc.get('description', ''),
+                'description': description,
                 'amount': float(lc.get('amount', 0.0)),
+                'product_id': product_id,
                 'apply': True,
             }))
 

--- a/purchase_quote_ai_analysis/wizard/quote_analysis_wizard.py
+++ b/purchase_quote_ai_analysis/wizard/quote_analysis_wizard.py
@@ -1,11 +1,27 @@
 import io
 import json
+import re
 
 import requests
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 from odoo.tools import float_compare, float_round
+
+
+# Fee/charge markers (fr/en). LLM classification of fee lines that appear as
+# quote line items is nondeterministic (observed live 2026-07-10) — anything
+# unmatched that looks like a fee is promoted to landed costs deterministically.
+FEE_KEYWORDS = (
+    'transport', 'freight', 'fret', 'surcharge', 'carburant', 'fuel',
+    'livraison', 'shipping', 'handling', 'manutention', 'frais', 'douane',
+    'duty', 'duties',
+)
+
+
+def _looks_like_fee(description):
+    d = (description or '').lower()
+    return any(k in d for k in FEE_KEYWORDS)
 
 
 def _extract_pdf_text(pdf_bytes):
@@ -171,7 +187,14 @@ class PurchaseQuoteAnalysisWizard(models.TransientModel):
     def action_analyse(self):
         self.ensure_one()
         po = self.purchase_order_id
-        po_lines = po.order_line.filtered(lambda l: not l.display_type and l.product_id)
+        # Fee/service lines (transport, surcharges — incl. manually added ones)
+        # don't participate in product matching: they'd only come back as bogus
+        # "missing from quote" discrepancies on re-analysis. Charges are
+        # reconciled through the landed-costs step instead.
+        po_lines = po.order_line.filtered(
+            lambda l: not l.display_type and l.product_id
+            and l.product_id.type != 'service'
+        )
 
         if not po_lines:
             raise UserError(_("The RFQ has no product lines to match against."))
@@ -213,6 +236,29 @@ class PurchaseQuoteAnalysisWizard(models.TransientModel):
 
         po_lines_list = list(po_lines)
         line_items = data.get('line_items', [])
+        landed_costs = list(data.get('landed_costs', []))
+
+        # Deterministic fee promotion: an unmatched line item that reads like a
+        # fee (T3-00 Surcharge de carburant…) is a landed cost, wherever the
+        # model chose to put it. Promote instead of flagging "extra in quote".
+        promoted, kept_items = [], []
+        for item in line_items:
+            if item.get('po_line_index', -1) == -1 and _looks_like_fee(item.get('description')):
+                qty = float(item.get('qty') or 1.0) or 1.0
+                amount = qty * float(item.get('unit_price', 0.0))
+                if not any(
+                    (lc.get('description') or '').strip().lower()
+                    == (item.get('description') or '').strip().lower()
+                    for lc in landed_costs
+                ):
+                    promoted.append({
+                        'description': item.get('description', ''),
+                        'amount': amount,
+                    })
+            else:
+                kept_items.append(item)
+        line_items = kept_items
+        landed_costs.extend(promoted)
 
         price_vals = []
         matched_indices = set()
@@ -230,7 +276,7 @@ class PurchaseQuoteAnalysisWizard(models.TransientModel):
             }))
 
         landed_vals = []
-        for lc in data.get('landed_costs', []):
+        for lc in landed_costs:
             landed_vals.append((0, 0, {
                 'description': lc.get('description', ''),
                 'amount': float(lc.get('amount', 0.0)),
@@ -341,12 +387,12 @@ class PurchaseQuoteAnalysisWizard(models.TransientModel):
             ))
 
         fee_lines_by_lc = {}
+        claimed_line_ids = set()
         for lc in to_apply:
             amount = float_round(lc.amount, precision_digits=precision)
-            po_line = po.order_line.filtered(
-                lambda l: l.product_id == lc.product_id and not l.display_type
-            )[:1]
+            po_line = self._find_fee_line(lc, to_apply, claimed_line_ids)
             if po_line:
+                claimed_line_ids.add(po_line.id)
                 po_line.write({'price_unit': amount, 'product_qty': 1})
             else:
                 taxes = lc.product_id.supplier_taxes_id.filtered(
@@ -362,6 +408,7 @@ class PurchaseQuoteAnalysisWizard(models.TransientModel):
                     'date_planned': fields.Datetime.now(),
                     'tax_ids': [fields.Command.set(taxes.ids)],
                 })
+                claimed_line_ids.add(po_line.id)
             fee_lines_by_lc[lc] = po_line
 
         ignored = self.landed_cost_ids.filtered(lambda l: not l.apply)
@@ -382,6 +429,37 @@ class PurchaseQuoteAnalysisWizard(models.TransientModel):
         self._post_apply_landed_costs(fee_lines_by_lc)
         self._post_total_sanity_check()
         return {'type': 'ir.actions.act_window_close'}
+
+    def _find_fee_line(self, lc, all_applied, claimed_line_ids):
+        """Pick the PO line a landed cost updates — claim-once and
+        description-aware, so two charges mapped to the same fee product can
+        never clobber each other (observed live 2026-07-10: 'Surcharge' and
+        'Transport' both on the Transport product overwrote the 16.25 line)."""
+        po = self.purchase_order_id
+        candidates = po.order_line.filtered(
+            lambda l: l.product_id == lc.product_id and not l.display_type
+            and l.id not in claimed_line_ids
+        )
+        if not candidates:
+            return candidates
+        # Prefer a candidate whose name shares a significant word with the
+        # charge description (matches manually added lines like
+        # 'Transport Supplément carburant' to 'T3-00 Surcharge de carburant').
+        tokens = {t for t in re.findall(r'\w{4,}', (lc.description or '').lower())}
+        if tokens:
+            scored = sorted(
+                candidates,
+                key=lambda l: len(tokens & set(re.findall(r'\w{4,}', (l.name or '').lower()))),
+                reverse=True,
+            )
+            if tokens & set(re.findall(r'\w{4,}', (scored[0].name or '').lower())):
+                return scored[0]
+        # No description signal: only safe to reuse a line when this product is
+        # claimed by a single charge — otherwise create a fresh line.
+        siblings = all_applied.filtered(lambda x: x.product_id == lc.product_id)
+        if len(siblings) == 1:
+            return candidates[0]
+        return candidates.browse()
 
     def _post_apply_landed_costs(self, fee_lines_by_lc):
         """Extension hook, called after landed-cost lines are written to the

--- a/purchase_quote_ai_analysis/wizard/quote_analysis_wizard_views.xml
+++ b/purchase_quote_ai_analysis/wizard/quote_analysis_wizard_views.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_purchase_quote_analysis_wizard_form" model="ir.ui.view">
+        <field name="name">purchase.quote.analysis.wizard.form</field>
+        <field name="model">purchase.quote.analysis.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Analyse Vendor Quote">
+                <field name="state" invisible="1"/>
+                <field name="has_landed_costs" invisible="1"/>
+                <field name="has_discrepancies" invisible="1"/>
+                <sheet>
+
+                    <!-- Step 1: Select attachment or paste the vendor quote -->
+                    <div invisible="state != 'input'">
+                        <group>
+                            <field name="input_mode" widget="radio"/>
+                        </group>
+                        <group invisible="input_mode != 'file'">
+                            <field name="quote_attachment_id"
+                                   string="Quote PDF"
+                                   options="{'no_create': true, 'no_quick_create': true}"/>
+                        </group>
+                        <div invisible="input_mode != 'text'">
+                            <field name="quote_text"
+                                   string="Quote Text"
+                                   placeholder="Paste the vendor quote text here…"
+                                   nolabel="1"/>
+                        </div>
+                    </div>
+
+                    <!-- Step 2: Review extracted prices -->
+                    <div invisible="state != 'review_prices'">
+                        <div class="alert alert-info" role="alert">
+                            Review the prices extracted from the vendor quote.
+                            Uncheck lines you do not want to apply.
+                            Lines without a matched RFQ product are shown for reference only.
+                        </div>
+                        <field name="price_line_ids" nolabel="1">
+                            <list editable="bottom">
+                                <field name="apply" string="Apply"/>
+                                <field name="product_id" string="Product" readonly="1"
+                                       optional="show"/>
+                                <field name="description" string="Quote Description" readonly="1"/>
+                                <field name="quoted_qty" string="Qty" readonly="1"/>
+                                <field name="quoted_unit_price" string="Unit Price"/>
+                            </list>
+                        </field>
+                    </div>
+
+                    <!-- Step 3: Discrepancies + landed costs -->
+                    <div invisible="state != 'review_landed'">
+
+                        <div invisible="not has_discrepancies">
+                            <div class="alert alert-warning" role="alert">
+                                <strong>Discrepancies between the vendor quote and this RFQ:</strong>
+                                review these before proceeding and resolve manually if needed.
+                            </div>
+                            <field name="discrepancy_ids" nolabel="1">
+                                <list>
+                                    <field name="discrepancy_type" string="Issue" readonly="1"/>
+                                    <field name="po_line_id" string="RFQ Line" readonly="1"
+                                           optional="show"/>
+                                    <field name="description" string="Description" readonly="1"/>
+                                    <field name="rfq_qty" string="RFQ Qty" readonly="1"/>
+                                    <field name="quoted_qty" string="Quoted Qty" readonly="1"/>
+                                </list>
+                            </field>
+                        </div>
+
+                        <div invisible="not has_landed_costs" class="mt16">
+                            <div class="alert alert-info" role="alert">
+                                The vendor quote includes additional charges (freight, handling, etc.).
+                                Select a product for each charge to add it as a line on this purchase order.
+                            </div>
+                            <field name="landed_cost_ids" nolabel="1">
+                                <list editable="bottom">
+                                    <field name="apply" string="Apply"/>
+                                    <field name="description" string="Description from Quote" readonly="1"/>
+                                    <field name="amount" string="Amount"/>
+                                    <field name="product_id"
+                                           string="Fee Product"
+                                           options="{'no_quick_create': true}"/>
+                                </list>
+                            </field>
+                        </div>
+
+                    </div>
+
+                </sheet>
+                <footer>
+                    <button string="Analyse"
+                            name="action_analyse"
+                            type="object"
+                            class="btn-primary"
+                            invisible="state != 'input'"/>
+                    <button string="Apply Prices"
+                            name="action_apply_prices"
+                            type="object"
+                            class="btn-primary"
+                            invisible="state != 'review_prices'"/>
+                    <button string="Apply Charges"
+                            name="action_apply_landed_costs"
+                            type="object"
+                            class="btn-primary"
+                            invisible="state != 'review_landed'"/>
+                    <button string="Skip"
+                            name="action_skip_landed_costs"
+                            type="object"
+                            class="btn-secondary"
+                            invisible="state != 'review_landed'"/>
+                    <button string="Cancel" special="cancel" class="btn-secondary"
+                            invisible="state != 'input'"/>
+                    <button string="Close" special="cancel" class="btn-secondary"
+                            invisible="state == 'input'"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/purchase_quote_ai_analysis/wizard/quote_analysis_wizard_views.xml
+++ b/purchase_quote_ai_analysis/wizard/quote_analysis_wizard_views.xml
@@ -77,9 +77,11 @@
                                     <field name="apply" string="Apply"/>
                                     <field name="description" string="Description from Quote" readonly="1"/>
                                     <field name="amount" string="Amount"/>
+                                    <!-- New fee products default to Service so they
+                                         qualify for the at-cost mirroring policy. -->
                                     <field name="product_id"
                                            string="Fee Product"
-                                           options="{'no_quick_create': true}"/>
+                                           context="{'default_type': 'service'}"/>
                                 </list>
                             </field>
                         </div>

--- a/sale_rfq_workflow/__init__.py
+++ b/sale_rfq_workflow/__init__.py
@@ -1,0 +1,16 @@
+from . import models
+from . import wizard
+
+
+def _backfill_sale_line_id(env):
+    """Link pre-existing supply RFQ lines through the core ``sale_line_id``
+    so procurement adoption covers orders generated before this module
+    was installed (the fields previously lived in a client module)."""
+    env.cr.execute(
+        """
+        UPDATE purchase_order_line
+           SET sale_line_id = supply_so_line_id
+         WHERE supply_so_line_id IS NOT NULL
+           AND sale_line_id IS NULL
+        """
+    )

--- a/sale_rfq_workflow/__manifest__.py
+++ b/sale_rfq_workflow/__manifest__.py
@@ -1,0 +1,49 @@
+{
+    'name': 'Sale RFQ Workflow',
+    'version': '19.0.1.0.0',
+    'category': 'Sales/Purchase',
+    'license': 'LGPL-3',
+    'author': 'Bemade Inc.',
+    'website': 'https://www.bemade.org',
+    'depends': ['sale_management', 'purchase_stock', 'sale_purchase_stock'],
+    'description': """
+Sale RFQ Workflow
+=================
+
+Quote-first procurement for resale flows: generate vendor RFQs from a Sales
+Order, get vendor pricing on them, and keep those same RFQs as the purchase
+documents when the Sales Order is confirmed.
+
+- **Generate RFQs from a Sales Order** via a guided wizard that groups SO
+  lines by primary vendor, prompts for vendor assignment on any unassigned
+  products (saving the vendor to the product's supplier info), and previews
+  the grouping before confirming. Generated RFQ lines are linked to their
+  source SO lines (both through ``supply_so_line_id`` and through the core
+  ``sale_line_id``).
+
+- **Procurement adoption on SO confirmation.** Core replenishment normally
+  matches only *draft* purchase orders, so an RFQ that has been sent to the
+  vendor (i.e. exactly the one that has been quoted) gets bypassed and a
+  brand-new RFQ is created from supplier-info pricing — losing the vendor
+  communication thread. This module makes the buy rule adopt the linked
+  supply RFQ instead, in ``draft``, ``sent`` or ``purchase`` state:
+
+  - the human-chosen vendor grouping wins over automatic seller selection,
+  - quantities already covered by the RFQ are not doubled (an SO quantity
+    increase still procures the difference),
+  - a quoted unit price on the RFQ line is never overwritten by the
+    supplier-info price.
+
+Sales Orders without linked supply RFQs use the standard flow, untouched.
+    """,
+    'data': [
+        'security/ir.model.access.csv',
+        'views/sale_order_views.xml',
+        'views/purchase_order_views.xml',
+        'wizard/rfq_generate_wizard_views.xml',
+    ],
+    'post_init_hook': '_backfill_sale_line_id',
+    'installable': True,
+    'auto_install': False,
+    'application': False,
+}

--- a/sale_rfq_workflow/models/__init__.py
+++ b/sale_rfq_workflow/models/__init__.py
@@ -1,0 +1,3 @@
+from . import sale_order
+from . import purchase_order
+from . import stock_rule

--- a/sale_rfq_workflow/models/purchase_order.py
+++ b/sale_rfq_workflow/models/purchase_order.py
@@ -1,6 +1,30 @@
 from odoo import fields, models
 
 
+def _procurement_sale_line_id(values):
+    """Sale-order line a procurement originates from, or False.
+
+    Two shapes exist in the wild:
+    - moveless buy values carry ``sale_line_id`` directly (bare
+      ``mts_else_mto`` chaining, as deployed at fitcrew);
+    - modules that chain the buy through real moves (e.g. Durpro's
+      mrp_mts_else_mto forces ``move_dest_ids`` onto mts_else_mto
+      procurements) drop ``sale_line_id`` from the buy values, but the
+      destination delivery moves still know their sale line.
+    Adoption must work in both (CI co-installs everything; found
+    2026-07-10 when the whole-repo suite failed while the isolated
+    module suite was green).
+    """
+    if values.get('sale_line_id'):
+        return values['sale_line_id']
+    moves = values.get('move_dest_ids')
+    if moves:
+        sale_lines = moves.mapped('sale_line_id')
+        if sale_lines[:1]:
+            return sale_lines[:1].id
+    return False
+
+
 class PurchaseOrder(models.Model):
     _inherit = 'purchase.order'
 
@@ -38,9 +62,10 @@ class PurchaseOrderLine(models.Model):
         # A supply RFQ line generated from this exact SO line is always the
         # merge candidate — the standard filters (propagate_cancel, uom, name
         # variants) must not push the procurement onto a duplicate line.
-        if not values.get('move_dest_ids') and values.get('sale_line_id'):
+        sale_line_id = _procurement_sale_line_id(values)
+        if sale_line_id:
             supply_lines = self.filtered(
-                lambda l: l.supply_so_line_id and l.sale_line_id.id == values['sale_line_id']
+                lambda l: l.supply_so_line_id and l.sale_line_id.id == sale_line_id
             )
             if supply_lines:
                 return supply_lines[0]

--- a/sale_rfq_workflow/models/purchase_order.py
+++ b/sale_rfq_workflow/models/purchase_order.py
@@ -1,0 +1,47 @@
+from odoo import fields, models
+
+
+class PurchaseOrder(models.Model):
+    _inherit = 'purchase.order'
+
+    supply_sale_order_id = fields.Many2one(
+        'sale.order',
+        string='Source Sales Order',
+        ondelete='set null',
+        copy=False,
+        index=True,
+    )
+
+    def action_view_supply_sale_order(self):
+        self.ensure_one()
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': 'sale.order',
+            'view_mode': 'form',
+            'res_id': self.supply_sale_order_id.id,
+            'target': 'current',
+        }
+
+
+class PurchaseOrderLine(models.Model):
+    _inherit = 'purchase.order.line'
+
+    supply_so_line_id = fields.Many2one(
+        'sale.order.line',
+        string='Source SO Line',
+        ondelete='set null',
+        copy=False,
+        index=True,
+    )
+
+    def _find_candidate(self, product_id, product_qty, product_uom, location_id, name, origin, company_id, values):
+        # A supply RFQ line generated from this exact SO line is always the
+        # merge candidate — the standard filters (propagate_cancel, uom, name
+        # variants) must not push the procurement onto a duplicate line.
+        if not values.get('move_dest_ids') and values.get('sale_line_id'):
+            supply_lines = self.filtered(
+                lambda l: l.supply_so_line_id and l.sale_line_id.id == values['sale_line_id']
+            )
+            if supply_lines:
+                return supply_lines[0]
+        return super()._find_candidate(product_id, product_qty, product_uom, location_id, name, origin, company_id, values)

--- a/sale_rfq_workflow/models/sale_order.py
+++ b/sale_rfq_workflow/models/sale_order.py
@@ -1,0 +1,37 @@
+from odoo import api, fields, models
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    supply_rfq_ids = fields.One2many(
+        'purchase.order', 'supply_sale_order_id',
+        string='Supply RFQs',
+        copy=False,
+    )
+    supply_rfq_count = fields.Integer(compute='_compute_supply_rfq_count')
+
+    @api.depends('supply_rfq_ids')
+    def _compute_supply_rfq_count(self):
+        for order in self:
+            order.supply_rfq_count = len(order.supply_rfq_ids)
+
+    def action_generate_supply_rfqs(self):
+        self.ensure_one()
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': 'sale.rfq.generate.wizard',
+            'view_mode': 'form',
+            'target': 'new',
+            'context': {'default_sale_order_id': self.id},
+        }
+
+    def action_view_supply_rfqs(self):
+        self.ensure_one()
+        action = self.env['ir.actions.act_window']._for_xml_id('purchase.purchase_rfq')
+        action['domain'] = [('supply_sale_order_id', '=', self.id)]
+        action['context'] = {}
+        if self.supply_rfq_count == 1:
+            action['view_mode'] = 'form'
+            action['res_id'] = self.supply_rfq_ids.id
+        return action

--- a/sale_rfq_workflow/models/stock_rule.py
+++ b/sale_rfq_workflow/models/stock_rule.py
@@ -1,0 +1,70 @@
+from odoo import models
+
+
+class StockRule(models.Model):
+    _inherit = 'stock.rule'
+
+    def _get_supply_rfq_line(self, values):
+        """Return the supply RFQ line generated from the procurement's source
+        SO line, if one exists on a living order.
+
+        Only moveless, SO-originated procurements are considered — move-chained
+        (MTO/dropship) procurements keep the standard behaviour.
+        """
+        sale_line_id = values.get('sale_line_id')
+        if not sale_line_id or values.get('move_dest_ids'):
+            return self.env['purchase.order.line']
+        return self.env['purchase.order.line'].sudo().search([
+            ('sale_line_id', '=', sale_line_id),
+            ('supply_so_line_id', '!=', False),
+            ('order_id.supply_sale_order_id', '!=', False),
+            ('order_id.state', 'in', ('draft', 'sent', 'purchase')),
+        ], order='id desc', limit=1)
+
+    def _get_matching_supplier(self, product_id, product_qty, product_uom, company_id, values):
+        # The vendor chosen at RFQ generation is authoritative: without this,
+        # _select_seller could route the procurement to another vendor and the
+        # linked RFQ would never be matched.
+        supply_line = self._get_supply_rfq_line(values)
+        if supply_line:
+            vendor = supply_line.order_id.partner_id
+            supplier = product_id.with_company(company_id.id)._select_seller(
+                partner_id=vendor,
+                quantity=product_qty,
+                uom_id=product_uom,
+                params={'force_uom': values.get('force_uom')},
+            )
+            supplier = supplier or product_id._prepare_sellers(False).filtered(
+                lambda s: s.partner_id == vendor
+                and (not s.company_id or s.company_id == company_id)
+            )[:1]
+            if supplier:
+                return supplier
+        return super()._get_matching_supplier(product_id, product_qty, product_uom, company_id, values)
+
+    def _make_po_get_domain(self, company_id, values, partner):
+        # Adopt the linked supply RFQ even after it was sent to the vendor —
+        # the core domain only matches state='draft', which is precisely what
+        # regenerates a fresh RFQ once the linked one has been quoted.
+        supply_line = self._get_supply_rfq_line(values)
+        if supply_line and supply_line.order_id.partner_id == partner:
+            return (('id', '=', supply_line.order_id.id),)
+        return super()._make_po_get_domain(company_id, values, partner)
+
+    def _update_purchase_order_line(self, product_id, product_qty, product_uom, company_id, values, line):
+        res = super()._update_purchase_order_line(product_id, product_qty, product_uom, company_id, values, line)
+        if line.supply_so_line_id and values.get('sale_line_id') == line.supply_so_line_id.id:
+            # The RFQ line already covers this SO line's demand: track the SO
+            # quantity instead of accumulating procurement quantities (initial
+            # confirmation would double it), and keep any larger quantity a
+            # buyer set manually.
+            so_line = line.supply_so_line_id
+            demand_qty = so_line.product_uom_id._compute_quantity(
+                so_line.product_uom_qty, line.product_uom_id, rounding_method='HALF-UP')
+            res['product_qty'] = max(line.product_qty, demand_qty)
+            res.pop('product_uom_id', None)
+            if not line.currency_id.is_zero(line.price_unit):
+                # The quoted price on the RFQ is authoritative over the
+                # supplier-info price the core merge would write.
+                res.pop('price_unit', None)
+        return res

--- a/sale_rfq_workflow/models/stock_rule.py
+++ b/sale_rfq_workflow/models/stock_rule.py
@@ -1,5 +1,7 @@
 from odoo import models
 
+from .purchase_order import _procurement_sale_line_id
+
 
 class StockRule(models.Model):
     _inherit = 'stock.rule'
@@ -8,11 +10,13 @@ class StockRule(models.Model):
         """Return the supply RFQ line generated from the procurement's source
         SO line, if one exists on a living order.
 
-        Only moveless, SO-originated procurements are considered — move-chained
-        (MTO/dropship) procurements keep the standard behaviour.
+        The source SO line comes either from the buy values directly or from
+        the destination moves (move-chained environments — see
+        _procurement_sale_line_id); either way the human-generated supply RFQ
+        is the one purchase document for that demand.
         """
-        sale_line_id = values.get('sale_line_id')
-        if not sale_line_id or values.get('move_dest_ids'):
+        sale_line_id = _procurement_sale_line_id(values)
+        if not sale_line_id:
             return self.env['purchase.order.line']
         return self.env['purchase.order.line'].sudo().search([
             ('sale_line_id', '=', sale_line_id),
@@ -53,7 +57,7 @@ class StockRule(models.Model):
 
     def _update_purchase_order_line(self, product_id, product_qty, product_uom, company_id, values, line):
         res = super()._update_purchase_order_line(product_id, product_qty, product_uom, company_id, values, line)
-        if line.supply_so_line_id and values.get('sale_line_id') == line.supply_so_line_id.id:
+        if line.supply_so_line_id and _procurement_sale_line_id(values) == line.supply_so_line_id.id:
             # The RFQ line already covers this SO line's demand: track the SO
             # quantity instead of accumulating procurement quantities (initial
             # confirmation would double it), and keep any larger quantity a

--- a/sale_rfq_workflow/security/ir.model.access.csv
+++ b/sale_rfq_workflow/security/ir.model.access.csv
@@ -1,0 +1,4 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_sale_rfq_generate_wizard,sale.rfq.generate.wizard,model_sale_rfq_generate_wizard,base.group_user,1,1,1,1
+access_sale_rfq_generate_vendor_line,sale.rfq.generate.vendor.line,model_sale_rfq_generate_vendor_line,base.group_user,1,1,1,1
+access_sale_rfq_generate_group_line,sale.rfq.generate.group.line,model_sale_rfq_generate_group_line,base.group_user,1,1,1,1

--- a/sale_rfq_workflow/tests/__init__.py
+++ b/sale_rfq_workflow/tests/__init__.py
@@ -1,0 +1,2 @@
+from . import test_rfq_generate_wizard
+from . import test_procurement_adoption

--- a/sale_rfq_workflow/tests/test_procurement_adoption.py
+++ b/sale_rfq_workflow/tests/test_procurement_adoption.py
@@ -1,0 +1,192 @@
+from odoo import Command
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("-at_install", "post_install")
+class TestProcurementAdoption(TransactionCase):
+    """SO confirmation must adopt the wizard-generated supply RFQs instead of
+    regenerating fresh RFQs from supplier-info pricing.
+
+    Baseline behaviour being fixed: core ``_make_po_get_domain`` only matches
+    draft POs, so a supply RFQ in state 'sent' (i.e. one that has been quoted
+    by the vendor) was bypassed and a duplicate PO was created at confirm,
+    without the vendor pricing or communication thread.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        env = cls.env
+        cls.buy_route = env.ref('purchase_stock.route_warehouse0_buy')
+        # Deliver-in-1-step as deployed at the client: short stock flips the
+        # delivery leg to MTO, chaining the SO procurement into the buy rule —
+        # the exact path that regenerated RFQs.
+        wh = env['stock.warehouse'].search([('company_id', '=', env.company.id)], limit=1)
+        wh.delivery_route_id.rule_ids.filtered(
+            lambda r: r.action == 'pull').procure_method = 'mts_else_mto'
+
+        cls.customer = env['res.partner'].create({
+            'name': 'Adoption Customer', 'is_company': True,
+        })
+        cls.vendor_a = env['res.partner'].create({
+            'name': 'Adoption Vendor A', 'is_company': True,
+        })
+        cls.vendor_b = env['res.partner'].create({
+            'name': 'Adoption Vendor B', 'is_company': True,
+        })
+
+        cls.product_a = cls._make_product('Adopt Product A', cls.vendor_a, seller_price=10.0)
+        cls.product_b = cls._make_product('Adopt Product B', cls.vendor_b, seller_price=20.0)
+
+    @classmethod
+    def _make_product(cls, name, vendor, seller_price):
+        return cls.env['product.product'].create({
+            'name': name,
+            'type': 'consu',
+            'is_storable': True,
+            'route_ids': [Command.link(cls.buy_route.id)],
+            'seller_ids': [Command.create({
+                'partner_id': vendor.id,
+                'price': seller_price,
+                'min_qty': 0,
+                'delay': 0,
+            })],
+        })
+
+    def _make_so(self, lines):
+        return self.env['sale.order'].create({
+            'partner_id': self.customer.id,
+            'order_line': [
+                Command.create({'product_id': product.id, 'product_uom_qty': qty})
+                for product, qty in lines
+            ],
+        })
+
+    def _generate_rfqs(self, so):
+        action = so.action_generate_supply_rfqs()
+        wizard = self.env[action['res_model']].with_context(action['context']).create({})
+        wizard.action_confirm()
+        return so.supply_rfq_ids
+
+    def _pos_for(self, so):
+        return self.env['purchase.order'].search([
+            ('origin', 'like', so.name), ('state', '!=', 'cancel'),
+        ])
+
+    def test_baseline_without_supply_rfq_creates_po(self):
+        """Guard: SOs without supply RFQs keep the standard flow — confirming
+        creates a fresh RFQ from supplier info."""
+        so = self._make_so([(self.product_a, 3)])
+        so.action_confirm()
+        pos = self._pos_for(so)
+        self.assertEqual(len(pos), 1)
+        self.assertFalse(pos.supply_sale_order_id)
+        self.assertEqual(pos.partner_id, self.vendor_a)
+
+    def test_sent_rfq_adopted_on_confirm(self):
+        """A quoted ('sent') supply RFQ is adopted: no duplicate PO, quantity
+        not doubled, quoted price preserved."""
+        so = self._make_so([(self.product_a, 3)])
+        rfq = self._generate_rfqs(so)
+        self.assertEqual(len(rfq), 1)
+        line = rfq.order_line
+        self.assertEqual(line.sale_line_id, so.order_line)
+
+        # Vendor quoted: price applied, RFQ marked sent.
+        line.price_unit = 9.5
+        rfq.write({'state': 'sent'})
+
+        so.action_confirm()
+
+        pos = self._pos_for(so)
+        self.assertEqual(pos, rfq, "confirm must not create a duplicate PO")
+        self.assertEqual(line.product_qty, 3, "quantity must not be doubled")
+        self.assertEqual(line.price_unit, 9.5, "quoted price must survive adoption")
+
+    def test_draft_rfq_adopted_on_confirm(self):
+        so = self._make_so([(self.product_a, 2)])
+        rfq = self._generate_rfqs(so)
+        so.action_confirm()
+        self.assertEqual(self._pos_for(so), rfq)
+        self.assertEqual(rfq.order_line.product_qty, 2)
+
+    def test_confirmed_rfq_not_duplicated(self):
+        """A supply RFQ already confirmed to the vendor must not spawn an
+        orphan duplicate at SO confirmation."""
+        so = self._make_so([(self.product_a, 4)])
+        rfq = self._generate_rfqs(so)
+        rfq.order_line.price_unit = 9.0
+        rfq.button_confirm()
+        self.assertEqual(rfq.state, 'purchase')
+
+        so.action_confirm()
+
+        pos = self._pos_for(so)
+        self.assertEqual(pos, rfq)
+        self.assertEqual(rfq.order_line.product_qty, 4)
+        self.assertEqual(rfq.order_line.price_unit, 9.0)
+
+    def test_vendor_grouping_preserved(self):
+        """Two vendors → each SO line adopts its own RFQ; the human grouping
+        wins over automatic seller selection."""
+        so = self._make_so([(self.product_a, 1), (self.product_b, 2)])
+        rfqs = self._generate_rfqs(so)
+        self.assertEqual(len(rfqs), 2)
+        rfqs.write({'state': 'sent'})
+
+        so.action_confirm()
+
+        pos = self._pos_for(so)
+        self.assertEqual(set(pos.ids), set(rfqs.ids))
+        by_vendor = {po.partner_id: po for po in pos}
+        self.assertEqual(by_vendor[self.vendor_a].order_line.product_id, self.product_a)
+        self.assertEqual(by_vendor[self.vendor_b].order_line.product_id, self.product_b)
+
+    def test_qty_increase_procures_delta(self):
+        """Increasing the SO quantity after confirmation raises the adopted
+        RFQ line to the new demand (not demand + old quantity)."""
+        so = self._make_so([(self.product_a, 3)])
+        rfq = self._generate_rfqs(so)
+        rfq.order_line.price_unit = 9.5
+        rfq.write({'state': 'sent'})
+        so.action_confirm()
+        self.assertEqual(rfq.order_line.product_qty, 3)
+
+        so.order_line.product_uom_qty = 5
+
+        self.assertEqual(self._pos_for(so), rfq)
+        self.assertEqual(rfq.order_line.product_qty, 5,
+                         "line must track the SO demand after a qty increase")
+        self.assertEqual(rfq.order_line.price_unit, 9.5)
+
+    def test_unquoted_zero_price_line_gets_seller_price(self):
+        """An RFQ line still at 0.0 (never quoted) takes the supplier-info
+        price on adoption rather than keeping a meaningless zero."""
+        so = self._make_so([(self.product_a, 2)])
+        rfq = self._generate_rfqs(so)
+        self.assertEqual(rfq.order_line.price_unit, 0.0)
+
+        so.action_confirm()
+
+        self.assertEqual(self._pos_for(so), rfq)
+        self.assertEqual(rfq.order_line.price_unit, 10.0)
+
+    def test_new_so_line_after_generation(self):
+        """A product added to the SO after RFQ generation has no supply line —
+        it must still be procured (standard flow), without disturbing the
+        adopted RFQ."""
+        so = self._make_so([(self.product_a, 1)])
+        rfq = self._generate_rfqs(so)
+        rfq.order_line.price_unit = 9.5
+        rfq.write({'state': 'sent'})
+
+        so.write({'order_line': [Command.create({
+            'product_id': self.product_b.id, 'product_uom_qty': 1,
+        })]})
+        so.action_confirm()
+
+        pos = self._pos_for(so)
+        self.assertIn(rfq, pos)
+        self.assertEqual(rfq.order_line.product_qty, 1)
+        other = pos - rfq
+        self.assertEqual(other.partner_id, self.vendor_b)

--- a/sale_rfq_workflow/tests/test_rfq_generate_wizard.py
+++ b/sale_rfq_workflow/tests/test_rfq_generate_wizard.py
@@ -1,0 +1,141 @@
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("-at_install", "post_install")
+class TestRfqGenerateWizard(TransactionCase):
+    """Coverage for the Generate Supply RFQs wizard.
+
+    Particularly the path where a SO line product has no primary vendor and
+    the user picks one in the wizard's first step. action_next has to
+    create a product.supplierinfo for the (vendor, product) pair — and on
+    Odoo 19, supplierinfo.product_uom_id is a required field, so the
+    create call must populate it.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        env = cls.env
+
+        cls.customer = env["res.partner"].create({
+            "name": "Generate-RFQs Customer",
+            "is_company": True,
+        })
+        cls.vendor = env["res.partner"].create({
+            "name": "Generate-RFQs Vendor",
+            "is_company": True,
+        })
+
+        cls.uom_unit = env.ref("uom.product_uom_unit")
+        cls.uom_dozen = env.ref("uom.product_uom_dozen")
+
+        # A consumable product with no seller_ids configured at all.
+        cls.product_no_vendor = env["product.product"].create({
+            "name": "Widget without vendor",
+            "type": "consu",
+            "uom_id": cls.uom_unit.id,
+            "list_price": 10.0,
+        })
+        # A second product on a non-default UoM, also with no vendor — used
+        # to confirm the wizard does not assume Units.
+        cls.product_no_vendor_dozen = env["product.product"].create({
+            "name": "Bundle without vendor",
+            "type": "consu",
+            "uom_id": cls.uom_dozen.id,
+            "list_price": 12.0,
+        })
+
+        cls.so = env["sale.order"].create({
+            "partner_id": cls.customer.id,
+            "order_line": [
+                (0, 0, {
+                    "product_id": cls.product_no_vendor.id,
+                    "product_uom_qty": 5,
+                }),
+                (0, 0, {
+                    "product_id": cls.product_no_vendor_dozen.id,
+                    "product_uom_qty": 2,
+                }),
+            ],
+        })
+
+    def _open_wizard(self):
+        action = self.so.action_generate_supply_rfqs()
+        Wizard = self.env[action["res_model"]].with_context(action["context"])
+        return Wizard.create({})
+
+    def test_action_next_creates_supplierinfo_with_uom(self):
+        """Picking a vendor in step 1 and pressing Next should persist the
+        choice as a product.supplierinfo with product_uom_id set."""
+        wizard = self._open_wizard()
+
+        # Both products lack a vendor — the wizard should surface them.
+        prompted_tmpls = wizard.vendor_line_ids.mapped("product_tmpl_id")
+        self.assertIn(self.product_no_vendor.product_tmpl_id, prompted_tmpls)
+        self.assertIn(self.product_no_vendor_dozen.product_tmpl_id, prompted_tmpls)
+
+        # Pick the same vendor on every line and advance.
+        wizard.vendor_line_ids.write({"vendor_id": self.vendor.id})
+        wizard.action_next()
+
+        # One supplierinfo per (product_tmpl, vendor); product_uom_id must
+        # come from the product (Units for one, Dozen for the other) — the
+        # 19.0 NOT NULL constraint on supplierinfo.product_uom_id makes
+        # this a regression-blocking assertion.
+        supplierinfo = self.env["product.supplierinfo"].search([
+            ("partner_id", "=", self.vendor.id),
+            ("product_tmpl_id", "in", prompted_tmpls.ids),
+        ])
+        self.assertEqual(len(supplierinfo), 2)
+        by_tmpl = {s.product_tmpl_id: s for s in supplierinfo}
+        self.assertEqual(
+            by_tmpl[self.product_no_vendor.product_tmpl_id].product_uom_id,
+            self.uom_unit,
+        )
+        self.assertEqual(
+            by_tmpl[self.product_no_vendor_dozen.product_tmpl_id].product_uom_id,
+            self.uom_dozen,
+        )
+
+        # Wizard should have advanced into the review state.
+        self.assertEqual(wizard.state, "review")
+        self.assertTrue(wizard.group_line_ids)
+
+        # action_confirm creates the actual RFQ; this is where the
+        # purchase.order.line tax_ids rename (19.0: taxes_id -> tax_ids)
+        # would otherwise blow up.
+        wizard.action_confirm()
+        rfqs = self.so.supply_rfq_ids
+        self.assertEqual(len(rfqs), 1)
+        rfq = rfqs[0]
+        self.assertEqual(rfq.partner_id, self.vendor)
+        self.assertEqual(
+            set(rfq.order_line.mapped("product_id.product_tmpl_id.id")),
+            set(prompted_tmpls.ids),
+        )
+
+    def test_action_next_skips_orphan_vendor_line(self):
+        """Defensive: if a vendor_line ends up with no product_tmpl_id (the
+        web client is known to drop readonly fields under some conditions
+        despite force_save), the wizard must skip it instead of trying to
+        create an orphan supplierinfo."""
+        wizard = self._open_wizard()
+        # Vendor every real line so action_next clears its missing-vendor guard.
+        wizard.vendor_line_ids.write({"vendor_id": self.vendor.id})
+        real_tmpl_ids = wizard.vendor_line_ids.mapped("product_tmpl_id").ids
+
+        # Inject an orphan vendor_line — vendor selected, but
+        # product_tmpl_id never made it back to the server.
+        self.env["sale.rfq.generate.vendor.line"].create({
+            "wizard_id": wizard.id,
+            "vendor_id": self.vendor.id,
+        })
+
+        wizard.action_next()  # should not raise on the orphan
+
+        # One supplierinfo per real line — none for the orphan.
+        sis = self.env["product.supplierinfo"].search([
+            ("partner_id", "=", self.vendor.id),
+        ])
+        self.assertEqual(set(sis.mapped("product_tmpl_id").ids), set(real_tmpl_ids))
+        self.assertTrue(all(s.product_uom_id for s in sis))

--- a/sale_rfq_workflow/views/purchase_order_views.xml
+++ b/sale_rfq_workflow/views/purchase_order_views.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_purchase_order_form_rfq_workflow" model="ir.ui.view">
+        <field name="name">sale.rfq.workflow.purchase.order.form</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.purchase_order_form"/>
+        <field name="arch" type="xml">
+
+            <!-- Smart button linking back to source SO -->
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button type="object"
+                        name="action_view_supply_sale_order"
+                        class="oe_stat_button"
+                        icon="fa-usd"
+                        invisible="not supply_sale_order_id">
+                    <div class="o_stat_info">
+                        <span class="o_stat_text">Source SO</span>
+                        <span class="o_stat_value">
+                            <field name="supply_sale_order_id" readonly="1"/>
+                        </span>
+                    </div>
+                </button>
+            </xpath>
+
+        </field>
+    </record>
+</odoo>

--- a/sale_rfq_workflow/views/sale_order_views.xml
+++ b/sale_rfq_workflow/views/sale_order_views.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_sale_order_form_rfq_workflow" model="ir.ui.view">
+        <field name="name">sale.rfq.workflow.sale.order.form</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+
+            <!-- Stat button -->
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button type="object"
+                        name="action_view_supply_rfqs"
+                        class="oe_stat_button"
+                        icon="fa-shopping-cart"
+                        invisible="supply_rfq_count == 0">
+                    <field string="Supply RFQs" name="supply_rfq_count" widget="statinfo"/>
+                </button>
+            </xpath>
+
+            <!-- Action button in header -->
+            <xpath expr="//header/button[last()]" position="after">
+                <button name="action_generate_supply_rfqs"
+                        type="object"
+                        string="Generate RFQs"
+                        class="btn-secondary"
+                        invisible="state not in ('draft', 'sent')"/>
+            </xpath>
+
+        </field>
+    </record>
+</odoo>

--- a/sale_rfq_workflow/wizard/__init__.py
+++ b/sale_rfq_workflow/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import rfq_generate_wizard

--- a/sale_rfq_workflow/wizard/rfq_generate_wizard.py
+++ b/sale_rfq_workflow/wizard/rfq_generate_wizard.py
@@ -1,0 +1,220 @@
+from collections import defaultdict
+
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError
+
+
+class SaleRfqGenerateWizard(models.TransientModel):
+    _name = 'sale.rfq.generate.wizard'
+    _description = 'Generate Supply RFQs from Sales Order'
+
+    sale_order_id = fields.Many2one('sale.order', required=True, readonly=True)
+    state = fields.Selection([
+        ('assign_vendors', 'Assign Vendors'),
+        ('review', 'Review'),
+    ], default='assign_vendors', required=True)
+
+    vendor_line_ids = fields.One2many(
+        'sale.rfq.generate.vendor.line', 'wizard_id',
+        string='Products Needing a Vendor',
+    )
+    group_line_ids = fields.One2many(
+        'sale.rfq.generate.group.line', 'wizard_id',
+        string='RFQ Groups',
+    )
+
+    @api.model
+    def default_get(self, fields_list):
+        res = super().default_get(fields_list)
+        so_id = self.env.context.get('default_sale_order_id')
+        if not so_id:
+            return res
+
+        so = self.env['sale.order'].browse(so_id)
+        seen_tmpls = set()
+        missing_vals = []
+
+        for line in so.order_line.filtered(lambda l: not l.display_type and l.product_id):
+            tmpl = line.product_id.product_tmpl_id
+            if tmpl.id in seen_tmpls:
+                continue
+            seen_tmpls.add(tmpl.id)
+            if not tmpl.seller_ids:
+                missing_vals.append((0, 0, {
+                    'product_tmpl_id': tmpl.id,
+                    'product_id': line.product_id.id,
+                }))
+
+        res['vendor_line_ids'] = missing_vals
+
+        if not missing_vals:
+            res['state'] = 'review'
+            res['group_line_ids'] = self._build_group_vals(so, {})
+
+        return res
+
+    @api.model
+    def _build_group_vals(self, so, override_vendor_map):
+        """Return (0,0,{...}) tuples for group_line_ids given a vendor override map
+        keyed by product.template id."""
+        groups = defaultdict(list)
+        for line in so.order_line.filtered(lambda l: not l.display_type and l.product_id):
+            tmpl = line.product_id.product_tmpl_id
+            vendor = override_vendor_map.get(tmpl.id)
+            if not vendor:
+                seller = tmpl.seller_ids.sorted('sequence')[:1]
+                vendor = seller.partner_id if seller else None
+            if vendor:
+                groups[vendor].append(line.product_id.display_name)
+        return [
+            (0, 0, {'vendor_id': vendor.id, 'product_summary': ', '.join(products)})
+            for vendor, products in groups.items()
+        ]
+
+    def action_next(self):
+        """Validate vendor assignments, create supplier info, advance to review."""
+        self.ensure_one()
+        unassigned = self.vendor_line_ids.filtered(lambda l: not l.vendor_id)
+        if unassigned:
+            raise UserError(_(
+                "Please assign a vendor for all products: %s",
+                ', '.join(unassigned.mapped('product_tmpl_id.name')),
+            ))
+
+        SupplierInfo = self.env['product.supplierinfo']
+        override_map = {}
+        for vline in self.vendor_line_ids:
+            tmpl = vline.product_tmpl_id
+            if not tmpl:
+                # Defensive: an empty product on a vendor_line means the
+                # web client dropped the readonly value on save (mitigated
+                # by force_save="1" in the view) — skip rather than create
+                # an orphan supplierinfo record.
+                continue
+            override_map[tmpl.id] = vline.vendor_id
+            if not tmpl.seller_ids.filtered(lambda s: s.partner_id == vline.vendor_id):
+                SupplierInfo.create({
+                    'partner_id': vline.vendor_id.id,
+                    'product_tmpl_id': tmpl.id,
+                    # 19.0: product.supplierinfo.product_uom_id is now required.
+                    'product_uom_id': tmpl.uom_id.id,
+                    'price': 0.0,
+                    'min_qty': 0.0,
+                })
+
+        self.group_line_ids.unlink()
+        self.write({
+            'group_line_ids': self._build_group_vals(self.sale_order_id, override_map),
+            'state': 'review',
+        })
+        return self._reopen()
+
+    def _prepare_po_line_vals(self, so_line):
+        taxes = so_line.product_id.supplier_taxes_id.filtered(
+            lambda t: t.company_id == so_line.order_id.company_id
+        )
+        return {
+            'product_id': so_line.product_id.id,
+            'name': so_line.name,
+            'product_qty': so_line.product_uom_qty,
+            'product_uom_id': so_line.product_uom_id.id,
+            'price_unit': 0.0,
+            'date_planned': fields.Datetime.now(),
+            'tax_ids': [fields.Command.set(taxes.ids)],
+            'supply_so_line_id': so_line.id,
+            # The core SO-line link is what lets procurement adopt this line
+            # (and this RFQ) when the sales order is confirmed.
+            'sale_line_id': so_line.id,
+        }
+
+    def action_confirm(self):
+        """Create one PO per vendor and link them back to the SO."""
+        self.ensure_one()
+        so = self.sale_order_id
+
+        # Build vendor map: product.template.id → res.partner
+        vendor_map = {}
+        for vline in self.vendor_line_ids:
+            vendor_map[vline.product_tmpl_id.id] = vline.vendor_id
+        for line in so.order_line.filtered(lambda l: not l.display_type and l.product_id):
+            tmpl = line.product_id.product_tmpl_id
+            if tmpl.id not in vendor_map:
+                seller = tmpl.seller_ids.sorted('sequence')[:1]
+                if seller:
+                    vendor_map[tmpl.id] = seller.partner_id
+
+        # Group SO lines by vendor
+        groups = defaultdict(list)
+        no_vendor = []
+        for line in so.order_line.filtered(lambda l: not l.display_type and l.product_id):
+            vendor = vendor_map.get(line.product_id.product_tmpl_id.id)
+            if vendor:
+                groups[vendor].append(line)
+            else:
+                no_vendor.append(line.product_id.display_name)
+
+        if no_vendor:
+            raise UserError(_(
+                "No vendor could be determined for: %s",
+                ', '.join(no_vendor),
+            ))
+
+        PurchaseOrder = self.env['purchase.order']
+        created_pos = PurchaseOrder
+        for vendor, lines in groups.items():
+            po = PurchaseOrder.create({
+                'partner_id': vendor.id,
+                'origin': so.name,
+                'supply_sale_order_id': so.id,
+                'order_line': [(0, 0, self._prepare_po_line_vals(sol)) for sol in lines],
+            })
+            created_pos |= po
+            po.message_post(body=_(
+                'RFQ generated from Sales Order %(name)s.',
+                name=so.name,
+            ))
+
+        so.message_post(body=_(
+            '%(count)s RFQ(s) generated: %(names)s.',
+            count=len(created_pos),
+            names=', '.join(created_pos.mapped('name')),
+        ))
+
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': 'purchase.order',
+            'view_mode': 'list,form',
+            'domain': [('id', 'in', created_pos.ids)],
+            'target': 'current',
+        }
+
+    def _reopen(self):
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': self._name,
+            'res_id': self.id,
+            'view_mode': 'form',
+            'target': 'new',
+        }
+
+
+class SaleRfqGenerateVendorLine(models.TransientModel):
+    _name = 'sale.rfq.generate.vendor.line'
+    _description = 'Product Needing Vendor Assignment'
+
+    wizard_id = fields.Many2one('sale.rfq.generate.wizard', required=True)
+    product_tmpl_id = fields.Many2one('product.template', string='Product', readonly=True)
+    product_id = fields.Many2one('product.product', string='Variant', readonly=True)
+    vendor_id = fields.Many2one(
+        'res.partner', string='Vendor',
+        domain=[('is_company', '=', True)],
+    )
+
+
+class SaleRfqGenerateGroupLine(models.TransientModel):
+    _name = 'sale.rfq.generate.group.line'
+    _description = 'RFQ Group Preview'
+
+    wizard_id = fields.Many2one('sale.rfq.generate.wizard', required=True)
+    vendor_id = fields.Many2one('res.partner', string='Vendor', readonly=True)
+    product_summary = fields.Char(string='Products', readonly=True)

--- a/sale_rfq_workflow/wizard/rfq_generate_wizard_views.xml
+++ b/sale_rfq_workflow/wizard/rfq_generate_wizard_views.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_sale_rfq_generate_wizard_form" model="ir.ui.view">
+        <field name="name">sale.rfq.generate.wizard.form</field>
+        <field name="model">sale.rfq.generate.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Generate Supply RFQs">
+                <field name="state" invisible="1"/>
+                <sheet>
+
+                    <!-- Step 1: Assign vendors to products that have none -->
+                    <div invisible="state != 'assign_vendors'">
+                        <div class="alert alert-warning" role="alert">
+                            The products below have no primary vendor configured.
+                            Assign a vendor for each — the entry will be saved to the product.
+                        </div>
+                        <field name="vendor_line_ids" nolabel="1">
+                            <list editable="bottom" create="0">
+                                <field name="product_tmpl_id" readonly="1" force_save="1" string="Product"/>
+                                <field name="vendor_id" string="Vendor"
+                                       options="{'no_quick_create': true}"/>
+                            </list>
+                        </field>
+                    </div>
+
+                    <!-- Step 2: Review grouping before generating -->
+                    <div invisible="state != 'review'">
+                        <div class="alert alert-info" role="alert">
+                            One RFQ will be created per vendor below. Review and confirm.
+                        </div>
+                        <field name="group_line_ids" nolabel="1">
+                            <list>
+                                <field name="vendor_id" string="Vendor" readonly="1"/>
+                                <field name="product_summary" string="Products" readonly="1"/>
+                            </list>
+                        </field>
+                    </div>
+
+                </sheet>
+                <footer>
+                    <button string="Next →"
+                            name="action_next"
+                            type="object"
+                            class="btn-primary"
+                            invisible="state != 'assign_vendors'"/>
+                    <button string="Generate RFQs"
+                            name="action_confirm"
+                            type="object"
+                            class="btn-primary"
+                            invisible="state != 'review'"/>
+                    <button string="Cancel" special="cancel" class="btn-secondary"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Two new generic modules extracted and hardened from the fitcrew client module (merged effort, task fitcrew-dev#1250).

## sale_rfq_workflow
Generate-RFQs-from-SO wizard (vendor grouping + preview; lines carry core sale_line_id) and **procurement adoption**: SO confirmation adopts the linked supply RFQ in draft/sent/purchase state instead of regenerating a fresh one from supplierinfo — quantities never double, quoted prices survive, human vendor grouping wins, delta procurement still works. Root cause: core _make_po_get_domain matches draft-only, bypassing exactly the RFQs that have been quoted (mts_else_mto ship rule chains SO demand into the buy rule). post_init backfill links pre-existing orders.

## purchase_quote_ai_analysis
AI vendor-quote analysis (DeepSeek): net-price extraction, rounded price apply to RFQ lines + supplierinfo, discrepancy review, landed-cost fee lines ON the purchase order (idempotent re-analysis; claim-once description-aware matching so charges sharing a product never clobber each other; deterministic keyword promotion of fee line items), quote-total sanity note, _post_apply_landed_costs extension hook.

## Verification
32 tests green incl. an end-to-end reproduction of the live QT-409536 quote flow; monolith→split upgrade proven twice on prod-copy DBs (zero data loss, 41 line links backfilled); owner-run local human-test gate passed (2 fix rounds folded in).

The fitcrew_supply_workflow 19.0.2.0.0 slimming + re-homing migration lands via the parent-repo MR alongside the submodule repoint. D29: staging live-verify of the full purchase cycle gates prod go-live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmfKwsrmtrdRc89K6pguiz