### PR TITLE
test(crm_account_management): mute odoo.sql_db in nameless-company test

### DIFF
--- a/crm_account_management/__manifest__.py
+++ b/crm_account_management/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "CRM Account Management",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.0.1",
     "category": "Sales/CRM",
     "summary": "Customer Account Management with Dashboard and Reporting",
     "description": """

--- a/crm_account_management/tests/test_us05_auto_create.py
+++ b/crm_account_management/tests/test_us05_auto_create.py
@@ -1,4 +1,5 @@
 from odoo.tests import tagged
+from odoo.tools import mute_logger
 from odoo.exceptions import ValidationError
 from datetime import date
 from dateutil.relativedelta import relativedelta
@@ -236,8 +237,15 @@ class TestUS05AutoCreateOU(AccountTestInvoicingCommon):
         self.assertEqual(len(ou2), 1, "Second company should have an OU")
         self.assertNotEqual(ou1.id, ou2.id, "Should be different OUs despite same name")
 
+    @mute_logger("odoo.sql_db")
     def test_company_without_name_still_creates_ou(self):
-        """Company without name should still create OU (though invalid)."""
+        """Company without name should still create OU (though invalid).
+
+        Creating a nameless company trips res_partner_check_name; odoo.sql_db
+        logs the failed INSERT at ERROR before the except swallows it. Mute it so
+        the deliberate failure doesn't fail an Odoo.sh build ("errors detected in
+        the logs") even though the test passes.
+        """
         # This tests the auto-creation logic, even though name validation might fail
         try:
             company = self.partner_model.create(


### PR DESCRIPTION
`test_company_without_name_still_creates_ou` deliberately creates a company with no name to prove OU auto-creation is resilient; that trips `res_partner_check_name` and `odoo.sql_db` logs the failed INSERT at ERROR (the except swallows it). The ERROR line fails Odoo.sh builds ("errors detected in the logs") even though the test passes, so mute `odoo.sql_db` for this test. Manifest patch-bumped.