### PR TITLE
[bemade_sports_clinic] #518 (fitcrew): per-row document download link in both document lists

### DIFF
--- a/bemade_sports_clinic/__manifest__.py
+++ b/bemade_sports_clinic/__manifest__.py
@@ -18,7 +18,7 @@
 #
 {
     'name': 'Sports Clinic Management',
-    'version': "19.0.1.5.3",
+    'version': "19.0.1.5.4",
     'summary': 'Comprehensive sports medicine clinic management with portal access and activity tracking.',
     'description': """
 Sports Clinic Management System

--- a/bemade_sports_clinic/views/sports_patient_injury_views.xml
+++ b/bemade_sports_clinic/views/sports_patient_injury_views.xml
@@ -8,6 +8,7 @@
         <field name="arch" type="xml">
             <list string="Injury Documents" create="true" delete="true">
                 <field name="name"/>
+                <field name="file_content" widget="binary" filename="file_name"/>
                 <field name="patient_id"/>
                 <field name="injury_id"/>
                 <field name="category"/>

--- a/bemade_sports_clinic/views/sports_patient_views.xml
+++ b/bemade_sports_clinic/views/sports_patient_views.xml
@@ -199,6 +199,7 @@
                                      <field name="document_ids">
                                          <list string="Documents" editable="bottom">
                                              <field name="name"/>
+                                             <field name="file_content" widget="binary" filename="file_name"/>
                                              <field name="injury_id" domain="[('patient_id', '=', parent.id)]"/>
                                              <field name="category"/>
                                              <field name="description"/>


### PR DESCRIPTION
Fitcrew dev task #518 — "documents on sports.patient are trop creux (hard to access)".

**Problem:** from the `sports.injury.document` list rows there was no way to reach the actual file — `file_content` (Binary) was only downloadable from the record's form.

**Change (view-only, +3/-1):**
- `views/sports_patient_views.xml` — patient Documents-tab o2m list: expose `file_content` as a `widget="binary" filename="file_name"` download column.
- `views/sports_patient_injury_views.xml` — `view_injury_document_tree` (the default list for BOTH the patient `action_view_documents` and injury `action_sports_injury_documents` smart buttons): same field — one edit fixes both lists.
- `__manifest__.py` — 19.0.1.5.3 → 19.0.1.5.4.

**Validation:** both XMLs well-formed; `file_content`/`file_name` confirmed on the model; binary widget standard in lists; **view-load smoke passed** (`-u bemade_sports_clinic` on a 19.0 fitcrew DB, clean). Definitive test = staging UAT.