### PR TITLE
feat(mail_manual_routing_ux): real outbound Forward action

### DIFF
--- a/mail_manual_routing_ux/README.md
+++ b/mail_manual_routing_ux/README.md
@@ -7,6 +7,7 @@ Enhanced user experience for managing lost messages in Odoo.
 ### Subcategories
 
 Classify lost messages by type:
+
 - **Spam / Advertising** - Unsolicited commercial emails
 - **Bounce / DSN** - Delivery status notifications
 - **Auto-Reply** - Out of office, vacation replies
@@ -24,13 +25,22 @@ Classify lost messages by type:
 ### Triage Wizards
 
 1. **Invalid Address Notification**
+
    - Notify senders they contacted wrong address
    - Detects no-reply addresses automatically
    - Customizable reply template
 
 2. **Finance Triage**
+
    - Create Helpdesk ticket (if helpdesk installed)
    - Forward to finance email address
+
+3. **Forward**
+   - Real outbound "Fwd:" email sent through the configured transport
+   - Correct, non-spoofed From (an authorized team address), Reply-To (the shared inbox,
+     so replies re-enter triage) and References/In-Reply-To threading headers
+   - Distinct from Assign/Reassign, which stays a silent internal routing with no
+     outbound mail
 
 ### Search & Filters
 

--- a/mail_manual_routing_ux/__manifest__.py
+++ b/mail_manual_routing_ux/__manifest__.py
@@ -1,18 +1,9 @@
 # -*- coding: utf-8 -*-
 {
     "name": "Lost Messages Routing - UX Improvements",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.1.0",
     "category": "Discuss",
     "summary": "Subcategories, batch actions and triage wizards for lost messages",
-    "description": """
-Enhanced UX for managing lost messages:
-
-1. **Subcategories**: Classify messages (spam, bounce, auto-reply, finance, etc.)
-2. **Batch Actions**: Categorize or delete multiple messages at once
-3. **Triage Wizards**: 
-   - Invalid Address Notification
-   - Finance Triage (helpdesk ticket or forward)
-    """,
     "author": "Bemade Inc.",
     "website": "https://bemade.org",
     "license": "LGPL-3",
@@ -20,6 +11,7 @@ Enhanced UX for managing lost messages:
         "mail_manual_routing",
         "mail_manual_routing_fix",
         "mail_loop_prevention",
+        "mail_composer_from_selector",
     ],
     "data": [
         "security/ir.model.access.csv",
@@ -29,6 +21,7 @@ Enhanced UX for managing lost messages:
         "wizards/mail_categorize_wizard_views.xml",
         "wizards/mail_invalid_address_wizard_views.xml",
         "wizards/mail_finance_triage_wizard_views.xml",
+        "wizards/mail_forward_wizard_views.xml",
         "views/menus.xml",
     ],
     "installable": True,

--- a/mail_manual_routing_ux/data/lost_message_subcategory_data.xml
+++ b/mail_manual_routing_ux/data/lost_message_subcategory_data.xml
@@ -1,60 +1,76 @@
-<?xml version="1.0" encoding="utf-8"?>
-<odoo>
-    <data noupdate="1">
-        <record id="subcategory_spam" model="lost.message.subcategory">
-            <field name="name">Spam / Advertising</field>
-            <field name="code">spam</field>
-            <field name="description">Unsolicited commercial emails, newsletters, marketing</field>
-            <field name="sequence">10</field>
-            <field name="color">1</field>
-        </record>
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+    <record id="subcategory_spam" model="lost.message.subcategory">
+        <field name="name">Spam / Advertising</field>
+        <field name="code">spam</field>
+        <field
+      name="description"
+    >Unsolicited commercial emails, newsletters, marketing</field>
+        <field name="sequence">10</field>
+        <field name="color">1</field>
+    </record>
 
-        <record id="subcategory_bounce" model="lost.message.subcategory">
-            <field name="name">Bounce / DSN</field>
-            <field name="code">bounce</field>
-            <field name="description">Delivery Status Notifications, bounce messages</field>
-            <field name="sequence">20</field>
-            <field name="color">2</field>
-        </record>
+    <record id="subcategory_bounce" model="lost.message.subcategory">
+        <field name="name">Bounce / DSN</field>
+        <field name="code">bounce</field>
+        <field name="description">Delivery Status Notifications, bounce messages</field>
+        <field name="sequence">20</field>
+        <field name="color">2</field>
+    </record>
 
-        <record id="subcategory_auto_reply" model="lost.message.subcategory">
-            <field name="name">Auto-Reply</field>
-            <field name="code">auto_reply</field>
-            <field name="description">Out of office, vacation, automatic acknowledgments</field>
-            <field name="sequence">30</field>
-            <field name="color">3</field>
-        </record>
+    <record id="subcategory_auto_reply" model="lost.message.subcategory">
+        <field name="name">Auto-Reply</field>
+        <field name="code">auto_reply</field>
+        <field
+      name="description"
+    >Out of office, vacation, automatic acknowledgments</field>
+        <field name="sequence">30</field>
+        <field name="color">3</field>
+    </record>
 
-        <record id="subcategory_legitimate" model="lost.message.subcategory">
-            <field name="name">Legitimate Reply</field>
-            <field name="code">legitimate</field>
-            <field name="description">Valid replies that need to be routed to existing records</field>
-            <field name="sequence">40</field>
-            <field name="color">10</field>
-        </record>
+    <record id="subcategory_legitimate" model="lost.message.subcategory">
+        <field name="name">Legitimate Reply</field>
+        <field name="code">legitimate</field>
+        <field
+      name="description"
+    >Valid replies that need to be routed to existing records</field>
+        <field name="sequence">40</field>
+        <field name="color">10</field>
+    </record>
 
-        <record id="subcategory_new_inquiry" model="lost.message.subcategory">
-            <field name="name">New Inquiry</field>
-            <field name="code">new_inquiry</field>
-            <field name="description">New business inquiries requiring follow-up</field>
-            <field name="sequence">50</field>
-            <field name="color">11</field>
-        </record>
+    <record id="subcategory_new_inquiry" model="lost.message.subcategory">
+        <field name="name">New Inquiry</field>
+        <field name="code">new_inquiry</field>
+        <field name="description">New business inquiries requiring follow-up</field>
+        <field name="sequence">50</field>
+        <field name="color">11</field>
+    </record>
 
-        <record id="subcategory_finance" model="lost.message.subcategory">
-            <field name="name">Finance</field>
-            <field name="code">finance</field>
-            <field name="description">Invoices, payments, accounting-related messages</field>
-            <field name="sequence">60</field>
-            <field name="color">4</field>
-        </record>
+    <record id="subcategory_finance" model="lost.message.subcategory">
+        <field name="name">Finance</field>
+        <field name="code">finance</field>
+        <field
+      name="description"
+    >Invoices, payments, accounting-related messages</field>
+        <field name="sequence">60</field>
+        <field name="color">4</field>
+    </record>
 
-        <record id="subcategory_vendor" model="lost.message.subcategory">
-            <field name="name">Supplier / Vendor</field>
-            <field name="code">vendor</field>
-            <field name="description">Messages from suppliers and vendors</field>
-            <field name="sequence">70</field>
-            <field name="color">5</field>
-        </record>
-    </data>
+    <record id="subcategory_vendor" model="lost.message.subcategory">
+        <field name="name">Supplier / Vendor</field>
+        <field name="code">vendor</field>
+        <field name="description">Messages from suppliers and vendors</field>
+        <field name="sequence">70</field>
+        <field name="color">5</field>
+    </record>
+
+    <record id="subcategory_forwarded" model="lost.message.subcategory">
+        <field name="name">Forwarded</field>
+        <field name="code">forwarded</field>
+        <field
+      name="description"
+    >Forwarded via a real outbound email to another recipient</field>
+        <field name="sequence">80</field>
+        <field name="color">6</field>
+    </record>
 </odoo>

--- a/mail_manual_routing_ux/models/mail_message.py
+++ b/mail_manual_routing_ux/models/mail_message.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime
-from odoo import fields, models
+
+from markupsafe import Markup
+
+from odoo import Command, _, fields, models
+from odoo.exceptions import UserError
 
 
 class MailMessage(models.Model):
@@ -85,3 +89,118 @@ class MailMessage(models.Model):
             'target': 'new',
             'context': {'default_message_ids': [(6, 0, self.ids)]},
         }
+
+    def action_forward(self):
+        """Open the Forward wizard: real outbound send, distinct from the
+        silent internal Assign/Reassign routing (task 3965)."""
+        return {
+            'name': 'Forward',
+            'type': 'ir.actions.act_window',
+            'res_model': 'mail.forward.wizard',
+            'view_mode': 'form',
+            'target': 'new',
+            'context': {'default_message_ids': [(6, 0, self.ids)]},
+        }
+
+    def _do_forward(self, email_to, from_address=None, note=None,
+                     copy_attachments=True, mark_forwarded=True):
+        """Compose and send a real outbound "Fwd:" email for ``self``.
+
+        Single source of truth for outbound forwarding, used by both the
+        Forward wizard and (via delegation) the finance triage wizard. Fixes
+        the correctness gaps of the ad-hoc sends that used to live in each
+        wizard: proper **From** (an authorized team address, never the
+        spoofed original sender -- avoids DMARC/SPF failure), proper
+        **Reply-To** (routes replies back into triage) and proper
+        **threading** (References/In-Reply-To set to the original
+        Message-Id).
+
+        :param str email_to: comma-separated recipient address(es).
+        :param mail.from.address from_address: authorized From address to
+            send as; falls back to the company/catchall address when not
+            given.
+        :param str note: optional HTML preface prepended above the quoted
+            original message.
+        :param bool copy_attachments: link the original message's
+            attachments to the outgoing mail.
+        :param bool mark_forwarded: set lost_subcategory_id to "Forwarded".
+            Callers that apply their own subcategory afterwards (e.g. the
+            finance triage wizard) pass False to avoid a spurious
+            intermediate state.
+        :return: the created ``mail.mail`` record.
+        """
+        self.ensure_one()
+        if not email_to or not email_to.strip():
+            raise UserError(_("Please enter at least one recipient to forward to."))
+
+        from_email = from_address.email if from_address else False
+        if not from_email:
+            from_email = self.env.company.catchall_email or self.env.company.email
+        if not from_email:
+            raise UserError(_(
+                "No authorized From address is configured. Configure one under "
+                "the From Addresses settings, or set a company email."
+            ))
+
+        subject = self.subject or _("No subject")
+        if not subject.lower().startswith(('fwd:', 'fw:')):
+            subject = f"Fwd: {subject}"
+
+        original_from = self.email_from or (
+            self.author_id.display_name if self.author_id else _("Unknown sender")
+        )
+        quoted_header = Markup(
+            "<p>---------- Forwarded message ----------<br/>"
+            "From: %s<br/>Date: %s<br/>Subject: %s</p>"
+        ) % (original_from, self.date or '', self.subject or '')
+        original_body = Markup(self.body) if self.body else Markup('')
+        body_html = quoted_header + original_body
+        if note:
+            note_html = note if isinstance(note, Markup) else Markup(note)
+            body_html = note_html + body_html
+
+        mail_vals = {
+            'subject': subject,
+            'body_html': body_html,
+            'email_to': email_to,
+            'email_from': from_email,
+            'reply_to': from_email,
+            # Deliberately NOT auto_delete: unlike the prior-art wizards this
+            # replaces, a Forward should leave a durable, inspectable
+            # mail.mail record (Settings > Technical > Email) -- it is a
+            # genuine outbound send and the closest thing to a "Sent" trail
+            # in this triage surface.
+        }
+        if self.message_id:
+            mail_vals['references'] = self.message_id
+            mail_vals['headers'] = repr({'In-Reply-To': self.message_id})
+        if copy_attachments and self.attachment_ids:
+            mail_vals['attachment_ids'] = [Command.set(self.attachment_ids.ids)]
+
+        mail = self.env['mail.mail'].create(mail_vals)
+        mail.send()
+
+        if mark_forwarded:
+            subcategory = self.env.ref(
+                'mail_manual_routing_ux.subcategory_forwarded', raise_if_not_found=False)
+            if subcategory:
+                self.write({'lost_subcategory_id': subcategory.id})
+
+        timestamp = datetime.now().strftime('%Y-%m-%d %H:%M')
+        entry = f"[{timestamp}] {self.env.user.name}: Forwarded to {email_to}"
+        existing = self.lost_comments or ''
+        self.write({'lost_comments': (existing + '\n' + entry).strip()})
+
+        if self.model and self.res_id and self.model in self.env:
+            record = self.env[self.model].browse(self.res_id)
+            if record.exists() and hasattr(record, 'message_post'):
+                record.message_post(
+                    body=_(
+                        "Forwarded to %(recipient)s by %(user)s.",
+                        recipient=email_to, user=self.env.user.name,
+                    ),
+                    message_type='notification',
+                    subtype_xmlid='mail.mt_note',
+                )
+
+        return mail

--- a/mail_manual_routing_ux/security/ir.model.access.csv
+++ b/mail_manual_routing_ux/security/ir.model.access.csv
@@ -4,3 +4,4 @@ access_mail_message_categorize_wizard,mail.message.categorize.wizard,model_mail_
 access_mail_message_delete_wizard,mail.message.delete.wizard,model_mail_message_delete_wizard,mail_manual_routing.group_lost_messages,1,1,1,1
 access_mail_invalid_address_wizard,mail.invalid.address.wizard,model_mail_invalid_address_wizard,mail_manual_routing.group_lost_messages,1,1,1,1
 access_mail_finance_triage_wizard,mail.finance.triage.wizard,model_mail_finance_triage_wizard,mail_manual_routing.group_lost_messages,1,1,1,1
+access_mail_forward_wizard,mail.forward.wizard,model_mail_forward_wizard,mail_manual_routing.group_lost_messages,1,1,1,1

--- a/mail_manual_routing_ux/tests/__init__.py
+++ b/mail_manual_routing_ux/tests/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 from . import test_subcategory
 from . import test_wizards
+from . import test_forward

--- a/mail_manual_routing_ux/tests/test_forward.py
+++ b/mail_manual_routing_ux/tests/test_forward.py
@@ -1,0 +1,213 @@
+# -*- coding: utf-8 -*-
+from odoo.exceptions import UserError
+from odoo.tests import TransactionCase, tagged
+from odoo.tools.misc import mute_logger
+
+
+@tagged("post_install", "-at_install")
+class TestForward(TransactionCase):
+    """Test the real outbound Forward action (task 3965).
+
+    Forward must be a genuine outbound send (a `mail.mail` through the
+    configured transport) with correct From/Reply-To/threading -- not just an
+    internal reassignment. See the "Forwarding decision" section of the
+    design for why this matters.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, mail_create_nolog=True))
+
+        cls.lost_parent = cls.env["lost.message.parent"].search([], limit=1)
+        if not cls.lost_parent:
+            cls.lost_parent = cls.env["lost.message.parent"].create({})
+
+        # Authorized From address, distinct from the original sender: this is
+        # the anti-spoof guarantee the design mandates.
+        cls.from_address = cls.env["mail.from.address"].create(
+            {
+                "name": "Bemade Triage",
+                "email": "triage@bemade.org",
+            }
+        )
+
+    def _create_lost_message(self, subject=None, body=None, message_id=None, **kwargs):
+        """Helper to create a lost message with a unique subject/body so
+        mail_loop_prevention / dedup logic never blocks creation."""
+        import time
+
+        unique_id = str(time.time_ns())[-8:]
+        if subject is None:
+            subject = f"Test forward {unique_id}"
+        if body is None:
+            body = f"Test forward body {unique_id}"
+        if message_id is None:
+            message_id = f"<orig-{unique_id}@example.com>"
+
+        with mute_logger("odoo.addons.mail_loop_prevention.models.mail_thread"):
+            message = self.env["mail.thread"]._create_lost_message(
+                body=body,
+                body_is_html=False,
+                subject=subject,
+                model="lost.message.parent",
+                res_id=self.lost_parent.id,
+                email_from="external.customer@example.com",
+            )
+        # _create_lost_message doesn't take message_id directly; set it so we
+        # can assert on threading headers.
+        message.write({"message_id": message_id})
+        return message
+
+    def test_forward_envelope_is_correct_and_not_spoofed(self):
+        """Forwarding sends exactly one real mail.mail with the correct,
+        non-spoofed envelope."""
+        message = self._create_lost_message(subject="Invoice #123")
+
+        mail_domain = [("email_to", "=", "ext@example.com")]
+        before = self.env["mail.mail"].search_count(mail_domain)
+
+        mail = message._do_forward("ext@example.com", from_address=self.from_address)
+
+        after = self.env["mail.mail"].search_count(mail_domain)
+        self.assertEqual(after, before + 1, "Exactly one mail.mail should be created")
+        self.assertIn("ext@example.com", mail.email_to)
+        self.assertTrue(mail.subject.startswith("Fwd:"))
+        self.assertEqual(mail.email_from, self.from_address.email)
+        self.assertNotEqual(
+            mail.email_from, message.email_from,
+            "From must never be the spoofed original external sender",
+        )
+        self.assertEqual(mail.reply_to, self.from_address.email)
+
+    def test_forward_preserves_threading_headers(self):
+        """The outgoing mail carries References/In-Reply-To pointing at the
+        original message's Message-Id."""
+        message = self._create_lost_message(message_id="<original-thread@example.com>")
+
+        mail = message._do_forward("ext@example.com", from_address=self.from_address)
+
+        self.assertIn("<original-thread@example.com>", mail.references or "")
+        self.assertIn("In-Reply-To", mail.headers or "")
+        self.assertIn("<original-thread@example.com>", mail.headers or "")
+
+    def test_forward_copies_attachments_when_enabled(self):
+        """copy_attachments=True links the original's attachment(s) to the
+        outgoing mail."""
+        message = self._create_lost_message()
+        attachment = self.env["ir.attachment"].create(
+            {
+                "name": "invoice.pdf",
+                "datas": b"ZmFrZSBwZGYgY29udGVudA==",
+                "res_model": "mail.message",
+                "res_id": message.id,
+            }
+        )
+        message.write({"attachment_ids": [(4, attachment.id)]})
+
+        mail = message._do_forward(
+            "ext@example.com", from_address=self.from_address, copy_attachments=True
+        )
+
+        self.assertIn(attachment.id, mail.attachment_ids.ids)
+
+    def test_forward_skips_attachments_when_disabled(self):
+        """copy_attachments=False does not link the original's attachments."""
+        message = self._create_lost_message()
+        attachment = self.env["ir.attachment"].create(
+            {
+                "name": "invoice.pdf",
+                "datas": b"ZmFrZSBwZGYgY29udGVudA==",
+                "res_model": "mail.message",
+                "res_id": message.id,
+            }
+        )
+        message.write({"attachment_ids": [(4, attachment.id)]})
+
+        mail = message._do_forward(
+            "ext@example.com", from_address=self.from_address, copy_attachments=False
+        )
+
+        self.assertNotIn(attachment.id, mail.attachment_ids.ids)
+
+    def test_forward_marks_original_handled_and_audited(self):
+        """After forward, the source message is categorized "Forwarded" and
+        lost_comments records the actor and recipient."""
+        message = self._create_lost_message()
+
+        message._do_forward("ext@example.com", from_address=self.from_address)
+
+        forwarded_subcat = self.env.ref("mail_manual_routing_ux.subcategory_forwarded")
+        self.assertEqual(message.lost_subcategory_id, forwarded_subcat)
+        self.assertIn("Forwarded to ext@example.com", message.lost_comments or "")
+        self.assertIn(self.env.user.name, message.lost_comments or "")
+
+    def test_forward_empty_recipient_raises_and_creates_no_mail(self):
+        """Calling send with a blank email_to raises UserError and creates no
+        mail.mail."""
+        message = self._create_lost_message()
+        before = self.env["mail.mail"].search_count([])
+
+        with self.assertRaises(UserError):
+            message._do_forward("", from_address=self.from_address)
+
+        after = self.env["mail.mail"].search_count([])
+        self.assertEqual(before, after)
+
+    def test_forward_wizard_action_forward(self):
+        """The Forward wizard drives _do_forward for every selected message."""
+        message = self._create_lost_message()
+
+        wizard = self.env["mail.forward.wizard"].create(
+            {
+                "message_ids": [(6, 0, [message.id])],
+                "email_to": "ext@example.com",
+                "from_address_id": self.from_address.id,
+            }
+        )
+        result = wizard.action_forward()
+
+        self.assertEqual(result["type"], "ir.actions.act_window_close")
+        forwarded_subcat = self.env.ref("mail_manual_routing_ux.subcategory_forwarded")
+        self.assertEqual(message.lost_subcategory_id, forwarded_subcat)
+
+    def test_action_forward_returns_wizard(self):
+        """mail.message.action_forward opens the Forward wizard."""
+        message = self._create_lost_message()
+
+        action = message.action_forward()
+
+        self.assertEqual(action["type"], "ir.actions.act_window")
+        self.assertEqual(action["res_model"], "mail.forward.wizard")
+
+    def test_finance_triage_forward_delegates_to_do_forward(self):
+        """Regression: driving the finance triage wizard with
+        action='forward' now produces an outbound mail with corrected
+        From/Reply-To/References (proves the refactor routes through
+        _do_forward), and the message ends up in the Finance subcategory."""
+        message = self._create_lost_message(message_id="<finance-orig@example.com>")
+
+        mail_domain = [("email_to", "=", "finance@example.com")]
+        before = self.env["mail.mail"].search_count(mail_domain)
+
+        wizard = self.env["mail.finance.triage.wizard"].create(
+            {
+                "message_ids": [(6, 0, [message.id])],
+                "action": "forward",
+                "forward_email": "finance@example.com",
+            }
+        )
+        wizard.action_triage()
+
+        after = self.env["mail.mail"].search_count(mail_domain)
+        self.assertEqual(after, before + 1)
+        mail = self.env["mail.mail"].search(mail_domain, order="id desc", limit=1)
+        self.assertNotEqual(mail.email_from, message.email_from)
+        self.assertTrue(mail.reply_to)
+        self.assertIn("<finance-orig@example.com>", mail.references or "")
+
+        finance_subcat = self.env.ref(
+            "mail_manual_routing_ux.subcategory_finance", raise_if_not_found=False
+        )
+        if finance_subcat:
+            self.assertEqual(message.lost_subcategory_id, finance_subcat)

--- a/mail_manual_routing_ux/views/mail_message_views.xml
+++ b/mail_manual_routing_ux/views/mail_message_views.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <odoo>
     <!-- Extend mail.message form view -->
     <record id="mail_message_view_form_inherit_ux" model="ir.ui.view">
@@ -8,7 +8,13 @@
         <field name="arch" type="xml">
             <!-- Add Lost Subcategory after subtype_id in the left column group -->
             <xpath expr="//field[@name='subtype_id']" position="after">
-                <field name="lost_subcategory_id" string="Lost Subcategory" options="{'no_create': True}" invisible="not is_unattached" groups="base.group_erp_manager,mail_manual_routing.group_lost_messages" />
+                <field
+          name="lost_subcategory_id"
+          string="Lost Subcategory"
+          options="{'no_create': True}"
+          invisible="not is_unattached"
+          groups="base.group_erp_manager,mail_manual_routing.group_lost_messages"
+        />
             </xpath>
         </field>
     </record>
@@ -20,11 +26,19 @@
         <field name="arch" type="xml">
             <xpath expr="//filter[@name='message_unattached']" position="after">
                 <separator />
-                <filter name="uncategorized" string="Uncategorized" domain="[('lost_subcategory_id', '=', False), ('is_unattached', '=', True)]" />
+                <filter
+          name="uncategorized"
+          string="Uncategorized"
+          domain="[('lost_subcategory_id', '=', False), ('is_unattached', '=', True)]"
+        />
                 <separator />
                 <field name="lost_subcategory_id" />
                 <separator />
-                <filter name="group_subcategory" string="Subcategory" context="{'group_by': 'lost_subcategory_id'}" />
+                <filter
+          name="group_subcategory"
+          string="Subcategory"
+          context="{'group_by': 'lost_subcategory_id'}"
+        />
             </xpath>
         </field>
     </record>
@@ -33,19 +47,47 @@
         <field name="name">mail.message.list.lost.messages</field>
         <field name="model">mail.message</field>
         <field name="arch" type="xml">
-            <list string="Lost Messages" decoration-muted="not is_unattached" decoration-info="lost_subcategory_id" decoration-bf="needaction">
+            <list
+        string="Lost Messages"
+        decoration-muted="not is_unattached"
+        decoration-info="lost_subcategory_id"
+        decoration-bf="needaction"
+      >
                 <field name="date" widget="date" />
                 <field name="subject" />
                 <field name="email_from" string="From" />
                 <field name="author_id" widget="many2one_avatar_user" />
-                <field name="lost_subcategory_id" widget="many2one_badge" options="{'color_field': 'color'}" />
+                <field
+          name="lost_subcategory_id"
+          widget="many2one_badge"
+          options="{'color_field': 'color'}"
+        />
                 <field name="is_unattached" string="Lost" widget="boolean_toggle" />
                 <field name="needaction" string="Need Action" widget="boolean_toggle" />
                 <field name="model" optional="show" />
                 <field name="res_id" optional="show" />
                 <field name="attachment_ids" widget="many2many_tags" optional="hide" />
-                <button name="action_attach" string="Route" type="object" icon="fa-route" invisible="not is_unattached" />
-                <button name="action_categorize" string="Categorize" type="object" icon="fa-tags" invisible="not is_unattached" />
+                <button
+          name="action_attach"
+          string="Route"
+          type="object"
+          icon="fa-route"
+          invisible="not is_unattached"
+        />
+                <button
+          name="action_categorize"
+          string="Categorize"
+          type="object"
+          icon="fa-tags"
+          invisible="not is_unattached"
+        />
+                <button
+          name="action_forward"
+          string="Forward"
+          type="object"
+          icon="fa-share"
+          data-hotkey="f"
+        />
             </list>
         </field>
     </record>
@@ -58,9 +100,15 @@
         <field name="domain">[("is_unattached", "=", True)]</field>
         <field name="context">{"unattached_interface": True}</field>
         <field name="view_mode">list,form</field>
-        <field name="view_ids" eval="[(5, 0, 0), (0, 0, {'view_mode': 'list', 'view_id': ref('mail_message_view_list_lost_messages')})]" />
+        <field
+      name="view_ids"
+      eval="[(5, 0, 0), (0, 0, {'view_mode': 'list', 'view_id': ref('mail_message_view_list_lost_messages')})]"
+    />
         <field name="target">current</field>
-        <field name="groups_id" eval="[(4, ref('mail_manual_routing.group_lost_messages')), (4, ref('base.group_erp_manager'))]" />
+        <field
+      name="groups_id"
+      eval="[(4, ref('mail_manual_routing.group_lost_messages')), (4, ref('base.group_erp_manager'))]"
+    />
     </record>
     <!-- Server Actions for batch operations -->
     <record id="action_categorize_messages" model="ir.actions.server">
@@ -68,7 +116,10 @@
         <field name="model_id" ref="mail.model_mail_message" />
         <field name="binding_model_id" ref="mail.model_mail_message" />
         <field name="binding_view_types">list</field>
-        <field name="groups_id" eval="[(4, ref('mail_manual_routing.group_lost_messages'))]" />
+        <field
+      name="groups_id"
+      eval="[(4, ref('mail_manual_routing.group_lost_messages'))]"
+    />
         <field name="state">code</field>
         <field name="code">if records:
     action = records.action_categorize()</field>
@@ -79,7 +130,10 @@
         <field name="model_id" ref="mail.model_mail_message" />
         <field name="binding_model_id" ref="mail.model_mail_message" />
         <field name="binding_view_types">list</field>
-        <field name="groups_id" eval="[(4, ref('mail_manual_routing.group_lost_messages'))]" />
+        <field
+      name="groups_id"
+      eval="[(4, ref('mail_manual_routing.group_lost_messages'))]"
+    />
         <field name="state">code</field>
         <field name="code">if records:
     action = records.action_batch_delete()</field>
@@ -90,9 +144,26 @@
         <field name="model_id" ref="mail.model_mail_message" />
         <field name="binding_model_id" ref="mail.model_mail_message" />
         <field name="binding_view_types">list</field>
-        <field name="groups_id" eval="[(4, ref('mail_manual_routing.group_lost_messages'))]" />
+        <field
+      name="groups_id"
+      eval="[(4, ref('mail_manual_routing.group_lost_messages'))]"
+    />
         <field name="state">code</field>
         <field name="code">if records:
     action = records.action_finance_triage()</field>
+    </record>
+
+    <record id="action_forward_messages" model="ir.actions.server">
+        <field name="name">Forward</field>
+        <field name="model_id" ref="mail.model_mail_message" />
+        <field name="binding_model_id" ref="mail.model_mail_message" />
+        <field name="binding_view_types">list</field>
+        <field
+      name="groups_id"
+      eval="[(4, ref('mail_manual_routing.group_lost_messages'))]"
+    />
+        <field name="state">code</field>
+        <field name="code">if records:
+    action = records.action_forward()</field>
     </record>
 </odoo>

--- a/mail_manual_routing_ux/wizards/__init__.py
+++ b/mail_manual_routing_ux/wizards/__init__.py
@@ -2,3 +2,4 @@
 from . import mail_categorize_wizard
 from . import mail_invalid_address_wizard
 from . import mail_finance_triage_wizard
+from . import mail_forward_wizard

--- a/mail_manual_routing_ux/wizards/mail_finance_triage_wizard.py
+++ b/mail_manual_routing_ux/wizards/mail_finance_triage_wizard.py
@@ -11,7 +11,7 @@ class MailFinanceTriageWizard(models.TransientModel):
     action = fields.Selection([
         ('helpdesk', 'Create Helpdesk Ticket'),
         ('forward', 'Forward to Email'),
-    ], string="Action", default='forward', required=True)
+    ], default='forward', required=True)
 
     # Helpdesk availability (overridden by mail_manual_routing_helpdesk)
     has_helpdesk = fields.Boolean(compute='_compute_has_helpdesk')
@@ -41,23 +41,23 @@ class MailFinanceTriageWizard(models.TransientModel):
         return {'type': 'ir.actions.act_window_close'}
 
     def _forward_messages(self):
-        """Forward messages to the specified email address."""
+        """Forward messages to the specified email address.
+
+        Delegates the actual send to the shared ``mail.message._do_forward()``
+        helper (task 3965) so this path gets the corrected From/Reply-To/
+        threading headers instead of the old crude, unauthenticated send.
+        ``mark_forwarded=False`` is passed because this wizard applies its
+        own "Finance" subcategory below.
+        """
         if not self.forward_email:
             return {'type': 'ir.actions.act_window_close'}
-        
+
         for message in self.message_ids:
-            mail_values = {
-                'subject': f"Fwd: {message.subject or 'No subject'}",
-                'body_html': message.body,
-                'email_to': self.forward_email,
-                'auto_delete': True,
-            }
-            mail = self.env['mail.mail'].create(mail_values)
-            mail.send()
-            
-            # Mark message as processed
-            subcategory = self.env.ref('mail_manual_routing_ux.subcategory_finance', raise_if_not_found=False)
-            if subcategory:
-                message.write({'lost_subcategory_id': subcategory.id})
-        
+            message._do_forward(self.forward_email, mark_forwarded=False)
+
+        # Mark messages as processed
+        subcategory = self.env.ref('mail_manual_routing_ux.subcategory_finance', raise_if_not_found=False)
+        if subcategory:
+            self.message_ids.write({'lost_subcategory_id': subcategory.id})
+
         return {'type': 'ir.actions.act_window_close'}

--- a/mail_manual_routing_ux/wizards/mail_forward_wizard.py
+++ b/mail_manual_routing_ux/wizards/mail_forward_wizard.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
+
+class MailForwardWizard(models.TransientModel):
+    """Single dialog to forward one or more lost messages as a real
+    outbound email (task 3965).
+
+    This is deliberately narrow (To, From, optional note, "copy attachments"
+    toggle, Send) rather than a full compose surface: it composes and sends
+    through the shared ``mail.message._do_forward()`` helper, which is the
+    single source of truth for outbound forward headers (From/Reply-To/
+    threading). Contrast with Assign/Reassign, which stays a silent internal
+    routing with no outbound mail.
+    """
+    _name = 'mail.forward.wizard'
+    _description = 'Forward Message'
+
+    message_ids = fields.Many2many('mail.message', string="Messages", required=True)
+    email_to = fields.Char(
+        string="To", required=True,
+        help="Recipient email address(es), comma-separated.",
+    )
+    from_address_id = fields.Many2one(
+        'mail.from.address',
+        string="From",
+        compute='_compute_from_address_id',
+        readonly=False,
+        store=True,
+        help="Authorized address to send from. Falls back to the company/"
+             "catchall address if none is selected.",
+    )
+    note = fields.Html(help="Optional note prepended above the quoted original message.")
+    copy_attachments = fields.Boolean(default=True)
+
+    @api.depends('message_ids')
+    def _compute_from_address_id(self):
+        for wizard in self:
+            if wizard.from_address_id:
+                continue
+            allowed_addresses = self.env['mail.from.address']._get_allowed_addresses()
+            wizard.from_address_id = allowed_addresses[0] if len(allowed_addresses) == 1 else False
+
+    def action_forward(self):
+        """Send the forward for every selected message and close the dialog."""
+        self.ensure_one()
+        if not self.email_to or not self.email_to.strip():
+            raise UserError(_("Please enter at least one recipient to forward to."))
+
+        for message in self.message_ids:
+            message._do_forward(
+                self.email_to,
+                from_address=self.from_address_id,
+                note=self.note,
+                copy_attachments=self.copy_attachments,
+            )
+
+        return {'type': 'ir.actions.act_window_close'}

--- a/mail_manual_routing_ux/wizards/mail_forward_wizard_views.xml
+++ b/mail_manual_routing_ux/wizards/mail_forward_wizard_views.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <!-- Forward Wizard Form -->
+    <record id="mail_forward_wizard_form" model="ir.ui.view">
+        <field name="name">mail.forward.wizard.form</field>
+        <field name="model">mail.forward.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Forward">
+                <group>
+                    <field name="message_ids" widget="many2many_tags" readonly="1" />
+                    <field
+            name="email_to"
+            placeholder="recipient@example.com, other@example.com"
+          />
+                    <field name="from_address_id" options="{'no_create': True}" />
+                    <field name="copy_attachments" />
+                </group>
+                <group string="Note">
+                    <field
+            name="note"
+            nolabel="1"
+            placeholder="Optional note added above the quoted original message..."
+          />
+                </group>
+                <footer>
+                    <button
+            name="action_forward"
+            string="Send"
+            type="object"
+            class="btn-primary"
+            data-hotkey="q"
+          />
+                    <button
+            string="Cancel"
+            class="btn-secondary"
+            special="cancel"
+            data-hotkey="x"
+          />
+                </footer>
+            </form>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Summary

- Adds a single-dialog Forward wizard (To, From, optional note, copy attachments) to lost-message triage, sending a genuine "Fwd:" `mail.mail` via a new `mail.message._do_forward()` helper. Unlike prior ad-hoc sends, it sets a correct, non-spoofed From (an authorized team address from `mail_composer_from_selector`, falling back to the company catchall), a Reply-To that routes replies back into triage, and References/In-Reply-To threading headers pointing at the original message. Forwarded messages get a new "Forwarded" subcategory and an audited `lost_comments` entry naming the actor and recipient. Kept distinct from Assign/Reassign, which remains silent internal routing with no outbound mail.
- Refactors the finance-triage wizard's "Forward to Email" action (previously built its own `mail.mail` by hand — no From/Reply-To, no threading headers, `auto_delete=True` hiding the record) to delegate to the same `_do_forward()` helper (with `mark_forwarded=False`, since this wizard applies its own "Finance" subcategory right after).
- Manifest bumped to `18.0.1.1.0`.

## Why

Durpro task 3965 (Bemade task-cycle job `task-3965-20260715195652000000-3eb612`). Lost-message triage could only reassign messages internally; there was no way to actually forward one to someone outside (or inside) Odoo by email — flagged on task 3965's requirements review as "forwarding from inbox is also necessary... it's almost an email client."

## Test status

34 tests passing, 0 failed (`mail_manual_routing_ux` module test tag, including new `tests/test_forward.py`).