### PR TITLE
[bemade_sports_clinic] #1260: unify portal + internal player-removal permissions (19.0.1.7.1)

### DIFF
--- a/bemade_sports_clinic/__manifest__.py
+++ b/bemade_sports_clinic/__manifest__.py
@@ -18,7 +18,7 @@
 #
 {
     'name': 'Sports Clinic Management',
-    'version': "19.0.1.7.0",
+    'version': "19.0.1.7.1",
     'summary': 'Comprehensive sports medicine clinic management with portal access and activity tracking.',
     'description': """
 Sports Clinic Management System

--- a/bemade_sports_clinic/controllers/access_control_mixin.py
+++ b/bemade_sports_clinic/controllers/access_control_mixin.py
@@ -261,27 +261,14 @@ class AccessControlMixin:
             
         return team
     
-    def _check_team_staff_access(self, team):
-        """
-        Check if the current user is a staff member of the team.
-        
-        :param team: Team record to check staff access for
-        :return: Staff records if user is team staff, empty recordset otherwise
-        """
-        user = request.env.user
-        return team.staff_ids.filtered(
-            lambda s: user.partner_id in s.user_ids.partner_id
-        )
-    
-    def _check_treatment_professional_access(self):
-        """
-        Check if the current user is a treatment professional.
-        
-        :return: True if user is a treatment professional or system admin
-        """
-        return (request.env.user.has_group('bemade_sports_clinic.group_portal_treatment_professional') or 
-                request.env.user.has_group('base.group_system'))
-    
+    # NOTE: _check_team_staff_access and _check_treatment_professional_access
+    # were removed in task 1260. They existed ONLY to gate the portal
+    # remove-player route, and their union was LOOSER than the model's removal
+    # policy (any staff role could remove; the portal TP check ignored which
+    # team). That route now calls the model's remove_from_team, whose single
+    # _may_remove_from_team predicate is the one source of truth. Do not
+    # reintroduce a portal-local removal check — it will drift from the model.
+
     def _check_access_to_patient(self, patient_id):
         """
         Verify the user has access to this patient.

--- a/bemade_sports_clinic/controllers/team_management_portal.py
+++ b/bemade_sports_clinic/controllers/team_management_portal.py
@@ -273,6 +273,10 @@ class TeamManagementPortal(CustomerPortal, AccessControlMixin):
                 'user_has_group': request.env.user.has_group,  # Pass the has_group method to template
                 'user': request.env.user,
                 'is_treatment_prof': is_treatment_prof or is_admin,
+                # Whether THIS viewer may action removals on this team (task 1260):
+                # gates the pending-removals alert so it shows only to those who can
+                # actually review/remove, not to any portal TP (e.g. a doctor).
+                'can_remove_on_team': request.env['sports.patient']._may_remove_from_team(team),
                 'is_team_staff': bool(is_team_staff),
                 # Activities tab context
                 'can_view_activities': can_use_activities,

--- a/bemade_sports_clinic/controllers/team_management_portal.py
+++ b/bemade_sports_clinic/controllers/team_management_portal.py
@@ -67,28 +67,33 @@ class TeamManagementPortal(CustomerPortal, AccessControlMixin):
     def portal_remove_player(self, team_id, player_id, **post):
         """
         Directly remove a player from the team.
-        Only accessible by treatment professionals or team staff.
+
+        Removal authority is the SAME policy the internal path enforces: the
+        team's therapist or head therapist (either TP group), or a system admin
+        (task 1260). Coaches and doctors use the Request Removal flow instead.
+        The permission check lives in the model (``remove_from_team`` ->
+        ``_may_remove_from_team``), NOT here, so the portal and internal paths
+        cannot diverge.
         """
         try:
+            # _check_team_access is VISIBILITY only (can this user see the team
+            # at all) — a separate concern from removal AUTHORITY, which the
+            # model check below enforces.
             team = self._check_team_access(team_id)
-            
-            # Only treatment professionals or team staff can directly remove
-            if not (self._check_treatment_professional_access() or self._check_team_staff_access(team)):
-                raise AccessError(_("You don't have permission to remove players from this team."))
-                
+
             patient = request.env['sports.patient'].browse(int(player_id))
             if not patient.exists():
                 raise MissingError(_("Player not found"))
-                
+
             if team not in patient.team_ids:
                 raise ValidationError(_("Player is not a member of this team"))
-                
-            # Check if this is a pending removal that's being approved
-            is_approving_pending = patient.pending_removal and self._check_treatment_professional_access()
-                
-            # Process removal with the appropriate action - no sudo needed as remove_from_team has built-in permission checks
-            result = patient._remove_from_team(team.id, clear_pending=True)
-            
+
+            # Route through the PUBLIC remove_from_team so the built-in
+            # permission check actually runs (the old code called the private
+            # _remove_from_team, which skips every check — the 1260 gap). No
+            # sudo: the model check must see the real user.
+            result = patient.remove_from_team(team.id, clear_pending=True)
+
             # Store success message in session for display after redirect
             request.session['notification'] = {
                 'type': 'success',
@@ -97,6 +102,24 @@ class TeamManagementPortal(CustomerPortal, AccessControlMixin):
                 'sticky': False,
             }
 
+            return request.redirect(f"/my/team/{team_id}")
+
+        except AccessError as e:
+            # A coach or doctor (or a TP who is not a therapist on THIS team)
+            # is not allowed to remove directly — point them at Request Removal
+            # rather than showing the generic failure text (task 1260). The
+            # model's AccessError message already names the request flow.
+            _logger.info("Portal player removal denied: %s", str(e))
+            request.session['notification'] = {
+                'type': 'warning',
+                'title': _('Removal Not Permitted'),
+                'message': _(
+                    "You don't have permission to remove players from this team "
+                    "directly. Please use the 'Request Removal' action instead — "
+                    "it notifies the team's head therapist."
+                ),
+                'sticky': False,
+            }
             return request.redirect(f"/my/team/{team_id}")
 
         except Exception as e:

--- a/bemade_sports_clinic/controllers/team_staff_portal.py
+++ b/bemade_sports_clinic/controllers/team_staff_portal.py
@@ -407,8 +407,25 @@ class TeamStaffPortal(CustomerPortal, AccessControlMixin):
             if sole_team_id and sole_team_id in staff_team_ids:
                 removal_team_id = sole_team_id
 
-        can_request_removal = bool(is_coach and removal_team_id)
-        can_direct_remove = bool(is_treatment_prof and removal_team_id)
+        # Show the direct-remove button ONLY when the viewer may actually remove
+        # from this team (task 1260 — the single permission predicate), so it
+        # never appears for someone the route will refuse (e.g. a doctor: holds a
+        # portal-TP group but isn't a therapist on the team). Request Removal is
+        # the fallback for any team staff who may NOT remove directly (coaches AND
+        # non-therapist TPs), so no staffer is left with no way to act.
+        env = http.request.env
+        removal_team = (
+            env['sports.team'].browse(removal_team_id)
+            if removal_team_id else env['sports.team']
+        )
+        # Evaluate the predicate in the PORTAL user's env (http.request.env, not
+        # sudo), on an empty patient recordset — it keys on env.user + team, not
+        # on a specific patient, so this correctly asks "may THIS viewer remove
+        # from this team".
+        can_direct_remove = bool(
+            removal_team_id and env['sports.patient']._may_remove_from_team(removal_team)
+        )
+        can_request_removal = bool(removal_team_id) and not can_direct_remove
 
         # Precompute tab-anchor return URLs (and url-encoded variants
         # for embedding in another URL's query string). Doing this in

--- a/bemade_sports_clinic/models/patient.py
+++ b/bemade_sports_clinic/models/patient.py
@@ -7,6 +7,13 @@ import logging
 
 _logger = logging.getLogger(__name__)
 
+# Roles that may DIRECTLY remove a player from a team (both the internal
+# recordset path and the portal route). Everyone else must use the Request
+# Removal flow, which routes a task to the head therapist. head_therapist is
+# mandatory: the removal-request workflow assigns its activity to the head
+# therapist, so a head therapist must be able to action it (task 1260).
+REMOVAL_ROLES = ('therapist', 'head_therapist')
+
 external_tracking_fields = {
     "last_consultation_date",
     "match_status",
@@ -799,6 +806,50 @@ class Patient(models.Model):
             return _("Removed from last team %s. The player now has no team.") % team_name
         return _("Removed from team %s by %s") % (team_name, user_name)
 
+    def _may_remove_from_team(self, team):
+        """Single source of truth for "may the current user directly remove a
+        player from ``team``?" — shared by BOTH the internal recordset
+        ``remove_from_team`` and the portal ``portal_remove_player`` route, so
+        the two paths can never drift apart again (task 1260).
+
+        Policy:
+        - ``base.group_system`` may remove any player, regardless of role; OR
+        - the user holds EITHER treatment-professional group AND has a staff row
+          on THIS team with ``role in REMOVAL_ROLES`` (therapist / head
+          therapist). Everyone else (coaches, doctors, non-staff) must use the
+          Request Removal flow.
+
+        BOTH treatment-professional groups are accepted on purpose.
+        ``group_portal_treatment_professional`` and
+        ``group_sports_clinic_treatment_professional`` are DISJOINT — the portal
+        group implies only ``base.group_portal``, never the internal group, and
+        the internal group is held only via ``group_sports_clinic_admin``. A
+        portal therapist therefore holds ONLY the portal group. Testing a single
+        group here would reject every portal treatment professional the moment
+        the portal route is wired through this predicate. Do not "simplify" one
+        of these two checks away.
+
+        :param sports.team team: the team the removal targets
+        :return bool: True if the current user may remove directly from ``team``
+        """
+        user = self.env.user
+        if user.has_group('base.group_system'):
+            return True
+
+        is_treatment_prof = (
+            user.has_group('bemade_sports_clinic.group_sports_clinic_treatment_professional')
+            or user.has_group('bemade_sports_clinic.group_portal_treatment_professional')
+        )
+        if not is_treatment_prof:
+            return False
+
+        # Team-scoped: a therapist may only remove from teams where THEY are a
+        # (head) therapist, not from any team they can merely see.
+        user_staff_roles = team.staff_ids.filtered(
+            lambda s: s.user_ids and user.id in s.user_ids.ids
+        )
+        return any(role.role in REMOVAL_ROLES for role in user_staff_roles)
+
     def remove_from_team(self, team_id, clear_pending=True, reason=None):
         """
         Public method to remove players from a team with proper permission checks.
@@ -807,9 +858,11 @@ class Patient(models.Model):
         The permission check is per-TEAM, not per-player, so it runs once for the
         call rather than once per record.
 
-        Permissions:
-        - System Administrators (base.group_system) can remove any player
-        - Treatment Professionals (group_sports_clinic_treatment_professional) can remove players from teams where they are therapists
+        Permissions are defined ONCE in ``_may_remove_from_team`` and shared with
+        the portal route:
+        - System Administrators (base.group_system) can remove any player.
+        - A treatment professional (EITHER TP group) can remove players from
+          teams where they are a therapist or head therapist (REMOVAL_ROLES).
 
         :param int team_id: ID of the team to remove the players from
         :param bool clear_pending: Whether to clear the pending_removal flag (default: True)
@@ -820,30 +873,14 @@ class Patient(models.Model):
         """
         team = self.env['sports.team'].browse(team_id)
 
-        # Get current user and check permissions first
-        current_user = self.env.user
-        is_admin = current_user.has_group('base.group_system')
-
-        # Check if user is a treatment professional on the team
-        user_staff_roles = team.staff_ids.filtered(
-            lambda s: s.user_ids and current_user.id in s.user_ids.ids
-        )
-        is_team_therapist = any(role.role == 'therapist' for role in user_staff_roles)
-        is_treatment_prof = current_user.has_group('bemade_sports_clinic.group_sports_clinic_treatment_professional')
-
-        # Permission check - do this before team membership validation
-        if not is_admin:
-            if not is_treatment_prof:
-                raise AccessError(_(
-                    "You don't have permission to remove players from teams. "
-                    "Only treatment professionals or administrators can perform this action. "
-                    "Please use the 'Request Removal' action instead."
-                ))
-            if not is_team_therapist:
-                raise AccessError(_(
-                    "You must be a therapist on the team to remove players. "
-                    "Please request removal through the team's head therapist."
-                ))
+        # Single permission policy, shared with the portal route (task 1260).
+        # The check is per-TEAM, so it runs once for the whole recordset.
+        if not self._may_remove_from_team(team):
+            raise AccessError(_(
+                "You don't have permission to remove players from this team. "
+                "Only the team's therapist or head therapist can remove players "
+                "directly. Please use the 'Request Removal' action instead."
+            ))
 
         # Now validate team existence and membership
         if not team.exists():
@@ -860,6 +897,13 @@ class Patient(models.Model):
     def _remove_from_team(self, team_id, clear_pending=True, reason=None):
         """
         Private method containing the actual sudo operations for team removal.
+
+        CHECK-FREE BY CONTRACT: this method performs NO permission or membership
+        validation. Its only caller is the public ``remove_from_team``, which
+        runs ``_may_remove_from_team`` and the membership checks first. Do not
+        call this directly from a new entry point (the portal route used to, and
+        that was exactly the permission gap task 1260 closed) — call the public
+        ``remove_from_team`` instead.
 
         Batched: the roster write is a single write for the whole recordset, so
         recompute_followers and _sync_date_left_last_team each run once instead

--- a/bemade_sports_clinic/tests/__init__.py
+++ b/bemade_sports_clinic/tests/__init__.py
@@ -4,6 +4,7 @@ from . import test_users
 from . import test_portal_access
 from . import test_treatment_professional_consistency
 from . import test_player_removal
+from . import test_removal_permission_matrix
 from . import test_mail_activity_portal_access
 from . import test_mail_activity_portal_integration
 from . import test_portal_activity_default_todo

--- a/bemade_sports_clinic/tests/test_removal_permission_matrix.py
+++ b/bemade_sports_clinic/tests/test_removal_permission_matrix.py
@@ -1,0 +1,303 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+"""Permission matrix for direct player removal (task 1260).
+
+One policy governs BOTH the internal recordset ``remove_from_team`` and the
+portal ``portal_remove_player`` route: they share the single predicate
+``sports.patient._may_remove_from_team(team)``. These tests drive the policy
+server-side, via ``remove_from_team`` with ``.with_user(...)`` and the predicate
+directly, for every role/group combination in the acceptance matrix. Both the
+INTERNAL treatment-professional group and the PORTAL one are exercised, because
+the two are disjoint and the whole point of the task is that a portal therapist
+must pass the same check an internal one does.
+
+The portal HTTP POST itself is browser-driven and verified by UAT on staging
+(see the dev-review artifact); it is not asserted here.
+
+Fixtures are synthetic throughout: invented names, no real player data.
+"""
+
+from odoo.tests import TransactionCase, tagged
+from odoo.exceptions import AccessError, ValidationError
+
+INTERNAL_TP = 'bemade_sports_clinic.group_sports_clinic_treatment_professional'
+PORTAL_TP = 'bemade_sports_clinic.group_portal_treatment_professional'
+PORTAL_COACH = 'bemade_sports_clinic.group_portal_team_coach'
+
+
+@tagged('post_install', '-at_install')
+class TestRemovalPermissionMatrix(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        env = cls.env
+
+        cls.org = env['res.partner'].create({'name': 'Matrix Org', 'is_company': True})
+        cls.team = env['sports.team'].create({'name': 'Matrix Team', 'parent_id': cls.org.id})
+        cls.other_team = env['sports.team'].create({'name': 'Matrix Other Team', 'parent_id': cls.org.id})
+        # A team can have only one head therapist, so the internal head-therapist
+        # persona gets its own team to sit on.
+        cls.ihead_team = env['sports.team'].create({'name': 'Matrix IHead Team', 'parent_id': cls.org.id})
+
+        # Isolate the permission POLICY (groups + roles) from record VISIBILITY:
+        # give the tested groups blanket read on the three models the predicate
+        # and membership check touch. There are no global (group-less) rules on
+        # these models, so a permissive group rule cleanly widens reads. Team
+        # visibility is a separate concern, enforced by _check_team_access on the
+        # portal, not by this policy.
+        for model in ('sports.patient', 'sports.team', 'sports.team.staff'):
+            model_id = env['ir.model']._get_id(model)
+            env['ir.rule'].create({
+                'name': 'Test 1260: blanket read %s' % model,
+                'model_id': model_id,
+                'domain_force': '[(1, "=", 1)]',
+                'groups': [(6, 0, [
+                    env.ref(INTERNAL_TP).id,
+                    env.ref(PORTAL_TP).id,
+                    env.ref(PORTAL_COACH).id,
+                ])],
+                'perm_read': True,
+                'perm_write': False,
+                'perm_create': False,
+                'perm_unlink': False,
+            })
+
+        base_user = env.ref('base.group_user').id
+        internal_user = env.ref('bemade_sports_clinic.group_sports_clinic_user').id
+        portal = env.ref('base.group_portal').id
+        internal_tp = env.ref(INTERNAL_TP).id
+        portal_tp = env.ref(PORTAL_TP).id
+        coach_g = env.ref(PORTAL_COACH).id
+
+        def _user(name, login, groups):
+            return env['res.users'].with_context(no_reset_password=True).create({
+                'name': name, 'login': login, 'email': '%s@example.com' % login,
+                'group_ids': [(6, 0, groups)],
+            })
+
+        def _staff(user, role, team=None):
+            env['sports.team.staff'].create({
+                'team_id': (team or cls.team).id,
+                'partner_id': user.partner_id.id,
+                'role': role,
+            })
+
+        cls.admin_user = env.ref('base.user_admin')
+
+        # Internal treatment professionals (internal TP group).
+        cls.internal_therapist = _user('Int Therapist', 'mtx_int_ther', [base_user, internal_user, internal_tp])
+        _staff(cls.internal_therapist, 'therapist')
+        cls.internal_head_therapist = _user('Int Head Therapist', 'mtx_int_head', [base_user, internal_user, internal_tp])
+        _staff(cls.internal_head_therapist, 'head_therapist', team=cls.ihead_team)
+
+        # Portal treatment professionals (portal TP group -- DISJOINT from the
+        # internal group). This is the population the naive fix would break.
+        cls.portal_therapist = _user('Portal Therapist', 'mtx_por_ther', [portal, portal_tp])
+        _staff(cls.portal_therapist, 'therapist')
+        cls.portal_head_therapist = _user('Portal Head Therapist', 'mtx_por_head', [portal, portal_tp])
+        _staff(cls.portal_head_therapist, 'head_therapist')
+
+        # A portal TP who is a therapist on OTHER team only -- proves team scope.
+        cls.tp_wrong_team = _user('Portal TP Wrong Team', 'mtx_por_wrong', [portal, portal_tp])
+        _staff(cls.tp_wrong_team, 'therapist', team=cls.other_team)
+
+        # A doctor who HOLDS a TP group (passes the group gate) but whose role is
+        # excluded -- proves the role allow-list, not just the group, gates.
+        cls.doctor_user = _user('Portal Doctor', 'mtx_doctor', [portal, portal_tp])
+        _staff(cls.doctor_user, 'doctor')
+
+        # Non-therapist staff roles.
+        cls.coach_user = _user('Coach', 'mtx_coach', [portal, coach_g])
+        _staff(cls.coach_user, 'coach')
+        cls.head_coach_user = _user('Head Coach', 'mtx_head_coach', [portal, coach_g])
+        _staff(cls.head_coach_user, 'head_coach')
+        cls.other_user = _user('Other Staff', 'mtx_other', [portal, coach_g])
+        _staff(cls.other_user, 'other')
+
+        # A plain user with no clinic groups and no staff row.
+        cls.regular_user = _user('Regular', 'mtx_regular', [base_user])
+
+        # A fresh player on the team for each test (created per-test to avoid
+        # cross-test roster mutation).
+
+    def _player(self, teams=None):
+        teams = teams or self.team
+        p = self.env['sports.patient'].create({
+            'first_name': 'Matrix', 'last_name': 'Player',
+        })
+        p.team_ids = [(6, 0, teams.ids)]
+        return p
+
+    def _assert_removed(self, player, user, team=None):
+        team = team or self.team
+        player.with_user(user).remove_from_team(team.id)
+        player.invalidate_recordset(['team_ids'])
+        self.assertNotIn(team, player.team_ids)
+
+    def _assert_denied(self, player, user, team=None):
+        team = team or self.team
+        with self.assertRaises(AccessError):
+            player.with_user(user).remove_from_team(team.id)
+        player.invalidate_recordset(['team_ids'])
+        self.assertIn(team, player.team_ids, "denied removal must not mutate the roster")
+
+    # ------------------------------------------------------------------
+    # AC1 -- head_therapist on the team CAN remove (the live bug this task fixes)
+    # ------------------------------------------------------------------
+    def test_ac1_internal_head_therapist_can_remove(self):
+        player = self._player(teams=self.ihead_team)
+        self._assert_removed(player, self.internal_head_therapist, team=self.ihead_team)
+
+    def test_ac1_portal_head_therapist_can_remove(self):
+        self._assert_removed(self._player(), self.portal_head_therapist)
+
+    # ------------------------------------------------------------------
+    # AC2 -- therapist on the team CAN remove
+    # ------------------------------------------------------------------
+    def test_ac2_internal_therapist_can_remove(self):
+        self._assert_removed(self._player(), self.internal_therapist)
+
+    def test_ac2_portal_therapist_can_remove(self):
+        self._assert_removed(self._player(), self.portal_therapist)
+
+    # ------------------------------------------------------------------
+    # AC3 -- coach / head_coach / other on the team CANNOT
+    # ------------------------------------------------------------------
+    def test_ac3_coach_cannot_remove(self):
+        self._assert_denied(self._player(), self.coach_user)
+
+    def test_ac3_head_coach_cannot_remove(self):
+        self._assert_denied(self._player(), self.head_coach_user)
+
+    def test_ac3_other_role_cannot_remove(self):
+        self._assert_denied(self._player(), self.other_user)
+
+    # ------------------------------------------------------------------
+    # AC4 -- doctor on the team CANNOT (behaviour change, asserted deliberately)
+    # ------------------------------------------------------------------
+    def test_ac4_doctor_cannot_remove(self):
+        # Holds a TP group, so passes the group gate; role 'doctor' is not in
+        # REMOVAL_ROLES, so the role gate denies.
+        self._assert_denied(self._player(), self.doctor_user)
+
+    # ------------------------------------------------------------------
+    # AC5 -- a TP who is a therapist on a DIFFERENT team CANNOT remove here
+    # ------------------------------------------------------------------
+    def test_ac5_tp_not_on_this_team_cannot_remove(self):
+        self._assert_denied(self._player(), self.tp_wrong_team)
+
+    def test_ac5_tp_can_remove_from_own_team(self):
+        # Same user, own team: proves the AC5 denial is team-scope, not a blanket
+        # denial of the user.
+        player = self._player(teams=self.other_team)
+        self._assert_removed(player, self.tp_wrong_team, team=self.other_team)
+
+    # ------------------------------------------------------------------
+    # AC6 -- base.group_system CAN remove regardless of role (no staff row)
+    # ------------------------------------------------------------------
+    def test_ac6_admin_can_remove(self):
+        self._assert_removed(self._player(), self.admin_user)
+
+    # ------------------------------------------------------------------
+    # AC7 -- portal TP therapist CAN remove (the disjoint-group case, explicit)
+    # ------------------------------------------------------------------
+    def test_ac7_portal_tp_group_therapist_can_remove(self):
+        self.assertTrue(
+            self.env.ref(PORTAL_TP) in self.portal_therapist.group_ids,
+            "guard: this persona must hold ONLY the portal TP group",
+        )
+        self.assertFalse(
+            self.portal_therapist.has_group(INTERNAL_TP),
+            "guard: the two TP groups are disjoint -- portal therapist must NOT "
+            "hold the internal group",
+        )
+        self._assert_removed(self._player(), self.portal_therapist)
+
+    # ------------------------------------------------------------------
+    # Non-TP, non-staff user is denied.
+    # ------------------------------------------------------------------
+    def test_regular_user_cannot_remove(self):
+        self._assert_denied(self._player(), self.regular_user)
+
+    # ------------------------------------------------------------------
+    # The predicate itself, exercised directly (single source of truth).
+    # ------------------------------------------------------------------
+    def test_predicate_matches_matrix(self):
+        player = self._player()
+        may = lambda u, team=self.team: player.with_user(u)._may_remove_from_team(team)
+        # Allowed against self.team.
+        self.assertTrue(may(self.admin_user))
+        self.assertTrue(may(self.internal_therapist))
+        self.assertTrue(may(self.portal_therapist))
+        self.assertTrue(may(self.portal_head_therapist))
+        # Allowed only against their OWN team.
+        self.assertTrue(may(self.internal_head_therapist, self.ihead_team))
+        self.assertTrue(may(self.tp_wrong_team, self.other_team))
+        # Denied against self.team.
+        self.assertFalse(may(self.doctor_user))
+        self.assertFalse(may(self.coach_user))
+        self.assertFalse(may(self.head_coach_user))
+        self.assertFalse(may(self.other_user))
+        self.assertFalse(may(self.tp_wrong_team))  # therapist elsewhere, not here
+        self.assertFalse(may(self.internal_head_therapist))  # head therapist elsewhere
+        self.assertFalse(may(self.regular_user))
+
+    # ------------------------------------------------------------------
+    # AC8 / AC9 -- the request -> head-therapist round trip (broken today)
+    # ------------------------------------------------------------------
+    def test_ac9_coach_can_still_request_removal(self):
+        player = self._player()
+        result = player.with_user(self.coach_user).with_context(lang='en_US').request_team_removal(
+            self.team.id, reason='Relocating',
+        )
+        player.invalidate_recordset(['pending_removal'])
+        self.assertTrue(player.pending_removal, "coach must still be able to REQUEST removal")
+        self.assertEqual(result['type'], 'ir.actions.client')
+
+    def test_ac8_request_then_head_therapist_actions_it(self):
+        player = self._player()
+
+        # 1. Coach requests removal (cannot remove directly -- AC3).
+        player.with_user(self.coach_user).with_context(lang='en_US').request_team_removal(
+            self.team.id, reason='Relocating',
+        )
+        player.invalidate_recordset(['pending_removal'])
+        self.assertTrue(player.pending_removal)
+
+        # 2. The cron routes an activity to the team's head therapist.
+        self.env['sports.patient']._cron_handle_pending_removals()
+        activity = self.env['mail.activity'].search([
+            ('res_model', '=', 'sports.patient'),
+            ('res_id', '=', player.id),
+            ('summary', 'ilike', 'Player Removal Request'),
+        ])
+        self.assertTrue(activity, "the cron must create a review activity")
+        self.assertEqual(
+            activity.user_id, self.portal_head_therapist,
+            "the removal activity must land on the team's head therapist",
+        )
+
+        # 3. The head therapist actions it: direct removal now SUCCEEDS (this is
+        #    the workflow that dead-ended in AccessError before task 1260).
+        self._assert_removed(player, self.portal_head_therapist)
+
+    # ------------------------------------------------------------------
+    # AC13 -- removal sends no outgoing mail (neutralized DB): the chatter post
+    # must not enqueue a mail.mail.
+    # ------------------------------------------------------------------
+    def test_ac13_removal_sends_no_mail(self):
+        player = self._player()
+        before = self.env['mail.mail'].search_count([])
+        player.with_user(self.internal_therapist).remove_from_team(self.team.id)
+        self.assertEqual(
+            self.env['mail.mail'].search_count([]), before,
+            "removal must not enqueue outgoing mail",
+        )
+
+    # ------------------------------------------------------------------
+    # Membership / team-existence errors are unchanged for an authorized user.
+    # ------------------------------------------------------------------
+    def test_not_a_member_raises_validation(self):
+        player = self._player()
+        with self.assertRaises(ValidationError):
+            player.with_user(self.admin_user).remove_from_team(self.other_team.id)

--- a/bemade_sports_clinic/tests/test_team_player_removal_wizard.py
+++ b/bemade_sports_clinic/tests/test_team_player_removal_wizard.py
@@ -9,7 +9,6 @@ _sync_date_left_last_team, covered here and in test_law25_roster_invariants.
 Fixtures are synthetic throughout: invented names, no real player data.
 """
 
-import sys
 from unittest.mock import patch
 
 from odoo import Command, fields
@@ -287,28 +286,31 @@ class TestTeamPlayerRemovalWizard(TransactionCase):
         self.assertFalse(bravo.date_left_last_team)
 
     def test_ac5_permission_check_runs_once_not_per_player(self):
+        # Task 1260 extracted the removal policy into the single predicate
+        # sports.patient._may_remove_from_team(team). The #1257 property this
+        # test guards -- "the permission check is per TEAM, not per player" --
+        # now means: that predicate is evaluated exactly ONCE per call, however
+        # many players the recordset holds. (The previous version counted
+        # has_group calls by frame introspection, which is unreliable across
+        # Odoo builds; counting the predicate directly is robust and tests the
+        # same guarantee against the new structure.)
         players = self._player('Alpha') | self._player('Bravo') | self._player('Charlie')
+        Patient = type(self.env['sports.patient'])
+        real_may = Patient._may_remove_from_team
         calls = []
-        Users = type(self.env['res.users'])
-        real_has_group = Users.has_group
 
-        def counting_has_group(user, group_ext_id):
-            # Count ONLY the checks made directly by remove_from_team's own body.
-            # Record rules and group-restricted fields call has_group plenty of
-            # times on their own; counting those would measure the ORM, not this
-            # method. The old loop of single-record calls would land here once
-            # per player.
-            if sys._getframe(1).f_code.co_name == 'remove_from_team':
-                calls.append(group_ext_id)
-            return real_has_group(user, group_ext_id)
+        def counting_may(records, team):
+            calls.append(team.id)
+            return real_may(records, team)
 
-        with patch.object(Users, 'has_group', counting_has_group):
+        with patch.object(Patient, '_may_remove_from_team', counting_may):
             players.with_user(self.admin_user).remove_from_team(self.team.id)
 
         self.assertEqual(
-            calls, ['base.group_system', TP_GROUP],
-            "The permission check is per-team, not per-player: each group is "
-            "checked once for the whole call, however many players it removes",
+            calls, [self.team.id],
+            "The permission check is per-team, not per-player: the removal "
+            "predicate is evaluated once for the whole call, however many "
+            "players it removes",
         )
 
     def test_ac5_roster_write_is_batched(self):

--- a/bemade_sports_clinic/views/sports_clinic_portal_views.xml
+++ b/bemade_sports_clinic/views/sports_clinic_portal_views.xml
@@ -593,6 +593,12 @@
                         <span t-else="" class="fw-bold">
                             <span t-field="player.last_name"/>, <span t-field="player.first_name"/>
                         </span>
+                        <!-- Task 1260: flag a player with a pending removal request so a
+                             TP scanning the roster can spot who needs actioning. -->
+                        <span t-if="player.pending_removal" class="badge bg-danger text-white"
+                              title="A removal request is pending for this player">
+                            <i class="fa fa-user-times me-1"/> Removal Pending
+                        </span>
                     </div>
                     <!-- Desktop-only: Right-aligned badges next to injury count -->
                     <div class="d-none d-md-flex align-items-center justify-content-end flex-wrap gap-2">
@@ -1053,8 +1059,11 @@
                                 </div>
                             </div>
                         </t>
-                        <!-- Cards grid replacing table -->
-                        <div class="container-fluid">
+                        <!-- Cards grid replacing table. id=pending-removals gives the
+                             alert's "Review now" link a real target: it scrolls the TP
+                             to the player list, where pending players carry a badge and
+                             the direct-remove control to action them. -->
+                        <div class="container-fluid" id="pending-removals">
                             <div class="row g-3 justify-content-center">
                                 <t t-foreach="players" t-as="player">
                                     <div class="col-12 col-lg-8">

--- a/bemade_sports_clinic/views/sports_clinic_portal_views.xml
+++ b/bemade_sports_clinic/views/sports_clinic_portal_views.xml
@@ -1040,8 +1040,9 @@
 
                 <div class="tab-content">
                     <div class="tab-pane fade show active" id="players" role="tabpanel" aria-labelledby="players-tab">
-                        <!-- Pending Removals Alert -->
-                        <t t-if="any(p.pending_removal for p in players) and user_has_group('bemade_sports_clinic.group_portal_treatment_professional')">
+                        <!-- Pending Removals Alert — only for viewers who can action
+                             a removal on this team (task 1260), not any portal TP. -->
+                        <t t-if="any(p.pending_removal for p in players) and can_remove_on_team">
                             <div class="alert alert-warning d-flex align-items-center" role="alert">
                                 <i class="fa fa-exclamation-triangle flex-shrink-0 me-2"></i>
                                 <div>
@@ -1218,11 +1219,19 @@
                             data-bs-toggle="modal" t-attf-data-bs-target="#directRemoveModal{{ player.id }}">
                         <i class="fa fa-user-times"></i> Remove Player
                     </button>
-                    <!-- Coach: Request removal for review -->
-                    <button t-if="can_request_removal" type="button" class="btn bg-o-color-2 text-white"
-                            data-bs-toggle="modal" t-attf-data-bs-target="#requestRemovalModal{{ player.id }}">
-                        <i class="fa fa-user-times"></i> Request Removal
-                    </button>
+                    <!-- Coach / non-therapist staff: request removal for review.
+                         When a request is already pending, show a disabled
+                         "Removal Pending" state instead of a clickable button
+                         (task 1260 UAT). -->
+                    <t t-if="can_request_removal">
+                        <button t-if="not player.pending_removal" type="button" class="btn bg-o-color-2 text-white"
+                                data-bs-toggle="modal" t-attf-data-bs-target="#requestRemovalModal{{ player.id }}">
+                            <i class="fa fa-user-times"></i> Request Removal
+                        </button>
+                        <button t-else="" type="button" class="btn btn-secondary" disabled="disabled">
+                            <i class="fa fa-hourglass-half"></i> Removal Pending
+                        </button>
+                    </t>
                     <!-- Activity buttons removed (task 1222): the player's and its
                          injuries' activities now live in the Activities tab below,
                          with an inline add header. -->


### PR DESCRIPTION
Task #1260 — portal player-removal permissions.

**Core change**
- One permission predicate `_may_remove_from_team(team)` shared by the internal path and the portal: **admin, OR (holds EITHER TP group — they are DISJOINT, so both must be accepted or every portal TP breaks — AND has a therapist/head-therapist role on THAT team)**.
- The portal route now calls the **public** `remove_from_team` (was the check-free private method); a denied user is pointed at Request Removal. Fixes a latent head-therapist bug (`role == 'therapist'` → `role in ('therapist','head_therapist')`).

**Portal UI polish (from dev-review UAT)**
- Remove button shows only to those who may actually remove; Request Removal shows for any non-removing team staff (coaches AND non-therapist TPs like doctors).
- The pending-removals alert shows only to viewers who can action a removal.
- The Request Removal button shows a disabled 'Removal Pending' state when a request is already in flight.
- The alert's 'Review now' link now scrolls to the roster (was a dead anchor); a 'Removal Pending' badge flags the pending player on the card.

**Behaviour change:** coaches and doctors lose *direct* portal removal — they use Request Removal, which notifies the head therapist.

**Verification:** full module suite green (644 tests, 0 fail) incl. an 18-case permission matrix; portal permission + button-visibility behaviour verified live via click-through on a copy of prod (therapist removes; doctor refused; correct button/alert/badge visibility). Fixtures synthetic. Manifest 19.0.1.7.0 → 19.0.1.7.1.