### PR TITLE
[sports_clinic] Add Merge Players wizard; block patient-destroying contact merges

### DIFF
--- a/bemade_sports_clinic/__manifest__.py
+++ b/bemade_sports_clinic/__manifest__.py
@@ -18,7 +18,7 @@
 #
 {
     'name': 'Sports Clinic Management',
-    'version': "19.0.1.5.4",
+    'version': "19.0.1.6.0",
     'summary': 'Comprehensive sports medicine clinic management with portal access and activity tracking.',
     'description': """
 Sports Clinic Management System
@@ -104,6 +104,7 @@ This module provides a complete sports medicine clinic management solution with 
         "views/treatment_note_views.xml",
         "views/res_partner_views.xml",
         "views/team_role_mass_assign_wizard_views.xml",
+        "views/patient_merge_wizard_views.xml",
         "views/res_users_views.xml",
     ],
     "demo": [

--- a/bemade_sports_clinic/models/__init__.py
+++ b/bemade_sports_clinic/models/__init__.py
@@ -21,3 +21,4 @@ from . import event_recurrence_wizard
 from . import event_batch_invoicing_wizard
 from . import sale_order_line
 from . import event_cancel_wizard
+from . import patient_merge_wizard

--- a/bemade_sports_clinic/models/base_partner_merge.py
+++ b/bemade_sports_clinic/models/base_partner_merge.py
@@ -1,4 +1,5 @@
-from odoo import api, fields, models
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError
 from collections import defaultdict
 import datetime
 import itertools
@@ -10,6 +11,46 @@ class MergePartnerAutomatic(models.TransientModel):
     def _get_ordered_partner(self, partner_ids):
         # Delegate to super to avoid drift
         return super()._get_ordered_partner(partner_ids)
+
+    def _merge(self, partner_ids, dst_partner=None, extra_checks=True):
+        """Refuse merges that would silently destroy patient records.
+
+        sports.patient declares UNIQUE(partner_id). When several of the merged
+        contacts each carry a patient, core's _update_foreign_keys_generic tries
+        to repoint them all at the destination, hits that constraint, and
+        recovers by issuing a raw ``DELETE FROM sports_patient`` (see
+        odoo/addons/base/wizard/base_partner_merge.py). That bypasses the ORM
+        and ondelete="restrict", and the database then CASCADEs away the
+        patients' injuries, treatment notes, documents and team links. The merge
+        reports success while the clinical history is gone -- this destroyed two
+        players' records in production on 2026-07-15.
+
+        Patients are counted with active_test=False: an archived patient still
+        occupies UNIQUE(partner_id) and is just as deletable by that DELETE.
+
+        Note the Merge Players wizard consolidates patients *before* delegating
+        the res.partner half to this method, so by then only one patient remains
+        and this guard passes on its own -- no bypass flag is needed.
+        """
+        patients = self.env['sports.patient'].sudo().with_context(
+            active_test=False,
+        ).search([('partner_id', 'in', partner_ids)])
+        if len(patients) > 1:
+            names = "\n".join(
+                " - %s" % name
+                for name in sorted(patients.mapped('partner_id.name'))
+            )
+            raise UserError(_(
+                "These contacts belong to more than one player:\n\n%(names)s\n\n"
+                "Merging the contacts would delete all but one of these players, "
+                "along with their injuries, treatment notes and documents.\n\n"
+                "To combine them, open the Players list, select the players, and "
+                "use Actions → Merge Players. That merges the players and "
+                "their contacts together, keeping the clinical history.",
+                names=names,
+            ))
+        return super()._merge(
+            partner_ids, dst_partner=dst_partner, extra_checks=extra_checks)
 
     @api.model
     def _update_values(self, src_partners, dst_partner):

--- a/bemade_sports_clinic/models/patient_merge_wizard.py
+++ b/bemade_sports_clinic/models/patient_merge_wizard.py
@@ -1,0 +1,435 @@
+from markupsafe import Markup
+
+from odoo import api, fields, models, Command, _
+from odoo.exceptions import UserError
+
+# Fields resolved by an explicit rule rather than by destination-precedence.
+# Never reported as conflicts: the rule, not the user, decides them.
+RULE_RESOLVED_FIELDS = (
+    "first_name", "last_name", "partner_id", "team_ids",
+    "last_consultation_date", "match_status", "practice_status",
+)
+# Clinical free text: never discarded, concatenated under a provenance header.
+TEXT_FIELDS = ("team_info_notes", "allergies")
+# Scalars: destination wins where set, sources fill blanks.
+SCALAR_FIELDS = ("date_of_birth", "predicted_return_date", "return_date")
+# Destination always wins; sources never fill (a False is a real value here).
+DEST_ONLY_FIELDS = ("pending_removal",)
+# Compared when looking for conflicts to warn about.
+CONFLICT_FIELDS = SCALAR_FIELDS + TEXT_FIELDS + DEST_ONLY_FIELDS
+# Suppress the follower email storm. last_consultation_date, match_status,
+# practice_status, predicted_return_date and return_date are all in
+# patient.external_tracking_fields and notify the team on change.
+QUIET = {
+    "tracking_disable": True,
+    "mail_notrack": True,
+    "mail_auto_subscribe_no_notify": True,
+    "mail_create_nosubscribe": True,
+}
+
+
+class PatientMergeWizard(models.TransientModel):
+    _name = "sports.patient.merge.wizard"
+    _description = "Merge Players"
+
+    patient_ids = fields.Many2many(
+        "sports.patient",
+        string="Players to merge",
+        required=True,
+    )
+    dst_patient_id = fields.Many2one(
+        "sports.patient",
+        string="Player to keep",
+        required=True,
+        domain="[('id', 'in', patient_ids)]",
+        help="The surviving record. Where two players disagree on a field, "
+             "this one's value is kept.",
+    )
+    conflict_info = fields.Html(
+        string="Please review", compute="_compute_conflict_info")
+    has_conflicts = fields.Boolean(compute="_compute_conflict_info")
+    contact_line_ids = fields.One2many(
+        "sports.patient.merge.contact.line", "wizard_id",
+        string="Other matching contacts",
+    )
+    blocked_contact_info = fields.Html(
+        string="Cannot be merged here", compute="_compute_blocked_contact_info")
+    has_blocked_contacts = fields.Boolean(
+        compute="_compute_blocked_contact_info")
+
+    # ------------------------------------------------------------------
+    # Defaults
+    # ------------------------------------------------------------------
+    @api.model
+    def default_get(self, fields_list):
+        res = super().default_get(fields_list)
+        active_ids = self.env.context.get("active_ids")
+        if active_ids is None:
+            # Created programmatically rather than opened from the Players
+            # list; there is nothing to seed. action_merge still validates.
+            return res
+        patients = self.env["sports.patient"].browse(active_ids).exists()
+        if len(patients) < 2:
+            raise UserError(_(
+                "Select at least two players to merge."))
+        res["patient_ids"] = [Command.set(patients.ids)]
+        # Default to the oldest record: most likely the original, and the one
+        # other records were duplicated from.
+        res["dst_patient_id"] = min(patients.ids)
+        res["contact_line_ids"] = [
+            Command.create(vals) for vals in self._candidate_line_vals(patients)
+        ]
+        return res
+
+    # ------------------------------------------------------------------
+    # Matching contacts
+    # ------------------------------------------------------------------
+    @api.model
+    def _match_domain(self, patients):
+        """Exact email OR sanitised phone OR same last name.
+
+        Sanitised phone matters: the real duplicate pair carried
+        '514-555-0142' and '+1 514-555-0142'. Exact string matching finds
+        nothing. Blank email/phone are excluded -- with false == false
+        matching, one merge could sweep in every contact lacking an email.
+        """
+        partners = patients.partner_id
+        emails = [e for e in partners.mapped("email") if e]
+        phones = [p for p in partners.mapped("phone_sanitized") if p]
+        last_names = [n for n in patients.mapped("last_name") if n]
+
+        leaves = []
+        if emails:
+            leaves.append([("email", "in", emails)])
+        if phones:
+            leaves.append([("phone_sanitized", "in", phones)])
+        for last_name in set(last_names):
+            leaves.append([("name", "ilike", last_name)])
+        if not leaves:
+            return None
+        domain = leaves[0]
+        for leaf in leaves[1:]:
+            domain = ["|"] + domain + leaf
+        return domain
+
+    @api.model
+    def _candidate_line_vals(self, patients):
+        domain = self._match_domain(patients)
+        if not domain:
+            return []
+        # One query, not one per patient. Archived partners are excluded by the
+        # default active_test.
+        candidates = self.env["res.partner"].search(domain) - patients.partner_id
+        if not candidates:
+            return []
+        # A partner belonging to ANOTHER patient must never be offered here:
+        # folding it into the res.partner merge would smuggle a second patient
+        # past the contact-merge guard and re-create the deletion bug.
+        others = self.env["sports.patient"].sudo().with_context(
+            active_test=False,
+        ).search([("partner_id", "in", candidates.ids)])
+        blocked = others.partner_id
+
+        vals = []
+        for partner in candidates - blocked:
+            vals.append({
+                "partner_id": partner.id,
+                "match_reason": self._match_reason(partner, patients),
+            })
+        for partner in blocked:
+            patient = others.filtered(lambda p: p.partner_id == partner)[:1]
+            vals.append({
+                "partner_id": partner.id,
+                "match_reason": self._match_reason(partner, patients),
+                "blocked_patient_id": patient.id,
+            })
+        return vals
+
+    @api.model
+    def _match_reason(self, partner, patients):
+        partners = patients.partner_id
+        if partner.email and partner.email in partners.mapped("email"):
+            return _("Same email")
+        if (partner.phone_sanitized
+                and partner.phone_sanitized in partners.mapped("phone_sanitized")):
+            return _("Same phone")
+        return _("Same last name")
+
+    @api.depends("contact_line_ids.blocked_patient_id")
+    def _compute_blocked_contact_info(self):
+        for wizard in self:
+            blocked = wizard.contact_line_ids.filtered("blocked_patient_id")
+            wizard.has_blocked_contacts = bool(blocked)
+            if not blocked:
+                wizard.blocked_contact_info = False
+                continue
+            rows = Markup("").join(
+                Markup("<li>%s &mdash; belongs to player <b>%s</b></li>") % (
+                    line.partner_id.display_name,
+                    line.blocked_patient_id.display_name,
+                )
+                for line in blocked
+            )
+            wizard.blocked_contact_info = Markup(
+                "<p>These contacts look like duplicates, but each belongs to "
+                "another player, so they cannot be merged here:</p>"
+                "<ul>%s</ul>"
+                "<p>If any of them is really the same person, cancel and "
+                "include that player in this merge instead.</p>"
+            ) % rows
+
+    # ------------------------------------------------------------------
+    # Conflicts
+    # ------------------------------------------------------------------
+    @api.depends("patient_ids", "dst_patient_id")
+    def _compute_conflict_info(self):
+        for wizard in self:
+            conflicts = wizard._collect_conflicts()
+            wizard.has_conflicts = bool(conflicts)
+            if not conflicts:
+                wizard.conflict_info = False
+                continue
+            # Free text and scalars need different wording. Saying "discarding"
+            # about a field that is actually concatenated is simply false, and
+            # a blanket footnote contradicting the per-field line is worse than
+            # no warning at all.
+            rows = Markup("")
+            for conflict in conflicts:
+                if conflict["combined"]:
+                    rows += Markup(
+                        "<li><b>%s</b>: the players disagree &mdash; both values "
+                        "are kept and combined, nothing is lost. Please reconcile "
+                        "them on the surviving player afterwards.</li>"
+                    ) % conflict["label"]
+                else:
+                    rows += Markup(
+                        "<li><b>%s</b>: keeping &ldquo;%s&rdquo;, discarding "
+                        "&ldquo;%s&rdquo; (from %s)</li>"
+                    ) % (conflict["label"], conflict["dst"], conflict["src"],
+                         conflict["src_patient"])
+            body = Markup("<p>These fields differ between the players:</p><ul>%s</ul>") % rows
+            if any(not c["combined"] for c in conflicts):
+                body += Markup(
+                    "<p>Discarded values are replaced by <b>%s</b>&rsquo;s. If a "
+                    "discarded value is the right one, cancel, fix it on the "
+                    "player&rsquo;s form, and merge again.</p>"
+                ) % wizard.dst_patient_id.display_name
+            wizard.conflict_info = body
+
+    def _collect_conflicts(self):
+        """Fields set on BOTH the destination and a source, with differing
+        values. A source-only value is not a conflict -- it fills a blank.
+
+        Only fields the acting user can actually READ are compared:
+        date_of_birth, team_info_notes and allergies are group-restricted, and
+        a restricted value must not leak into a warning.
+        """
+        self.ensure_one()
+        dst = self.dst_patient_id
+        srcs = self.patient_ids - dst
+        if not dst or not srcs:
+            return []
+        readable = self.env["sports.patient"].fields_get(
+            allfields=list(CONFLICT_FIELDS))
+        conflicts = []
+        for fname in CONFLICT_FIELDS:
+            if fname not in readable:
+                continue
+            dst_value = dst[fname]
+            if not dst_value:
+                continue
+            for src in srcs:
+                src_value = src[fname]
+                if src_value and src_value != dst_value:
+                    conflicts.append({
+                        "label": readable[fname]["string"],
+                        "dst": dst_value,
+                        "src": src_value,
+                        "src_patient": src.display_name,
+                        # Free text is concatenated, not overwritten -- the
+                        # warning must not claim the source value is discarded.
+                        "combined": fname in TEXT_FIELDS,
+                    })
+        return conflicts
+
+    # ------------------------------------------------------------------
+    # Merge
+    # ------------------------------------------------------------------
+    def action_merge(self):
+        self.ensure_one()
+        dst = self.dst_patient_id
+        if len(self.patient_ids) < 2:
+            raise UserError(_("Select at least two players to merge."))
+        if dst not in self.patient_ids:
+            raise UserError(_(
+                "The player to keep must be one of the players being merged."))
+        if not self.env.user.has_group(
+                "bemade_sports_clinic.group_sports_clinic_admin"):
+            raise UserError(_(
+                "Only Sports Clinic Administrators can merge players."))
+        anonymized = self.patient_ids.sudo().filtered("is_anonymized")
+        if anonymized:
+            raise UserError(_(
+                "These players have been anonymized under Law 25 and cannot be "
+                "merged: %(names)s\n\nTheir identifying data was erased on "
+                "purpose; merging one would relink erased data to an "
+                "identified person.",
+                names=", ".join(anonymized.mapped("display_name")),
+            ))
+
+        dst = dst.sudo()
+        srcs = (self.patient_ids - self.dst_patient_id).sudo()
+
+        values = self._resolve_values(dst, srcs)
+        self._reassign_children(dst, srcs)
+        if values:
+            dst.with_context(**QUIET).write(values)
+        self._move_chatter(dst, srcs)
+
+        audit_body = self._audit_body(dst, srcs)
+        src_partners = srcs.partner_id
+        # Children have moved; unlinking now cannot cascade a clinical record.
+        srcs.unlink()
+        # _message_log, not message_post: it records the note without notifying
+        # followers. message_post on mt_note would email the whole team about a
+        # merge of historical data.
+        dst.with_context(**QUIET)._message_log(body=audit_body)
+
+        # Belt and braces: a blocked line is not tickable in the view, but if one
+        # is selected anyway its partner belongs to another player, and merging
+        # it would put two patients into the contact merge -- the exact shape of
+        # the bug this whole change exists to prevent. Refuse explicitly rather
+        # than relying on the guard to catch it downstream.
+        selected = self.contact_line_ids.filtered("selected")
+        smuggled = selected.filtered("blocked_patient_id")
+        if smuggled:
+            raise UserError(_(
+                "These contacts belong to other players and cannot be merged "
+                "here: %(names)s\n\nInclude those players in the merge instead.",
+                names=", ".join(smuggled.mapped("partner_id.display_name")),
+            ))
+
+        # Only one patient remains, so the contact-merge guard passes on its own.
+        partners = dst.partner_id | src_partners | selected.partner_id
+        if len(partners) > 1:
+            self.env["base.partner.merge.automatic.wizard"].sudo()._merge(
+                partners.ids, dst_partner=dst.partner_id)
+        return {"type": "ir.actions.act_window_close"}
+
+    def _resolve_values(self, dst, srcs):
+        values = {}
+        for fname in SCALAR_FIELDS:
+            if not dst[fname]:
+                for src in srcs:
+                    if src[fname]:
+                        values[fname] = src[fname]
+                        break
+        # Law 25 retention clock: the most recent consultation across all the
+        # merged records, NOT the destination's. Taking a stale destination
+        # value could prematurely age out a record seen more recently.
+        dates = [p.last_consultation_date
+                 for p in (dst | srcs) if p.last_consultation_date]
+        if dates and max(dates) != dst.last_consultation_date:
+            values["last_consultation_date"] = max(dates)
+        teams = dst.team_ids | srcs.team_ids
+        if teams != dst.team_ids:
+            values["team_ids"] = [Command.set(teams.ids)]
+        for fname in TEXT_FIELDS:
+            merged = self._merge_text(dst, srcs, fname)
+            if merged != dst[fname]:
+                values[fname] = merged
+        # match_status/practice_status are deliberately absent: only four
+        # combinations are valid (see constrain_match_and_practice_status), so
+        # they stay as the destination's pair rather than being resolved
+        # independently into an invalid one.
+        return values
+
+    def _merge_text(self, dst, srcs, fname):
+        """Destination text first, each differing source appended under a
+        provenance header. Identical text is not duplicated."""
+        parts = []
+        seen = set()
+        for patient in dst | srcs:
+            value = (patient[fname] or "").strip()
+            if not value or value in seen:
+                continue
+            seen.add(value)
+            if patient == dst:
+                parts.append(value)
+            else:
+                parts.append("--- %s ---\n%s" % (
+                    _("Merged from %(name)s (ID %(id)s)",
+                      name=patient.display_name, id=patient.id),
+                    value,
+                ))
+        return "\n\n".join(parts) if parts else False
+
+    def _reassign_children(self, dst, srcs):
+        """Injuries FIRST: sports.treatment.note._check_injury_patient_match and
+        sports.injury.document._check_injury_belongs_to_patient both assert
+        injury.patient_id == record.patient_id, so moving a note before its
+        injury raises."""
+        for model in ("sports.patient.injury", "sports.treatment.note",
+                      "sports.injury.document", "sports.patient.contact"):
+            records = self.env[model].sudo().with_context(
+                active_test=False).search([("patient_id", "in", srcs.ids)])
+            if records:
+                records.with_context(**QUIET).write({"patient_id": dst.id})
+
+    def _move_chatter(self, dst, srcs):
+        messages = self.env["mail.message"].sudo().search([
+            ("model", "=", "sports.patient"), ("res_id", "in", srcs.ids),
+        ])
+        if messages:
+            messages.write({"res_id": dst.id})
+        activities = self.env["mail.activity"].sudo().search([
+            ("res_model", "=", "sports.patient"), ("res_id", "in", srcs.ids),
+        ])
+        if activities:
+            activities.write({"res_id": dst.id})
+        followers = self.env["mail.followers"].sudo().search([
+            ("res_model", "=", "sports.patient"), ("res_id", "in", srcs.ids),
+        ])
+        existing = dst.sudo().message_follower_ids.mapped("partner_id")
+        for follower in followers:
+            if follower.partner_id in existing:
+                follower.unlink()
+            else:
+                follower.write({"res_id": dst.id})
+                existing |= follower.partner_id
+
+    def _audit_body(self, dst, srcs):
+        # Must be Markup: mail bodies escape plain strings, so a str here shows
+        # the user raw <p> tags in the chatter. Markup %-interpolation also
+        # escapes the values, which matters because player names are user input.
+        rows = Markup("").join(
+            Markup("<li>%s (ID %s)</li>") % (src.display_name, src.id)
+            for src in srcs
+        )
+        # Name the acting user explicitly: the merge runs sudo, so the message
+        # author would otherwise be the system user and the Law 25 trail would
+        # not record who did this.
+        return Markup(_(
+            "<p>Merged into this player by %(user)s:</p><ul>%(rows)s</ul>"
+            "<p>Their injuries, treatment notes, documents, team links and "
+            "history were moved here. Notes and allergies from the merged "
+            "records were combined into this one &mdash; please review them.</p>"
+        )) % {
+            "user": self.env.user.display_name,
+            "rows": rows,
+        }
+
+
+class PatientMergeContactLine(models.TransientModel):
+    _name = "sports.patient.merge.contact.line"
+    _description = "Merge Players: Matching Contact"
+
+    wizard_id = fields.Many2one(
+        "sports.patient.merge.wizard", required=True, ondelete="cascade")
+    partner_id = fields.Many2one("res.partner", string="Contact", readonly=True)
+    match_reason = fields.Char(string="Matched on", readonly=True)
+    selected = fields.Boolean(string="Merge too", default=False)
+    blocked_patient_id = fields.Many2one(
+        "sports.patient", string="Belongs to player", readonly=True)
+    partner_email = fields.Char(related="partner_id.email", readonly=True)
+    partner_phone = fields.Char(related="partner_id.phone", readonly=True)

--- a/bemade_sports_clinic/security/ir.model.access.csv
+++ b/bemade_sports_clinic/security/ir.model.access.csv
@@ -76,3 +76,7 @@ access_injury_note_history_treatment_pro,Treatment Professional Access for Injur
 access_injury_note_history_admin,Admin Access for Injury Note History,model_sports_injury_note_history,group_sports_clinic_admin,1,0,0,0
 access_injury_note_history_portal_tp,Portal Treatment Prof Access for Injury Note History,model_sports_injury_note_history,bemade_sports_clinic.group_portal_treatment_professional,1,0,0,0
 access_injury_note_history_portal_coach,Portal Coach Access for Injury Note History,model_sports_injury_note_history,bemade_sports_clinic.group_portal_team_coach,1,0,0,0
+access_sports_patient_merge_wizard_admin,Clinic Admin Access for Patient Merge Wizard,model_sports_patient_merge_wizard,bemade_sports_clinic.group_sports_clinic_admin,1,1,1,1
+access_sports_patient_merge_wizard_system,System Access for Patient Merge Wizard,model_sports_patient_merge_wizard,base.group_system,1,1,1,1
+access_sports_patient_merge_contact_line_admin,Clinic Admin Access for Patient Merge Contact Line,model_sports_patient_merge_contact_line,bemade_sports_clinic.group_sports_clinic_admin,1,1,1,1
+access_sports_patient_merge_contact_line_system,System Access for Patient Merge Contact Line,model_sports_patient_merge_contact_line,base.group_system,1,1,1,1

--- a/bemade_sports_clinic/tests/__init__.py
+++ b/bemade_sports_clinic/tests/__init__.py
@@ -61,3 +61,9 @@ from . import test_append_query
 from . import test_cov_portal_datetime_lang
 from . import test_law25_anonymize
 from . import test_cov_calendar_label
+from . import test_patient_merge_guard
+from . import test_patient_merge_wizard
+from . import test_patient_merge_conflicts
+from . import test_patient_merge_suggestions
+from . import test_patient_merge_security
+from . import test_patient_merge_prod_regression

--- a/bemade_sports_clinic/tests/test_patient_merge_conflicts.py
+++ b/bemade_sports_clinic/tests/test_patient_merge_conflicts.py
@@ -1,0 +1,316 @@
+"""Merge Players wizard: conflict surfacing and clinical free-text handling.
+
+Policy agreed with the owner (2026-07-15):
+  * Scalar fields -- destination wins where set, sources fill blanks. Where both
+    are set and DIFFER, the wizard warns prominently so the user can cancel,
+    reconcile on the patient forms, and re-run. The warning is advisory, not a
+    hard block: the user may proceed knowingly.
+  * Clinical free text -- never discarded. Concatenated under a provenance
+    header. Dropping an allergy recorded only on the source is a safety risk,
+    not just a data-quality one.
+
+The real records justified both rules: one held a full insurance policy number
+while the other held only a bare insurer name, and their allergies recorded the
+same drug under two different spellings -- which no automatic rule should
+silently pick between.
+
+ACCEPTANCE CRITERIA
+-------------------
+AC1  A field set on BOTH patients with differing values is reported as a
+     conflict before the merge is applied, naming the field, the destination
+     value and each source value.
+AC2  A field set only on the source is NOT a conflict -- it silently fills the
+     destination's blank (that is AC7 of the wizard suite, not a warning).
+AC3  Identical values on both patients are NOT reported as conflicts.
+AC4  The warning is advisory: proceeding applies destination-wins. The wizard
+     must also be cancellable with zero side effects -- nothing written, no
+     patient unlinked, no partner merged.
+AC5  Conflicts are computed over fields the acting user can actually READ.
+     date_of_birth, team_info_notes and allergies are group-restricted to the
+     treatment-professional groups (patient.py:72); the check must not leak a
+     restricted value into a warning shown to a user who cannot see the field.
+AC6  team_info_notes: destination text kept, each source's text appended under a
+     '--- Merged from <name> (ID <id>) ---' provenance header. Destination-only
+     and source-only cases both behave (no stray header, no leading separator).
+AC7  allergies: same concatenation rule. An allergy recorded ONLY on the source
+     must appear on the survivor -- this is the safety-critical case.
+AC8  Concatenation is not duplicated when both patients carry identical text --
+     the survivor must not read 'Peanut allergy / Peanut allergy'.
+AC9  Free-text concatenation is applied with tracking disabled, consistent with
+     the rest of the merge (team_info_notes is tracked; allergies is not).
+AC10 Conflict detection ignores fields the merge resolves by rule rather than by
+     precedence: last_consultation_date (max), team_ids (union), and the
+     match_status/practice_status pair are never reported as conflicts.
+"""
+
+from odoo import Command
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged('post_install', '-at_install')
+class TestPatientMergeConflicts(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env.user.sudo().group_ids = [
+            Command.link(cls.env.ref(
+                'bemade_sports_clinic.group_sports_clinic_treatment_professional').id),
+            Command.link(cls.env.ref(
+                'bemade_sports_clinic.group_sports_clinic_admin').id),
+        ]
+        cls.team = cls.env['sports.team'].create({'name': 'Braves'})
+
+    def _patient(self, first_name, **vals):
+        vals.setdefault('last_name', 'Sampleton')
+        vals['first_name'] = first_name
+        return self.env['sports.patient'].create(vals)
+
+    def _wizard(self, patients, dst):
+        Wizard = self.env['sports.patient.merge.wizard'].with_context(
+            active_ids=patients.ids)
+        values = Wizard.default_get(list(Wizard._fields))
+        values['dst_patient_id'] = dst.id
+        return Wizard.create(values)
+
+    def test_differing_scalar_reported_as_conflict(self):
+        """AC1."""
+        dst = self._patient('Alexandre', date_of_birth='2010-03-01')
+        src = self._patient('Alex', date_of_birth='2008-01-01')
+
+        wizard = self._wizard(dst | src, dst)
+
+        self.assertTrue(wizard.has_conflicts, "differing DOB must be flagged")
+        self.assertIn('2010-03-01', wizard.conflict_info,
+                      "warning must show the value being kept")
+        self.assertIn('2008-01-01', wizard.conflict_info,
+                      "warning must show the value being discarded")
+
+    def test_source_only_value_is_not_a_conflict(self):
+        """AC2."""
+        dst = self._patient('Alexandre')
+        src = self._patient('Alex', date_of_birth='2008-01-01')
+
+        wizard = self._wizard(dst | src, dst)
+
+        self.assertFalse(wizard.has_conflicts,
+                         "filling a blank is not a conflict")
+
+    def test_identical_values_not_reported(self):
+        """AC3."""
+        dst = self._patient('Alexandre', date_of_birth='2010-03-01')
+        src = self._patient('Alex', date_of_birth='2010-03-01')
+
+        wizard = self._wizard(dst | src, dst)
+
+        self.assertFalse(wizard.has_conflicts,
+                         "identical values are not a conflict")
+
+    def test_warning_is_advisory_and_cancel_is_clean(self):
+        """AC4."""
+        dst = self._patient('Alexandre', date_of_birth='2010-03-01')
+        src = self._patient('Alex', date_of_birth='2008-01-01')
+
+        wizard = self._wizard(dst | src, dst)
+        self.assertTrue(wizard.has_conflicts)
+
+        # Cancelling: merely building the wizard must change nothing.
+        self.assertTrue(src.exists(), "source patient must be untouched")
+        self.assertEqual(str(src.date_of_birth), '2008-01-01')
+        self.assertTrue(src.partner_id.exists())
+
+        # Proceeding anyway is allowed -- the warning does not block.
+        wizard.action_merge()
+        self.assertEqual(str(dst.date_of_birth), '2010-03-01')
+        self.assertFalse(src.exists())
+
+    def test_conflicts_respect_field_group_restrictions(self):
+        """AC5: a restricted value must not leak into the warning.
+
+        return_date is NOT group-restricted while date_of_birth and
+        team_info_notes are. Conflicting on both proves the filter is
+        SELECTIVE: a blanket-empty warning would pass a naive assertNotIn
+        while telling us nothing.
+        """
+        dst = self._patient('Alexandre', date_of_birth='2010-03-01',
+                            return_date='2025-12-01',
+                            team_info_notes='destination note')
+        src = self._patient('Alex', date_of_birth='2008-01-01',
+                            return_date='2025-12-15',
+                            team_info_notes='source note')
+
+        restricted_user = self.env['res.users'].create({
+            'name': 'Clinic User', 'login': 'clinic_user_conflicts',
+            'group_ids': [Command.set([
+                self.env.ref('base.group_user').id,
+                self.env.ref('bemade_sports_clinic.group_sports_clinic_user').id,
+            ])],
+        })
+        wizard = self._wizard(dst | src, dst)
+
+        # Compute in the RESTRICTED env first. Odoo caches a non-stored compute
+        # per (record, field) for the whole transaction, not per user, so
+        # reading as admin first poisons the cache and makes this test pass
+        # vacuously against a value the restricted user never computed.
+        info = wizard.with_user(restricted_user).conflict_info or ''
+        wizard.invalidate_recordset(['conflict_info', 'has_conflicts'])
+
+        # Non-vacuity guard: a treatment professional DOES see the restricted
+        # fields, so the assertions below fail for the right reason.
+        admin_info = wizard.conflict_info or ''
+        self.assertIn('2008-01-01', admin_info)
+        self.assertIn('Notes', admin_info)
+
+        # The restricted user still gets the conflict they ARE allowed to see...
+        self.assertIn('2025-12-15', info,
+                      "an unrestricted conflict must still be reported -- an "
+                      "empty warning would make this test meaningless")
+        # ...but never the restricted ones.
+        self.assertNotIn('2008-01-01', info,
+                         "date_of_birth is TP-restricted and must not leak")
+        self.assertNotIn('Notes', info,
+                         "team_info_notes is TP-restricted and must not leak")
+
+    def test_team_info_notes_concatenated_with_provenance(self):
+        """AC6: the real insurance-note case."""
+        dst = self._patient(
+            'Alexandre',
+            team_info_notes="no provincial health card --> private insurer, policy POLICY-000123")
+        src = self._patient('Alex', team_info_notes='private insurer')
+        src_id = src.id
+
+        self._wizard(dst | src, dst).action_merge()
+
+        self.assertIn('POLICY-000123', dst.team_info_notes,
+                      "destination note must be kept -- the policy number lives "
+                      "only on the destination and is the detail a "
+                      "destination-wins-and-discard rule would lose")
+        self.assertIn('private insurer', dst.team_info_notes,
+                      "source note must be preserved, not discarded")
+        self.assertIn(str(src_id), dst.team_info_notes,
+                      "appended text must carry provenance")
+
+    def test_destination_only_text_has_no_stray_header(self):
+        """AC6: no provenance header when there is nothing to append."""
+        dst = self._patient('Alexandre', team_info_notes='only note')
+        src = self._patient('Alex')
+
+        self._wizard(dst | src, dst).action_merge()
+
+        self.assertEqual(dst.team_info_notes, 'only note',
+                         "a lone note must not gain a provenance header")
+
+    def test_source_only_text_has_no_leading_separator(self):
+        """AC6."""
+        dst = self._patient('Alexandre')
+        src = self._patient('Alex', team_info_notes='source only')
+
+        self._wizard(dst | src, dst).action_merge()
+
+        self.assertTrue(dst.team_info_notes.strip().startswith('---')
+                        or dst.team_info_notes.strip() == 'source only',
+                        "must not start with a blank separator")
+        self.assertIn('source only', dst.team_info_notes)
+
+    def test_source_only_allergy_survives(self):
+        """AC7: safety-critical."""
+        dst = self._patient('Alexandre')
+        src = self._patient('Alex', allergies='Aspirin')
+
+        self._wizard(dst | src, dst).action_merge()
+
+        self.assertIn('Aspirin', dst.allergies or '',
+                      "an allergy recorded only on the source must survive")
+
+    def test_differing_allergies_both_survive(self):
+        """AC7: the real 'Aspirin' vs 'ASA' case -- both must be kept."""
+        dst = self._patient('Alexandre', allergies='Aspirin')
+        src = self._patient('Alex', allergies='ASA')
+
+        wizard = self._wizard(dst | src, dst)
+        self.assertTrue(wizard.has_conflicts,
+                        "differing allergies must be flagged for reconciliation")
+        wizard.action_merge()
+
+        self.assertIn('Aspirin', dst.allergies)
+        self.assertIn('ASA', dst.allergies)
+
+    def test_identical_text_not_duplicated(self):
+        """AC8."""
+        dst = self._patient('Alexandre', allergies='Peanut allergy')
+        src = self._patient('Alex', allergies='Peanut allergy')
+
+        self._wizard(dst | src, dst).action_merge()
+
+        self.assertEqual(dst.allergies, 'Peanut allergy',
+                         "identical text must not be duplicated")
+
+    def test_concatenation_does_not_notify(self):
+        """AC9."""
+        dst = self._patient('Alexandre', team_info_notes='a')
+        src = self._patient('Alex', team_info_notes='b')
+        before = self.env['mail.mail'].search_count([])
+
+        self._wizard(dst | src, dst).action_merge()
+
+        self.assertEqual(self.env['mail.mail'].search_count([]), before,
+                         "concatenating tracked notes must not notify")
+
+    def test_text_conflicts_do_not_claim_the_value_is_discarded(self):
+        """AC1: the warning must not contradict what the merge actually does.
+
+        Raised in human testing: the per-field line said Notes were being
+        'discarded' while the footer said notes are 'combined rather than
+        discarded'. Notes are never discarded -- they are concatenated.
+        """
+        dst = self._patient('Alexandre', team_info_notes='destination note')
+        src = self._patient('Alex', team_info_notes='source note')
+
+        wizard = self._wizard(dst | src, dst)
+
+        info = wizard.conflict_info
+        self.assertTrue(wizard.has_conflicts)
+        self.assertIn('combined', info,
+                      "a text conflict must say the values are combined")
+        self.assertNotIn('discarding', info,
+                         "a text conflict must never claim the source text is "
+                         "discarded -- it is concatenated")
+
+    def test_scalar_conflicts_still_say_discarded(self):
+        """AC1: scalars genuinely are discarded, and must say so."""
+        dst = self._patient('Alexandre', date_of_birth='2010-03-01')
+        src = self._patient('Alex', date_of_birth='2008-01-01')
+
+        wizard = self._wizard(dst | src, dst)
+
+        self.assertIn('discarding', wizard.conflict_info,
+                      "a scalar conflict must be explicit that a value is lost")
+
+    def test_conflict_info_escapes_user_text(self):
+        """Notes are user input rendered into an Html field."""
+        dst = self._patient('Alexandre', team_info_notes='<b>dst</b>')
+        src = self._patient('Alex', team_info_notes='<i>src</i>')
+
+        wizard = self._wizard(dst | src, dst)
+
+        # Text conflicts no longer echo values, but the player names are still
+        # interpolated -- ensure nothing user-supplied lands as live markup.
+        self.assertNotIn('<b>dst</b>', wizard.conflict_info,
+                         "user text must not be injected as live markup")
+
+    def test_rule_resolved_fields_not_reported_as_conflicts(self):
+        """AC10."""
+        dst = self._patient('Alexandre', last_consultation_date='2025-01-01',
+                            match_status='no', practice_status='no',
+                            team_ids=[Command.set(self.team.ids)])
+        src = self._patient('Alex', last_consultation_date='2025-11-06',
+                            match_status='yes', practice_status='yes')
+
+        wizard = self._wizard(dst | src, dst)
+
+        info = wizard.conflict_info or ''
+        self.assertNotIn('Last Consultation', info,
+                         "last_consultation_date is resolved by the MAX rule")
+        self.assertNotIn('2025-11-06', info)
+        self.assertFalse(wizard.has_conflicts,
+                         "rule-resolved fields must not be reported")

--- a/bemade_sports_clinic/tests/test_patient_merge_guard.py
+++ b/bemade_sports_clinic/tests/test_patient_merge_guard.py
@@ -1,0 +1,145 @@
+"""Contact-merge guard: refuse partner merges that would destroy patients.
+
+BACKGROUND
+----------
+sports.patient declares UNIQUE(partner_id). Odoo core's
+base.partner.merge.automatic.wizard._update_foreign_keys_generic reacts to a
+unique-constraint violation by issuing a raw
+    DELETE FROM sports_patient WHERE partner_id IN (<src ids>)
+(odoo/addons/base/wizard/base_partner_merge.py:171-180). That bypasses the ORM
+and ondelete="restrict", and DB-level CASCADE then takes the patient's injuries,
+treatment notes, injury documents and team links with it. This destroyed two
+players' clinical history in fitcrew prod on 2026-07-15.
+
+The guard makes that path unreachable: a partner merge that would collide is
+refused up front, and staff are pointed at the Merge Players wizard instead.
+
+ACCEPTANCE CRITERIA
+-------------------
+AC1  Merging contacts linked to more than one patient raises UserError before
+     any write occurs; every patient, injury, treatment note, document and team
+     link still exists afterwards, and the partners are all still present.
+AC2  The error message names the players involved and directs the user to the
+     Merge Players action (it must not be a bare constraint traceback).
+AC3  Merging contacts linked to exactly one patient still succeeds; the patient
+     survives and its partner_id is repointed to the destination partner.
+AC4  Merging contacts linked to no patients is unaffected (core behaviour).
+AC5  An ARCHIVED patient still counts toward the guard. active_test=False must
+     be used: an archived patient continues to occupy UNIQUE(partner_id) and is
+     just as deletable by the raw DELETE.
+AC6  The guard counts patients, not partners: merging 3 contacts where only the
+     destination carries a patient is allowed.
+"""
+
+from odoo import Command
+from odoo.exceptions import UserError
+from odoo.tests import TransactionCase, tagged
+from odoo.tools.misc import mute_logger
+
+
+@tagged('post_install', '-at_install')
+class TestPatientMergeGuard(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.Wizard = cls.env['base.partner.merge.automatic.wizard']
+        cls.Partner = cls.env['res.partner']
+
+    def _patient(self, first_name, last_name='Tester'):
+        return self.env['sports.patient'].create({
+            'first_name': first_name, 'last_name': last_name,
+        })
+
+    @mute_logger('odoo.models.unlink', 'odoo.sql_db')
+    def test_merge_two_patients_contacts_is_blocked(self):
+        """AC1: UserError, and no clinical data is touched."""
+        pa = self._patient('Ann')
+        pb = self._patient('Bea')
+        injury = self.env['sports.patient.injury'].create({
+            'patient_id': pb.id, 'diagnosis': 'Sprain',
+            'injury_date': '2025-10-09', 'stage': 'active',
+        })
+        note = self.env['sports.treatment.note'].create({
+            'patient_id': pb.id, 'note': 'ice', 'date': '2025-10-10',
+        })
+        partner_ids = (pa.partner_id | pb.partner_id).ids
+
+        with self.assertRaises(UserError):
+            self.Wizard._merge(partner_ids, dst_partner=pa.partner_id)
+
+        self.assertTrue(pa.exists() and pb.exists(), "a patient was destroyed")
+        self.assertTrue(injury.exists(), "injury cascade-deleted")
+        self.assertTrue(note.exists(), "treatment note cascade-deleted")
+        self.assertTrue(pa.partner_id.exists() and pb.partner_id.exists(),
+                        "a partner was merged away despite the refusal")
+
+    @mute_logger('odoo.models.unlink', 'odoo.sql_db')
+    def test_block_message_names_players_and_points_to_wizard(self):
+        """AC2."""
+        pa = self._patient('Ann', 'Sampleton')
+        pb = self._patient('Bea', 'Sampleton')
+
+        with self.assertRaises(UserError) as ctx:
+            self.Wizard._merge((pa.partner_id | pb.partner_id).ids,
+                               dst_partner=pa.partner_id)
+
+        message = str(ctx.exception)
+        self.assertIn('Ann Sampleton', message, "message must name the players")
+        self.assertIn('Bea Sampleton', message, "message must name the players")
+        self.assertIn('Merge Players', message,
+                      "message must point to the Merge Players route")
+
+    def test_merge_single_patient_contacts_still_works(self):
+        """AC3: the one legitimate case core handles correctly."""
+        patient = self._patient('Solo')
+        dst = self.Partner.create({'name': 'Solo Duplicate'})
+
+        self.Wizard._merge((dst | patient.partner_id).ids, dst_partner=dst)
+
+        self.assertTrue(patient.exists(), "the only patient was destroyed")
+        self.assertEqual(patient.partner_id, dst,
+                         "patient should be repointed at the destination")
+
+    def test_merge_non_patient_contacts_unaffected(self):
+        """AC4: regression guard on ordinary partner merges."""
+        a = self.Partner.create({'name': 'Plain A'})
+        b = self.Partner.create({'name': 'Plain B'})
+
+        self.Wizard._merge((a | b).ids, dst_partner=a)
+
+        self.assertTrue(a.exists(), "destination partner should survive")
+        self.assertFalse(b.exists(), "source partner should be merged away")
+
+    @mute_logger('odoo.models.unlink', 'odoo.sql_db')
+    def test_archived_patient_counts_toward_guard(self):
+        """AC5: the case an active_test-naive implementation would miss."""
+        active_patient = self._patient('Active')
+        archived_patient = self._patient('Archived')
+        archived_patient.active = False
+        self.assertFalse(archived_patient.active, "fixture must be archived")
+
+        with self.assertRaises(UserError):
+            self.Wizard._merge(
+                (active_patient.partner_id | archived_patient.partner_id).ids,
+                dst_partner=active_patient.partner_id,
+            )
+
+        self.assertTrue(
+            archived_patient.exists(),
+            "archived patient was destroyed -- it still occupies "
+            "UNIQUE(partner_id) and must count toward the guard",
+        )
+
+    def test_three_contacts_one_patient_allowed(self):
+        """AC6: guard is not over-eager."""
+        patient = self._patient('Only')
+        dup_a = self.Partner.create({'name': 'Only Dup A'})
+        dup_b = self.Partner.create({'name': 'Only Dup B'})
+
+        self.Wizard._merge((patient.partner_id | dup_a | dup_b).ids,
+                           dst_partner=patient.partner_id)
+
+        self.assertTrue(patient.exists(), "patient should survive")
+        self.assertFalse(dup_a.exists(), "duplicate A should be merged away")
+        self.assertFalse(dup_b.exists(), "duplicate B should be merged away")

--- a/bemade_sports_clinic/tests/test_patient_merge_prod_regression.py
+++ b/bemade_sports_clinic/tests/test_patient_merge_prod_regression.py
@@ -1,0 +1,261 @@
+"""End-to-end regression: the fitcrew prod incident of 2026-07-15.
+
+WHAT HAPPENED
+-------------
+A player existed as three res.partner records with an inconsistent first name
+two of them carried a sports.patient each; the merge destination carried
+none. Staff merged the three CONTACTS, because no Merge Players route existed.
+The chatter shows they had spent the preceding minutes hand-copying fields from
+one patient to the other -- doing a patient merge manually, for want of a tool.
+
+Core's _update_foreign_keys_generic tried
+    UPDATE sports_patient SET partner_id = <dst> WHERE partner_id IN (<srcs>)
+Both rows collided on UNIQUE(partner_id), Postgres raised, and core's except
+branch issued a raw DELETE of both patients. DB-level CASCADE then removed their
+injuries, treatment notes, injury documents and team links. The contact merge
+itself looked perfectly successful. Zero Sampleton patients remained.
+
+This suite reproduces that exact topology. It must FAIL on the unfixed code (by
+losing patients) and pass afterwards. It is the test that would have caught this
+before it reached prod, and the reason the bug survived migration is that
+test_cov_base_partner_merge.py only ever calls _update_values directly and never
+exercises _merge at all.
+
+ACCEPTANCE CRITERIA
+-------------------
+AC1  REPRODUCTION: 3 partners, 2 of them carrying patients with injuries,
+     treatment notes, documents and team links; destination carries no patient.
+     Merging the three contacts must NOT delete any patient.
+AC2  On unfixed code this suite fails by losing patients -- confirming it
+     reproduces the real defect rather than passing vacuously.
+AC3  With the guard in place, merging those three contacts raises UserError and
+     every patient, injury, treatment note, document and team link survives.
+AC4  The correct route works on the same fixture: Merge Players over the two
+     patients, with the third contact folded in, yields ONE patient carrying the
+     union of both players' clinical history, and ONE contact.
+AC5  No clinical record from EITHER patient is missing after AC4 -- asserted by
+     explicit count and by identity, not just by count (a cascade that deleted
+     two and a repoint that duplicated two would both pass a naive count check).
+AC6  The surviving patient's name reflects the destination's spelling, and the
+     surviving partner's name matches it (via _recompute_name).
+AC7  The two source partners no longer exist; the destination partner does.
+AC8  The surviving patient's chatter contains the audit note naming both merged
+     patients -- the same trail that made the prod incident reconstructable.
+AC9  The whole flow emits no outbound follower notification.
+AC10 Guard rail on the fixture itself: assert the FK topology this bug depends
+     on still holds (sports.patient.partner_id is UNIQUE, and injuries/notes/
+     documents/team-links CASCADE from sports_patient). If a future migration
+     changes ondelete or drops the constraint, this suite must fail loudly
+     rather than silently testing nothing.
+"""
+
+from odoo import Command
+from odoo.exceptions import UserError
+from odoo.tests import TransactionCase, tagged
+from odoo.tools.misc import mute_logger
+
+
+@tagged('post_install', '-at_install')
+class TestPatientMergeProdRegression(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # date_of_birth / team_info_notes / allergies are group-restricted, and
+        # merging players is gated on the clinic admin group.
+        cls.tp_group = cls.env.ref(
+            'bemade_sports_clinic.group_sports_clinic_treatment_professional')
+        cls.admin_group = cls.env.ref(
+            'bemade_sports_clinic.group_sports_clinic_admin')
+        cls.env.user.sudo().group_ids = [
+            Command.link(cls.tp_group.id), Command.link(cls.admin_group.id)]
+        cls.Wizard = cls.env['base.partner.merge.automatic.wizard']
+
+    def _build_prod_fixture(self):
+        """Recreate the prod topology: 3 partners, 2 patients, dst has none."""
+        team = self.env['sports.team'].create({'name': 'BRAVES - Junior AAA'})
+
+        # The destination contact -- a duplicate carrying NO patient, exactly
+        # like the real one. This is what made ALL patients vanish rather than
+        # leaving one behind.
+        dst_partner = self.env['res.partner'].create({'name': 'Alex Sampleton'})
+
+        # Two patients, each auto-creating its own partner (as prod did).
+        patient_a = self.env['sports.patient'].create({
+            'first_name': 'Alexandre', 'last_name': 'Sampleton',
+            'date_of_birth': '2010-03-01',
+            'team_ids': [Command.set([team.id])],
+        })
+        patient_b = self.env['sports.patient'].create({
+            'first_name': 'Alex', 'last_name': 'Sampleton',
+            'date_of_birth': '2010-03-01',
+            'team_ids': [Command.set([team.id])],
+        })
+
+        # Clinical history on B -- the real record had an active injury.
+        injury = self.env['sports.patient.injury'].create({
+            'patient_id': patient_b.id,
+            'diagnosis': 'Sprained right shoulder',
+            'injury_date': '2025-10-09',
+            'stage': 'active',
+        })
+        note = self.env['sports.treatment.note'].create({
+            'patient_id': patient_b.id,
+            'injury_id': injury.id,
+            'note': 'follow-up imaging required',
+            'date': '2025-11-06',
+        })
+        return {
+            'team': team, 'dst_partner': dst_partner,
+            'patient_a': patient_a, 'patient_b': patient_b,
+            'injury': injury, 'note': note,
+        }
+
+    @mute_logger('odoo.models.unlink', 'odoo.sql_db')
+    def test_contact_merge_of_two_patient_contacts_is_refused(self):
+        """AC1, AC3: the incident, now blocked.
+
+        On the UNFIXED code this fails at assertRaises -- no error is raised,
+        the merge "succeeds", and both patients are silently gone (AC2).
+        """
+        fx = self._build_prod_fixture()
+        partner_ids = (
+            fx['dst_partner'] | fx['patient_a'].partner_id | fx['patient_b'].partner_id
+        ).ids
+
+        with self.assertRaises(UserError):
+            self.Wizard._merge(partner_ids, dst_partner=fx['dst_partner'])
+
+        # Nothing may be destroyed by a refused merge.
+        self.assertTrue(fx['patient_a'].exists(), "patient A was destroyed")
+        self.assertTrue(fx['patient_b'].exists(), "patient B was destroyed")
+        self.assertTrue(fx['injury'].exists(), "injury cascade-deleted")
+        self.assertTrue(fx['note'].exists(), "treatment note cascade-deleted")
+
+    def _merge_players(self, patients, dst, include_partners=None):
+        Wizard = self.env['sports.patient.merge.wizard'].with_context(
+            active_ids=patients.ids)
+        values = Wizard.default_get(list(Wizard._fields))
+        values['dst_patient_id'] = dst.id
+        wizard = Wizard.create(values)
+        for partner in include_partners or self.env['res.partner']:
+            line = wizard.contact_line_ids.filtered(
+                lambda l: l.partner_id == partner)
+            self.assertTrue(
+                line, f"{partner.display_name} should have been suggested")
+            line.selected = True
+        wizard.action_merge()
+        return wizard
+
+    def test_merge_players_consolidates_the_three_contacts(self):
+        """AC4, AC7: the route staff should have had."""
+        fx = self._build_prod_fixture()
+        dst, src = fx['patient_a'], fx['patient_b']
+        dst_partner, src_partner = dst.partner_id, src.partner_id
+        spare = fx['dst_partner']  # the third contact, carrying no patient
+
+        self._merge_players(dst | src, dst, include_partners=spare)
+
+        self.assertTrue(dst.exists(), "one player must survive")
+        self.assertFalse(src.exists(), "the duplicate player must be gone")
+        # Scoped to the fixture rather than searching by last name: this suite
+        # runs against a copy of production, which already contains the real
+        # Sampleton records, and a name-based count would collide with them.
+        self.assertEqual(
+            (dst | src).exists(), dst,
+            "exactly one of the merged players must remain, and it must be "
+            "the destination")
+        # AC7: all three contacts collapse into the survivor's.
+        self.assertTrue(dst_partner.exists(), "destination contact must survive")
+        self.assertFalse(src_partner.exists(), "source contact must be merged")
+        self.assertFalse(spare.exists(),
+                         "the third duplicate contact must be merged too -- "
+                         "leaving it behind is what sent staff back to the "
+                         "contact merge in the first place")
+
+    def test_no_clinical_record_lost_by_identity(self):
+        """AC5: count-and-identity, not count alone."""
+        fx = self._build_prod_fixture()
+        dst, src = fx['patient_a'], fx['patient_b']
+        injury_id, note_id = fx['injury'].id, fx['note'].id
+
+        self._merge_players(dst | src, dst)
+
+        injury = self.env['sports.patient.injury'].browse(injury_id)
+        note = self.env['sports.treatment.note'].browse(note_id)
+        self.assertTrue(injury.exists(), "the original injury row must survive")
+        self.assertTrue(note.exists(), "the original note row must survive")
+        self.assertEqual(injury.patient_id, dst)
+        self.assertEqual(note.patient_id, dst)
+        self.assertEqual(injury.diagnosis, 'Sprained right shoulder',
+                         "the surviving injury must be the same record, not a "
+                         "lookalike recreated by the merge")
+        self.assertEqual(dst.injury_ids, injury,
+                         "no duplicate injuries may appear")
+
+    def test_surviving_names_use_destination_spelling(self):
+        """AC6."""
+        fx = self._build_prod_fixture()
+        dst, src = fx['patient_a'], fx['patient_b']
+
+        self._merge_players(dst | src, dst)
+
+        self.assertEqual(dst.first_name, 'Alexandre')
+        self.assertEqual(dst.partner_id.name, 'Alexandre Sampleton',
+                         "the surviving contact must carry the surviving "
+                         "player's spelling")
+
+    def test_audit_note_names_both_merged_patients(self):
+        """AC8."""
+        fx = self._build_prod_fixture()
+        dst, src = fx['patient_a'], fx['patient_b']
+        src_id = src.id
+
+        self._merge_players(dst | src, dst)
+
+        bodies = ' '.join(dst.message_ids.mapped('body'))
+        self.assertIn(str(src_id), bodies,
+                      "the audit trail must name the merged-away player id -- "
+                      "this is what made the prod incident reconstructable")
+
+    def test_flow_emits_no_notifications(self):
+        """AC9."""
+        fx = self._build_prod_fixture()
+        dst, src = fx['patient_a'], fx['patient_b']
+        before = self.env['mail.mail'].search_count([])
+
+        self._merge_players(dst | src, dst)
+
+        self.assertEqual(self.env['mail.mail'].search_count([]), before,
+                         "merging historical data must not email the team")
+
+    def test_fk_topology_assumptions_still_hold(self):
+        """AC10: fail loudly if a migration changes the shape of the bug."""
+        self.env.cr.execute("""
+            SELECT 1 FROM pg_constraint c
+              JOIN pg_class r ON c.conrelid = r.oid
+              JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = c.conkey[1]
+             WHERE c.contype = 'u' AND r.relname = 'sports_patient'
+               AND a.attname = 'partner_id'
+        """)
+        self.assertTrue(
+            self.env.cr.fetchone(),
+            "UNIQUE(partner_id) on sports_patient is gone -- core's merge no "
+            "longer takes the DELETE branch and this suite tests nothing. "
+            "Re-derive the guard's justification before deleting these tests.",
+        )
+
+        self.env.cr.execute("""
+            SELECT c.conrelid::regclass::text, c.confdeltype
+              FROM pg_constraint c
+             WHERE c.contype = 'f'
+               AND c.confrelid = 'sports_patient'::regclass
+        """)
+        ondelete = dict(self.env.cr.fetchall())
+        for table in ('sports_patient_injury', 'sports_treatment_note',
+                      'sports_injury_document', 'sports_team_patient_rel'):
+            self.assertEqual(
+                ondelete.get(table), 'c',
+                f"{table} no longer CASCADEs from sports_patient; the blast "
+                f"radius of a raw DELETE has changed -- revisit the guard.",
+            )

--- a/bemade_sports_clinic/tests/test_patient_merge_security.py
+++ b/bemade_sports_clinic/tests/test_patient_merge_security.py
@@ -1,0 +1,188 @@
+"""Merge Players wizard: access control and Law 25 safety rails.
+
+Merging patients is destructive and touches PHI, so it is admin-only, and it
+refuses to touch anonymized records.
+
+ACCEPTANCE CRITERIA
+-------------------
+AC1  A user in group_sports_clinic_admin can run the wizard end to end.
+AC2  A plain group_sports_clinic_user cannot. ir.model.access.csv gives that
+     group perm_unlink=0 on sports.patient, so a merge would fail mid-way with a
+     raw AccessError after partial writes; the wizard must refuse up front
+     instead, leaving nothing half-merged.
+AC3  A treatment professional's access follows the module's existing convention
+     for destructive wizards -- asserted explicitly here so the decision is
+     recorded rather than incidental. TP alone is NOT admin (group_sports_clinic_admin
+     implies TP, not the reverse), so a bare TP is refused.
+AC4  A portal user (group_portal_treatment_professional / group_portal_team_coach)
+     can never reach the wizard, by ACL and by the action's group gate.
+AC5  The wizard's TransientModel has ir.model.access.csv rows. Transient models
+     still need ACLs; a missing row is a silent runtime failure for non-admins.
+AC6  The action bound to the patient list is gated on group_sports_clinic_admin,
+     so the cog entry is not merely hidden but unusable by others.
+AC7  Merging a patient with is_anonymized=True raises. _law25_anonymize scrubs
+     mail history, followers and tracking values (patient.py:278); merging an
+     anonymized record into a live one would relink scrubbed PHI to an
+     identified person and defeat the erasure.
+AC8  AC7 holds regardless of direction: anonymized as SOURCE and anonymized as
+     DESTINATION both raise.
+AC9  The wizard operates with sudo() only where field-level group restrictions
+     require it (date_of_birth, team_info_notes, allergies), and never uses sudo
+     to escape the AC2/AC4 access decisions.
+AC10 A merge that raises for any reason above leaves the database untouched --
+     both patients, all children and all partners still present.
+"""
+
+from odoo import Command
+from odoo.exceptions import AccessError, UserError
+from odoo.tests import TransactionCase, tagged
+from odoo.tools.misc import mute_logger
+
+
+@tagged('post_install', '-at_install')
+class TestPatientMergeSecurity(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.admin_group = cls.env.ref(
+            'bemade_sports_clinic.group_sports_clinic_admin')
+        cls.tp_group = cls.env.ref(
+            'bemade_sports_clinic.group_sports_clinic_treatment_professional')
+        cls.user_group = cls.env.ref(
+            'bemade_sports_clinic.group_sports_clinic_user')
+        cls.env.user.sudo().group_ids = [
+            Command.link(cls.tp_group.id), Command.link(cls.admin_group.id)]
+
+    def _user(self, login, groups):
+        return self.env['res.users'].create({
+            'name': login, 'login': login,
+            'group_ids': [Command.set(
+                [self.env.ref('base.group_user').id] + [g.id for g in groups])],
+        })
+
+    def _patient(self, first_name, **vals):
+        vals.setdefault('last_name', 'Sampleton')
+        vals['first_name'] = first_name
+        return self.env['sports.patient'].create(vals)
+
+    def _wizard(self, patients, dst, user=None):
+        Wizard = self.env['sports.patient.merge.wizard'].with_context(
+            active_ids=patients.ids)
+        values = Wizard.default_get(list(Wizard._fields))
+        values['dst_patient_id'] = dst.id
+        wizard = Wizard.create(values)
+        return wizard.with_user(user) if user else wizard
+
+    def test_clinic_admin_can_merge(self):
+        """AC1."""
+        admin = self._user('merge_admin', [self.admin_group])
+        dst = self._patient('Alexandre')
+        src = self._patient('Alex')
+
+        self._wizard(dst | src, dst, user=admin).action_merge()
+
+        self.assertTrue(dst.exists())
+        self.assertFalse(src.exists())
+
+    @mute_logger('odoo.addons.base.models.ir_model')
+    def test_plain_clinic_user_refused_up_front(self):
+        """AC2, AC10."""
+        plain = self._user('merge_plain', [self.user_group])
+        dst = self._patient('Alexandre')
+        src = self._patient('Alex')
+
+        with self.assertRaises(Exception) as ctx:
+            self._wizard(dst | src, dst, user=plain).action_merge()
+        self.assertIsInstance(ctx.exception, (UserError, AccessError),
+                              'refusal must be a clean access/user error, '
+                              f'got {type(ctx.exception).__name__}')
+
+        self.assertTrue(dst.exists() and src.exists(),
+                        "a refused merge must leave both players intact")
+        self.assertTrue(dst.partner_id.exists() and src.partner_id.exists(),
+                        "a refused merge must not merge any contact")
+
+    @mute_logger('odoo.addons.base.models.ir_model')
+    def test_bare_treatment_professional_refused(self):
+        """AC3: admin implies TP, not the reverse."""
+        tp_user = self._user('merge_tp', [self.tp_group, self.user_group])
+        dst = self._patient('Alexandre')
+        src = self._patient('Alex')
+
+        self.assertFalse(
+            tp_user.has_group('bemade_sports_clinic.group_sports_clinic_admin'),
+            "fixture precondition: a bare TP must not be a clinic admin")
+        with self.assertRaises(Exception) as ctx:
+            self._wizard(dst | src, dst, user=tp_user).action_merge()
+        self.assertIsInstance(ctx.exception, (UserError, AccessError))
+
+        self.assertTrue(src.exists(), "nothing may be merged away")
+
+    def test_wizard_has_acl_rows(self):
+        """AC5: transient models still need ACLs."""
+        for model_name in ('sports.patient.merge.wizard',
+                           'sports.patient.merge.contact.line'):
+            model = self.env['ir.model'].search([('model', '=', model_name)])
+            self.assertTrue(model, f"{model_name} is not registered")
+            acls = self.env['ir.model.access'].search(
+                [('model_id', '=', model.id)])
+            self.assertTrue(
+                acls, f"{model_name} has no ir.model.access rows -- non-admins "
+                      f"would hit a silent runtime failure")
+            self.assertIn(
+                self.admin_group, acls.mapped('group_id'),
+                f"{model_name} must be reachable by clinic admins")
+
+    def test_action_gated_on_admin(self):
+        """AC6."""
+        action = self.env.ref('bemade_sports_clinic.action_sports_patient_merge')
+        self.assertIn(self.admin_group, action.group_ids,
+                      "the Merge Players action must be gated on clinic admin")
+        self.assertEqual(action.binding_model_id.model, 'sports.patient',
+                         "the action must be bound to the Players list")
+
+    def test_anonymized_source_raises(self):
+        """AC7, AC10."""
+        dst = self._patient('Alexandre')
+        src = self._patient('Alex')
+        src.sudo()._law25_anonymize()
+        self.assertTrue(src.sudo().is_anonymized, "fixture must be anonymized")
+
+        with self.assertRaises(UserError):
+            self._wizard(dst | src, dst).action_merge()
+
+        self.assertTrue(src.exists() and dst.exists(),
+                        "an anonymized player must be left untouched")
+
+    def test_anonymized_destination_raises(self):
+        """AC8."""
+        dst = self._patient('Alexandre')
+        src = self._patient('Alex')
+        dst.sudo()._law25_anonymize()
+
+        with self.assertRaises(UserError):
+            self._wizard(dst | src, dst).action_merge()
+
+        self.assertTrue(src.exists() and dst.exists())
+
+    @mute_logger('odoo.addons.base.models.ir_model')
+    def test_failed_merge_leaves_children_untouched(self):
+        """AC10: no partial merge survives a refusal."""
+        plain = self._user('merge_plain2', [self.user_group])
+        dst = self._patient('Alexandre')
+        src = self._patient('Alex')
+        injury = self.env['sports.patient.injury'].create({
+            'patient_id': src.id, 'diagnosis': 'Sprain',
+            'injury_date': '2025-10-09', 'stage': 'active',
+        })
+
+        with self.assertRaises(Exception) as ctx:
+            self._wizard(dst | src, dst, user=plain).action_merge()
+        self.assertIsInstance(ctx.exception, (UserError, AccessError),
+                              'refusal must be a clean access/user error, '
+                              f'got {type(ctx.exception).__name__}')
+
+        self.assertTrue(injury.exists(), "injury must survive a refused merge")
+        self.assertEqual(injury.patient_id, src,
+                         "children must not be repointed by a refused merge")

--- a/bemade_sports_clinic/tests/test_patient_merge_suggestions.py
+++ b/bemade_sports_clinic/tests/test_patient_merge_suggestions.py
@@ -1,0 +1,297 @@
+"""Merge Players wizard: suggesting other contacts to fold into the same merge.
+
+Motivation from the prod incident: the player had THREE contacts but only two
+patients. The third (no patient attached) was a duplicate too. Consolidating the patients alone would have left it behind, and staff would
+have been straight back to the contact-merge workaround that caused the damage.
+
+Policy agreed with the owner (2026-07-15, revised after the restored backup was
+examined): suggest on exact email OR sanitised phone OR same last name -- a match
+on ANY of those surfaces the contact for optional inclusion. Suggestions are
+always user-selected, never auto-included.
+
+The revision is evidence-driven. In the real incident the two patient partners
+carried '514-555-0142' and '+1 514-555-0142' (same number, different formatting,
+which sanitise identically), and the third duplicate contact had NO phone and
+NO email at all. Exact email/phone matching would have found
+nothing and suggested nothing -- leaving staff exactly where they started.
+
+ACCEPTANCE CRITERIA
+-------------------
+AC1  Given the merged patients' partners, the wizard suggests other res.partner
+     records matching on ANY of: exact email, sanitised phone, or same last name.
+AC1b The last-name rule is what catches a duplicate contact carrying no email and
+     no phone -- the case the real incident left behind. Because it is the
+     noisiest rule (common surnames: Tremblay, Gagnon), matches must be presented
+     with enough context to judge (name, email, phone, linked player if any) and
+     must never be pre-ticked.
+AC2  Suggestions EXCLUDE partners already part of the merge (the destination's
+     and the sources' own partners must not be offered back).
+AC3  A partner attached to a DIFFERENT patient is never suggested as a contact to
+     fold in. Doing so would smuggle a patient into the res.partner merge behind
+     the guard's back and re-create the original deletion bug.
+AC3b The user is nonetheless ADVISED when this case arises: such a partner is
+     reported in the wizard as an unmergeable match, naming the player it belongs
+     to, so staff can reconcile (merge those players, or correct the duplicate
+     email/phone) before re-attempting. Silently omitting it would leave staff
+     believing the duplicate was handled, which is how the original workaround
+     started. The advisory must not offer it as a tickable suggestion.
+AC4  Suggestions are opt-in: running the wizard without ticking any leaves every
+     suggested partner untouched and unmerged.
+AC5  Ticked suggestions are merged into the destination's partner in the same
+     transaction as the patient merge.
+AC6  Phone matching compares sanitised values -- '514-555-0142' and
+     '+1 514-555-0142' are the same phone.
+AC7  Empty/false email and phone never match. Two contacts both lacking an email
+     must NOT be suggested for each other -- with false == false matching, a
+     single merge could sweep in hundreds of unrelated contacts.
+AC8  Archived partners are not suggested.
+AC9  Suggestion computation is bounded: it must not scan the whole partner table
+     per patient in a way that degrades on a 10k-contact database.
+"""
+
+from odoo import Command
+from odoo.exceptions import UserError
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged('post_install', '-at_install')
+class TestPatientMergeSuggestions(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env.user.sudo().group_ids = [
+            Command.link(cls.env.ref(
+                'bemade_sports_clinic.group_sports_clinic_treatment_professional').id),
+            Command.link(cls.env.ref(
+                'bemade_sports_clinic.group_sports_clinic_admin').id),
+        ]
+
+    def _patient(self, first_name, last_name='Sampleton', **vals):
+        patient = self.env['sports.patient'].create(
+            dict(vals, first_name=first_name, last_name=last_name))
+        return patient
+
+    def _wizard(self, patients, dst=None):
+        Wizard = self.env['sports.patient.merge.wizard'].with_context(
+            active_ids=patients.ids)
+        values = Wizard.default_get(list(Wizard._fields))
+        values['dst_patient_id'] = (dst or patients[0]).id
+        return Wizard.create(values)
+
+    def _suggested(self, wizard):
+        return wizard.contact_line_ids.filtered(
+            lambda l: not l.blocked_patient_id).partner_id
+
+    def test_suggests_partner_sharing_email(self):
+        """AC1."""
+        dst = self._patient('Alexandre', 'Alpha')
+        src = self._patient('Alex', 'Beta')
+        dst.partner_id.email = 'shared@example.com'
+        dup = self.env['res.partner'].create({
+            'name': 'Unrelated Name', 'email': 'shared@example.com'})
+
+        wizard = self._wizard(dst | src, dst)
+
+        self.assertIn(dup, self._suggested(wizard),
+                      "a contact sharing an email must be suggested")
+
+    def test_suggests_partner_sharing_phone(self):
+        """AC1, AC6: sanitised comparison, the real formatting mismatch."""
+        dst = self._patient('Alexandre', 'Alpha')
+        src = self._patient('Alex', 'Beta')
+        dst.partner_id.phone = '514-555-0142'
+        dup = self.env['res.partner'].create({
+            'name': 'Unrelated Name', 'phone': '+1 514-555-0142'})
+        self.assertEqual(
+            dup.phone_sanitized, dst.partner_id.phone_sanitized,
+            "fixture precondition: both phones must sanitise identically",
+        )
+
+        wizard = self._wizard(dst | src, dst)
+
+        self.assertIn(dup, self._suggested(wizard),
+                      "differently-formatted same phone must be suggested")
+
+    def test_suggests_partner_sharing_last_name(self):
+        """AC1b: the third-contact case -- no email, no phone, same last name."""
+        dst = self._patient('Alexandre')
+        src = self._patient('Alex')
+        dup = self.env['res.partner'].create({'name': 'Alex Sampleton'})
+        self.assertFalse(dup.email or dup.phone,
+                         "fixture must have neither email nor phone")
+
+        wizard = self._wizard(dst | src, dst)
+
+        self.assertIn(dup, self._suggested(wizard),
+                      "a same-last-name contact with no email/phone must be "
+                      "suggested -- this is the contact the real incident left "
+                      "behind")
+
+    def test_suggestions_are_not_pre_ticked(self):
+        """AC1b."""
+        dst = self._patient('Alexandre')
+        src = self._patient('Alex')
+        self.env['res.partner'].create({'name': 'Alex Sampleton'})
+
+        wizard = self._wizard(dst | src, dst)
+
+        self.assertTrue(wizard.contact_line_ids, "fixture must produce lines")
+        self.assertFalse(any(wizard.contact_line_ids.mapped('selected')),
+                         "suggestions must never be pre-ticked")
+
+    def test_merge_participants_not_suggested(self):
+        """AC2."""
+        dst = self._patient('Alexandre')
+        src = self._patient('Alex')
+
+        wizard = self._wizard(dst | src, dst)
+
+        suggested = wizard.contact_line_ids.partner_id
+        self.assertNotIn(dst.partner_id, suggested,
+                         "the destination's own contact must not be offered")
+        self.assertNotIn(src.partner_id, suggested,
+                         "a source's own contact must not be offered")
+
+    def test_partner_of_another_patient_not_suggested(self):
+        """AC3: must not smuggle a patient past the guard."""
+        dst = self._patient('Alexandre')
+        src = self._patient('Alex')
+        other = self._patient('Jonas')  # same last name -> would match
+
+        wizard = self._wizard(dst | src, dst)
+
+        self.assertNotIn(
+            other.partner_id, self._suggested(wizard),
+            "a contact belonging to another player must never be tickable -- "
+            "merging it would delete that player via the core merge",
+        )
+
+    def test_partner_of_another_patient_reported_as_unmergeable(self):
+        """AC3b: advise the user so they can reconcile first."""
+        dst = self._patient('Alexandre')
+        src = self._patient('Alex')
+        other = self._patient('Jonas')
+
+        wizard = self._wizard(dst | src, dst)
+
+        blocked = wizard.contact_line_ids.filtered('blocked_patient_id')
+        self.assertIn(other.partner_id, blocked.partner_id,
+                      "the match must be reported, not silently dropped")
+        self.assertTrue(wizard.has_blocked_contacts)
+        self.assertIn(other.display_name, wizard.blocked_contact_info,
+                      "advisory must name the player it belongs to")
+
+    def test_ticking_a_blocked_contact_is_refused(self):
+        """AC3: defence in depth.
+
+        The view makes a blocked line's tick box readonly, but if one were
+        selected anyway the merge must refuse rather than feed two patients into
+        the contact merge -- the exact shape of the original bug.
+        """
+        dst = self._patient('Alexandre')
+        src = self._patient('Alex')
+        other = self._patient('Jonas')
+
+        wizard = self._wizard(dst | src, dst)
+        blocked = wizard.contact_line_ids.filtered('blocked_patient_id')
+        self.assertTrue(blocked, "fixture must produce a blocked line")
+        blocked.selected = True
+
+        with self.assertRaises(UserError):
+            wizard.action_merge()
+
+        self.assertTrue(other.exists(), "the other player must be untouched")
+        self.assertTrue(other.partner_id.exists())
+        self.assertTrue(src.exists(), "nothing may be half-merged")
+
+    def test_suggestions_are_opt_in(self):
+        """AC4."""
+        dst = self._patient('Alexandre')
+        src = self._patient('Alex')
+        dup = self.env['res.partner'].create({'name': 'Alex Sampleton'})
+
+        self._wizard(dst | src, dst).action_merge()
+
+        self.assertTrue(dup.exists(),
+                        "an unticked suggestion must be left alone")
+
+    def test_ticked_suggestion_merged_into_destination_partner(self):
+        """AC5."""
+        dst = self._patient('Alexandre')
+        src = self._patient('Alex')
+        dup = self.env['res.partner'].create({'name': 'Alex Sampleton'})
+
+        wizard = self._wizard(dst | src, dst)
+        wizard.contact_line_ids.filtered(
+            lambda l: l.partner_id == dup).selected = True
+        wizard.action_merge()
+
+        self.assertFalse(dup.exists(),
+                         "a ticked suggestion must be merged away")
+        self.assertTrue(dst.partner_id.exists())
+
+    def test_blank_email_and_phone_never_match(self):
+        """AC7: the false==false mass-merge trap."""
+        dst = self._patient('Alexandre', 'Alpha')
+        src = self._patient('Alex', 'Beta')
+        self.assertFalse(dst.partner_id.email or dst.partner_id.phone)
+        stranger = self.env['res.partner'].create({'name': 'Totally Unrelated'})
+
+        wizard = self._wizard(dst | src, dst)
+
+        self.assertNotIn(
+            stranger, wizard.contact_line_ids.partner_id,
+            "a contact with no email/phone and a different last name must not "
+            "match -- false == false would sweep in the whole address book",
+        )
+
+    def test_archived_partners_not_suggested(self):
+        """AC8."""
+        dst = self._patient('Alexandre')
+        src = self._patient('Alex')
+        archived = self.env['res.partner'].create({
+            'name': 'Alex Sampleton', 'active': False})
+
+        wizard = self._wizard(dst | src, dst)
+
+        self.assertNotIn(archived, wizard.contact_line_ids.partner_id,
+                         "archived contacts must not be suggested")
+
+    def test_suggestion_lookup_is_a_single_search(self):
+        """AC9: bounded -- ONE search over res.partner, not one per patient.
+
+        Asserted structurally rather than with a query-count ceiling: a loose
+        ceiling passes no matter what, and a tight one breaks on unrelated ORM
+        churn. What matters is that every patient's criteria are OR-ed into a
+        single domain.
+        """
+        patients = self.env['sports.patient']
+        for index in range(5):
+            patients |= self._patient(f'Player{index}', f'Name{index}')
+            patients[-1].partner_id.email = f'p{index}@example.com'
+
+        Wizard = self.env['sports.patient.merge.wizard']
+        domain = Wizard._match_domain(patients)
+
+        searches = []
+        original_search = type(self.env['res.partner']).search
+
+        def counting_search(self_model, args, *a, **kw):
+            searches.append(args)
+            return original_search(self_model, args, *a, **kw)
+
+        self.patch(type(self.env['res.partner']), 'search', counting_search)
+        Wizard._candidate_line_vals(patients)
+
+        self.assertEqual(
+            len(searches), 1,
+            "candidate lookup must issue exactly one res.partner search "
+            f"regardless of patient count, got {len(searches)}",
+        )
+        # All five emails must ride in that one domain.
+        flat = str(domain)
+        for index in range(5):
+            self.assertIn(f'p{index}@example.com', flat,
+                          "every patient's criteria must be OR-ed into the "
+                          "single domain, not searched separately")

--- a/bemade_sports_clinic/tests/test_patient_merge_wizard.py
+++ b/bemade_sports_clinic/tests/test_patient_merge_wizard.py
@@ -1,0 +1,376 @@
+"""Merge Players wizard: consolidating two patients into one.
+
+The route staff actually needed. Merging duplicate CONTACTS was only ever a
+workaround for the absence of this. The wizard consolidates the patients first,
+then delegates the res.partner half to Odoo's core merge wizard -- by which
+point only one patient remains, so the contact-merge guard passes naturally and
+there is no bypass flag or second code path.
+
+ACCEPTANCE CRITERIA
+-------------------
+AC1  Merging 2 patients leaves exactly 1 patient. The destination survives with
+     its id intact (it is the record staff have open and linked to elsewhere).
+AC2  All children repoint to the destination and NONE are lost:
+     injuries (sports.patient.injury), treatment notes (sports.treatment.note),
+     injury documents (sports.injury.document), emergency contacts
+     (sports.patient.contact -- note its patient_id has no ondelete, so a naive
+     unlink orphans them silently rather than failing loudly).
+AC3  Injuries and their dependent notes/documents repoint in ONE transaction.
+     sports.treatment.note._check_injury_patient_match and
+     sports.injury.document._check_injury_belongs_to_patient both assert that
+     injury.patient_id == record.patient_id, so a partial repoint raises.
+AC4  team_ids is the UNION of all merged patients' teams; date_left_last_team is
+     re-derived afterwards via _sync_date_left_last_team (teamless <=> date set).
+AC5  Source patients are unlinked only AFTER their children have moved -- the
+     unlink must never cascade a single clinical record away.
+AC6  The source patients' res.partner records are merged into the destination's
+     partner via base.partner.merge.automatic.wizard; no orphan partners remain.
+AC7  Scalar resolution: destination wins where it has a value; sources fill
+     blanks only. No field the destination left empty is discarded.
+AC8  last_consultation_date takes the MAX across all merged patients, NOT the
+     destination's. It drives the Law 25 retention clock, and taking a stale
+     destination value could prematurely age out a record that was in fact seen
+     more recently.
+AC9  match_status and practice_status move together as a PAIR from the
+     destination. constrain_match_and_practice_status (patient.py:332) allows
+     only (yes,yes), (no,yes), (no,no_contact), (no,no) -- resolving them
+     independently can synthesise an invalid combination such as (yes,no).
+AC10 The merge fires NO outbound notification to followers. last_consultation_date,
+     match_status, practice_status, predicted_return_date and return_date are all
+     in external_tracking_fields (patient.py:10) and email the team on change;
+     merge writes must use tracking_disable.
+AC11 Chatter is preserved: the source patients' mail.message history, activities
+     and followers move to the destination rather than being orphaned by res_id.
+AC12 An audit note is posted on the destination naming each merged-away patient
+     and its id -- the Law 25 trail, and the thing that let us reconstruct the
+     prod incident at all.
+AC13 first_name/last_name resolve from the destination and the surviving
+     partner's name is recomputed through _recompute_name (which threads the
+     patient_update context past the res_partner.write guard at res_partner.py:37).
+AC14 Merging is idempotent-safe: a wizard run over a single patient, or with the
+     destination not among the selected patients, raises rather than no-oping.
+"""
+
+import base64
+
+from odoo import Command
+from odoo.exceptions import UserError
+from odoo.tests import Form, TransactionCase, tagged
+from odoo.tools.misc import mute_logger
+
+
+@tagged('post_install', '-at_install')
+class TestPatientMergeWizard(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env.user.sudo().group_ids = [
+            Command.link(cls.env.ref(
+                'bemade_sports_clinic.group_sports_clinic_treatment_professional').id),
+            Command.link(cls.env.ref(
+                'bemade_sports_clinic.group_sports_clinic_admin').id),
+        ]
+        cls.team_a = cls.env['sports.team'].create({'name': 'Braves Junior AAA'})
+        cls.team_b = cls.env['sports.team'].create({'name': 'Braves Midget'})
+
+    def _patient(self, first_name, **vals):
+        vals.setdefault('last_name', 'Sampleton')
+        vals['first_name'] = first_name
+        return self.env['sports.patient'].create(vals)
+
+    def _merge(self, patients, dst):
+        wizard = self.env['sports.patient.merge.wizard'].with_context(
+            active_ids=patients.ids)
+        values = wizard.default_get(list(wizard._fields))
+        values['dst_patient_id'] = dst.id
+        return wizard.create(values).action_merge()
+
+    def test_merge_leaves_one_patient_destination_survives(self):
+        """AC1."""
+        dst = self._patient('Alexandre')
+        src = self._patient('Alex')
+        dst_id = dst.id
+
+        self._merge(dst | src, dst)
+
+        self.assertTrue(dst.exists(), "destination must survive with its id")
+        self.assertEqual(dst.id, dst_id, "destination id must not change")
+        self.assertFalse(src.exists(), "source patient should be merged away")
+
+    def test_all_children_repoint_to_destination(self):
+        """AC2: injuries, notes, documents, emergency contacts."""
+        dst = self._patient('Alexandre')
+        src = self._patient('Alex')
+        injury = self.env['sports.patient.injury'].create({
+            'patient_id': src.id, 'diagnosis': 'Sprained right shoulder',
+            'injury_date': '2025-10-09', 'stage': 'active',
+        })
+        note = self.env['sports.treatment.note'].create({
+            'patient_id': src.id, 'injury_id': injury.id,
+            'note': 'follow-up imaging required', 'date': '2025-11-06',
+        })
+        doc = self.env['sports.injury.document'].create({
+            'name': 'IRM', 'patient_id': src.id, 'injury_id': injury.id,
+            'file_content': base64.b64encode(b'x'), 'category': 'medical_imaging',
+        })
+        contact = self.env['sports.patient.contact'].create({
+            'patient_id': src.id, 'name': 'Father', 'contact_type': 'father',
+        })
+
+        self._merge(dst | src, dst)
+
+        for record, label in ((injury, 'injury'), (note, 'treatment note'),
+                              (doc, 'document'), (contact, 'emergency contact')):
+            self.assertTrue(record.exists(), f"{label} was destroyed")
+            self.assertEqual(record.patient_id, dst,
+                             f"{label} did not repoint to the destination")
+
+    def test_injury_and_dependents_repoint_atomically(self):
+        """AC3: the constraint that punishes a partial repoint.
+
+        Moving a note before its injury raises ValidationError. This asserts the
+        merge orders them correctly rather than tripping its own constraints.
+        """
+        dst = self._patient('Alexandre')
+        src = self._patient('Alex')
+        injury = self.env['sports.patient.injury'].create({
+            'patient_id': src.id, 'diagnosis': 'Sprain',
+            'injury_date': '2025-10-09', 'stage': 'active',
+        })
+        notes = self.env['sports.treatment.note']
+        for day in ('2025-10-10', '2025-10-11', '2025-10-12'):
+            notes |= self.env['sports.treatment.note'].create({
+                'patient_id': src.id, 'injury_id': injury.id,
+                'note': f'note {day}', 'date': day,
+            })
+
+        self._merge(dst | src, dst)
+
+        self.assertEqual(injury.patient_id, dst)
+        for note in notes:
+            self.assertEqual(note.injury_id.patient_id, note.patient_id,
+                             "note and its injury disagree on the patient")
+
+    def test_team_ids_union_and_date_left_last_team_resync(self):
+        """AC4."""
+        dst = self._patient('Alexandre', team_ids=[Command.set(self.team_a.ids)])
+        src = self._patient('Alex', team_ids=[Command.set(self.team_b.ids)])
+
+        self._merge(dst | src, dst)
+
+        self.assertEqual(dst.team_ids, self.team_a | self.team_b,
+                         "teams should be the union of both players'")
+        self.assertFalse(dst.date_left_last_team,
+                         "a player with teams must not carry a left-team date")
+
+    def test_teamless_merge_stamps_retention_clock(self):
+        """AC4: the teamless <=> date-set invariant holds after merging too."""
+        dst = self._patient('Alexandre')
+        src = self._patient('Alex')
+
+        self._merge(dst | src, dst)
+
+        self.assertTrue(dst.date_left_last_team,
+                        "a teamless player must carry a left-team date")
+
+    def test_sources_unlinked_after_children_moved(self):
+        """AC5: no cascade takes clinical data."""
+        dst = self._patient('Alexandre')
+        src = self._patient('Alex')
+        injury = self.env['sports.patient.injury'].create({
+            'patient_id': src.id, 'diagnosis': 'Sprain',
+            'injury_date': '2025-10-09', 'stage': 'active',
+        })
+        injury_id = injury.id
+
+        self._merge(dst | src, dst)
+
+        self.assertFalse(src.exists(), "source should be gone")
+        self.assertTrue(
+            self.env['sports.patient.injury'].browse(injury_id).exists(),
+            "injury was cascade-deleted with the source patient",
+        )
+
+    def test_source_partners_merged_into_destination_partner(self):
+        """AC6."""
+        dst = self._patient('Alexandre')
+        src = self._patient('Alex')
+        dst_partner, src_partner = dst.partner_id, src.partner_id
+
+        self._merge(dst | src, dst)
+
+        self.assertTrue(dst_partner.exists(), "destination contact must survive")
+        self.assertFalse(src_partner.exists(),
+                         "source contact should be merged away, not orphaned")
+        self.assertEqual(dst.partner_id, dst_partner)
+
+    def test_scalar_destination_wins_sources_fill_blanks(self):
+        """AC7."""
+        dst = self._patient('Alexandre', date_of_birth='2010-03-01')
+        src = self._patient('Alex', date_of_birth='2008-01-01',
+                            return_date='2025-12-01')
+
+        self._merge(dst | src, dst)
+
+        self.assertEqual(str(dst.date_of_birth), '2010-03-01',
+                         "destination value must win where set")
+        self.assertEqual(str(dst.return_date), '2025-12-01',
+                         "source must fill a field the destination left blank")
+
+    def test_last_consultation_date_takes_max(self):
+        """AC8: Law 25 retention clock.
+
+        The real records had exactly this shape: the destination blank, the
+        source consulted on 2025-11-06.
+        """
+        dst = self._patient('Alexandre', last_consultation_date='2025-01-01')
+        src = self._patient('Alex', last_consultation_date='2025-11-06')
+
+        self._merge(dst | src, dst)
+
+        self.assertEqual(
+            str(dst.last_consultation_date), '2025-11-06',
+            "must take the most recent consultation, not the destination's -- "
+            "a stale value prematurely ages out the retention clock",
+        )
+
+    def test_last_consultation_date_max_when_destination_blank(self):
+        """AC8: destination blank is the case that bit prod."""
+        dst = self._patient('Alexandre')
+        src = self._patient('Alex', last_consultation_date='2025-11-06')
+
+        self._merge(dst | src, dst)
+
+        self.assertEqual(str(dst.last_consultation_date), '2025-11-06')
+
+    def test_status_pair_stays_valid(self):
+        """AC9: never synthesise an invalid (match, practice) combination."""
+        dst = self._patient('Alexandre', match_status='no', practice_status='no')
+        src = self._patient('Alex', match_status='yes', practice_status='yes')
+
+        self._merge(dst | src, dst)
+
+        self.assertEqual((dst.match_status, dst.practice_status), ('no', 'no'),
+                         "the destination's status pair must be kept intact")
+        # Would raise ValidationError if the pair were invalid.
+        dst.constrain_match_and_practice_status()
+
+    def test_merge_sends_no_follower_notifications(self):
+        """AC10."""
+        dst = self._patient('Alexandre', team_ids=[Command.set(self.team_a.ids)])
+        src = self._patient('Alex', last_consultation_date='2025-11-06',
+                            team_ids=[Command.set(self.team_b.ids)])
+        before = self.env['mail.mail'].search_count([])
+
+        self._merge(dst | src, dst)
+
+        self.assertEqual(
+            self.env['mail.mail'].search_count([]), before,
+            "the merge queued outbound mail -- external_tracking_fields "
+            "notify the team, so merge writes must be tracking-disabled",
+        )
+
+    def test_chatter_and_followers_move_to_destination(self):
+        """AC11."""
+        dst = self._patient('Alexandre')
+        src = self._patient('Alex')
+        src.message_post(body='historical note', message_type='comment')
+        src_messages = self.env['mail.message'].search([
+            ('model', '=', 'sports.patient'), ('res_id', '=', src.id)])
+        self.assertTrue(src_messages, "fixture must have chatter to move")
+        message_ids = src_messages.ids
+
+        self._merge(dst | src, dst)
+
+        moved = self.env['mail.message'].browse(message_ids)
+        for message in moved:
+            self.assertEqual(message.res_id, dst.id,
+                             "chatter was orphaned instead of moved")
+
+    def test_audit_note_posted_on_destination(self):
+        """AC12."""
+        dst = self._patient('Alexandre')
+        src = self._patient('Alex')
+        src_id, src_name = src.id, src.display_name
+
+        self._merge(dst | src, dst)
+
+        bodies = ' '.join(dst.message_ids.mapped('body'))
+        self.assertIn(str(src_id), bodies,
+                      "audit note must record the merged-away player's id")
+        self.assertIn(src_name.split()[0], bodies,
+                      "audit note must name the merged-away player")
+
+    def test_audit_note_renders_as_html_not_escaped_tags(self):
+        """AC12: the note must READ as prose, not show raw markup.
+
+        Mail bodies escape plain strings -- a str body renders as literal
+        '&lt;p&gt;' text in the chatter. Caught by human testing: substring
+        assertions pass just as happily on escaped markup, so they never saw it.
+        """
+        dst = self._patient('Alexandre')
+        src = self._patient('Alex')
+
+        self._merge(dst | src, dst)
+
+        body = dst.message_ids[0].body
+        self.assertNotIn('&lt;p&gt;', body,
+                         "audit note is escaped -- the user sees raw HTML tags")
+        self.assertNotIn('&lt;ul&gt;', body)
+        self.assertIn('<p>', body, "audit note must contain real markup")
+
+    def test_audit_note_escapes_player_names(self):
+        """AC12: names are user input and must not inject markup."""
+        dst = self._patient('Alexandre')
+        src = self._patient('<b>Bold</b>')
+
+        self._merge(dst | src, dst)
+
+        body = dst.message_ids[0].body
+        self.assertNotIn('<b>Bold</b>', body,
+                         "a player name must not be injected as live markup")
+        self.assertIn('&lt;b&gt;Bold', body, "the name must appear, escaped")
+
+    def test_partner_name_recomputed_from_destination(self):
+        """AC13."""
+        dst = self._patient('Alexandre')
+        src = self._patient('Alex')
+
+        self._merge(dst | src, dst)
+
+        self.assertEqual(dst.first_name, 'Alexandre')
+        self.assertEqual(
+            dst.partner_id.name, 'Alexandre Sampleton',
+            "surviving contact name must match the surviving player's name",
+        )
+
+    @mute_logger('odoo.models.unlink')
+    def test_invalid_selections_raise(self):
+        """AC14."""
+        solo = self._patient('Solo')
+        other = self._patient('Other')
+        outsider = self._patient('Outsider')
+
+        with self.assertRaises(UserError):
+            self.env['sports.patient.merge.wizard'].with_context(
+                active_ids=solo.ids).default_get(['patient_ids'])
+
+        wizard = self.env['sports.patient.merge.wizard'].create({
+            'patient_ids': [Command.set((solo | other).ids)],
+            'dst_patient_id': outsider.id,
+        })
+        with self.assertRaises(UserError):
+            wizard.action_merge()
+
+    def test_wizard_form_view_is_usable(self):
+        """The view must render and save -- catches missing/misnamed fields."""
+        dst = self._patient('Alexandre')
+        src = self._patient('Alex')
+        with Form(self.env['sports.patient.merge.wizard'].with_context(
+                active_ids=(dst | src).ids)) as form:
+            form.dst_patient_id = dst
+        wizard = form.save()
+        self.assertEqual(wizard.patient_ids, dst | src)
+        wizard.action_merge()
+        self.assertFalse(src.exists())

--- a/bemade_sports_clinic/views/patient_merge_wizard_views.xml
+++ b/bemade_sports_clinic/views/patient_merge_wizard_views.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_sports_patient_merge_wizard_form" model="ir.ui.view">
+        <field name="name">sports.patient.merge.wizard.form</field>
+        <field name="model">sports.patient.merge.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Merge Players">
+                <div class="alert alert-warning" role="alert">
+                    Merging combines these players into a single record. The
+                    players you are merging away will be deleted, and their
+                    injuries, treatment notes, documents and history moved to
+                    the player you keep. This cannot be undone.
+                </div>
+                <group>
+                    <field name="patient_ids" widget="many2many_tags"
+                           options="{'no_create': True}" readonly="1"/>
+                    <field name="dst_patient_id"
+                           options="{'no_create': True, 'no_open': True}"/>
+                </group>
+                <field name="has_conflicts" invisible="1"/>
+                <div class="alert alert-info" role="alert"
+                     invisible="not has_conflicts">
+                    <field name="conflict_info" readonly="1" nolabel="1"/>
+                </div>
+                <field name="has_blocked_contacts" invisible="1"/>
+                <div class="alert alert-warning" role="alert"
+                     invisible="not has_blocked_contacts">
+                    <field name="blocked_contact_info" readonly="1" nolabel="1"/>
+                </div>
+                <separator string="Other matching contacts"
+                           invisible="not contact_line_ids"/>
+                <p class="text-muted" invisible="not contact_line_ids">
+                    These contacts look like duplicates of the same person.
+                    Tick any that should be merged into the surviving contact.
+                </p>
+                <field name="contact_line_ids" nolabel="1"
+                       invisible="not contact_line_ids">
+                    <list editable="bottom" create="false" delete="false">
+                        <!-- A contact belonging to another player must never be
+                             tickable: merging it would pull that player's
+                             contact into the merge and destroy them. It is still
+                             listed, with the owning player named, so staff can
+                             reconcile rather than assume it was handled. -->
+                        <field name="selected" string="Merge too"
+                               readonly="blocked_patient_id != False"/>
+                        <field name="partner_id" readonly="1"/>
+                        <field name="partner_email" readonly="1"/>
+                        <field name="partner_phone" readonly="1"/>
+                        <field name="match_reason" readonly="1"/>
+                        <field name="blocked_patient_id" readonly="1"
+                               string="Belongs to player"/>
+                    </list>
+                </field>
+                <footer>
+                    <button name="action_merge" type="object" string="Merge Players"
+                            class="btn-primary"
+                            confirm="Merge these players into one? This cannot be undone."/>
+                    <button string="Cancel" class="btn-secondary" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_sports_patient_merge" model="ir.actions.act_window">
+        <field name="name">Merge Players</field>
+        <field name="res_model">sports.patient.merge.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+        <field name="binding_model_id" ref="model_sports_patient"/>
+        <field name="binding_view_types">list</field>
+        <field name="group_ids"
+               eval="[(4, ref('bemade_sports_clinic.group_sports_clinic_admin'))]"/>
+    </record>
+
+</odoo>


### PR DESCRIPTION
## The bug

Merging duplicate **contacts** silently destroyed the linked **players** in production, taking their injuries and treatment notes with them. The merge reported success.

`sports.patient` declares `UNIQUE(partner_id)`. When several merged contacts each carry a patient, core's `_update_foreign_keys_generic` tries to repoint them all at the destination, violates that constraint, and recovers by issuing a raw:

```sql
DELETE FROM sports_patient WHERE partner_id IN (<src ids>)
```

That bypasses the ORM and `ondelete="restrict"`, and the database then CASCADEs away the patients' injuries, treatment notes, documents and team links.

**Not a 19.0 regression** — the override is byte-identical on 18.0. It survived migration because `test_cov_base_partner_merge` only ever called `_update_values` directly and never exercised `_merge`, so the whole deletion path was untested despite the file looking covered.

## Why both halves ship together

Staff reached for the contact merge *because no patient merge existed* — the chatter shows them hand-copying fields between the two records minutes beforehand. Blocking the contact merge alone would have left them with no route at all.

**Guard** — a contact merge spanning more than one patient raises `UserError` naming the players and pointing at Merge Players. Counted with `active_test=False`: an archived patient still occupies the unique constraint and is just as deletable.

**Wizard** — `sports.patient.merge.wizard` on the Players list, gated on `group_sports_clinic_admin`. It repoints injuries (before their notes/documents, or the injury/patient consistency constraints fire), unions teams, moves chatter, unlinks the sources, then delegates the contacts to core. By then one patient remains, so **the guard passes on its own** — no bypass flag, no second code path.

## Field resolution

| Field | Rule |
|---|---|
| Scalars | Destination wins; sources fill blanks; differences warned |
| `last_consultation_date` | **MAX** — drives the Law 25 retention clock; the destination's was blank in the real case |
| Notes / allergies | Concatenated with provenance, never discarded; identical text deduped |
| `match_status`/`practice_status` | Move as a **pair** — only four combinations are valid |
| `team_ids` | Union, then `date_left_last_team` re-derives |

Anonymized players are refused: merging one would relink erased PHI to an identified person.

Matching contacts are suggested on email, **sanitised** phone, or last name — always opt-in, never pre-ticked. Sanitising matters: the real duplicates carried the same number in two formats, which exact matching misses. Last name matters too: the third duplicate contact had no email and no phone at all. Contacts owned by another player are reported but never tickable, and refused defensively if selected anyway.

All writes are tracking-disabled and the audit note uses `_message_log` with a `Markup` body — five of these fields email followers on change, and a plain `str` body renders as escaped tags in the chatter.

## Tests

**73 tests**, including a regression suite that reproduces the production topology and **fails on the unfixed code** by losing the patients (verified before writing the fix). It also asserts the unique constraint and CASCADEs still exist, so a future migration that changes them fails loudly rather than silently testing nothing.

All fixtures are synthetic. Verified against a neutralized copy of production plus a human test pass on the real duplicate records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)