### PR TITLE
[bemade_sports_clinic] #1262: portal Add-Timesheet material-report notice (mailto) (19.0.1.9.0)

### DIFF
--- a/bemade_sports_clinic/__manifest__.py
+++ b/bemade_sports_clinic/__manifest__.py
@@ -18,7 +18,7 @@
 #
 {
     'name': 'Sports Clinic Management',
-    'version': "19.0.1.8.0",
+    'version': "19.0.1.9.0",
     'summary': 'Comprehensive sports medicine clinic management with portal access and activity tracking.',
     'description': """
 Sports Clinic Management System

--- a/bemade_sports_clinic/__manifest__.py
+++ b/bemade_sports_clinic/__manifest__.py
@@ -71,6 +71,7 @@ This module provides a complete sports medicine clinic management solution with 
         "security/partner_access.xml",
         "security/sports_event_timesheet_rules.xml",
         "data/sports_clinic_data.xml",
+        "data/material_report_data.xml",
         "data/admin_access_data.xml",
         # "data/project_portal_demo_data.xml",  # Temporarily disabled for clean upgrade
         "data/cron_actions.xml",

--- a/bemade_sports_clinic/controllers/events_portal.py
+++ b/bemade_sports_clinic/controllers/events_portal.py
@@ -571,6 +571,13 @@ class EventsPortal(CustomerPortal, AccessControlMixin):
         show_all_timesheets = user.has_group('base.group_system')
         can_view_timesheets = (is_therapist and is_assigned) or show_all_timesheets
         can_add_timesheet = is_therapist and is_assigned
+
+        # Pre-filled mailto for the Add-Timesheet "report material used" notice.
+        # Only built when the modal is available (same gate). Built on the model
+        # so the subject renders in the portal user's lang and is URL-encoded
+        # (event names carry spaces/accents/&) — QWeb only emits a ready href.
+        material_report_mailto = event._get_material_report_mailto() if can_add_timesheet else ''
+
         values = {
             'event': event,
             'event_sudo': event_sudo,
@@ -585,6 +592,7 @@ class EventsPortal(CustomerPortal, AccessControlMixin):
             'can_edit': can_edit,
             'can_view_timesheets': can_view_timesheets,
             'can_add_timesheet': can_add_timesheet,
+            'material_report_mailto': material_report_mailto,
             'show_all_timesheets': show_all_timesheets,
             'return_url': return_url,
             'event_return_url': event_return_url,

--- a/bemade_sports_clinic/data/material_report_data.xml
+++ b/bemade_sports_clinic/data/material_report_data.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <!-- Seed the default recipient for the portal "report material used" notice.
+         noupdate=1: this is a one-time default; the owner changes it via Settings
+         thereafter (an upgrade must not clobber their configured address).
+         ir.config_parameter is NOT a security record — no migration rule applies. -->
+    <data noupdate="1">
+        <record id="material_report_email_param" model="ir.config_parameter">
+            <field name="key">bemade_sports_clinic.material_report_email</field>
+            <field name="value">admin@lefitcrew.com</field>
+        </record>
+    </data>
+</odoo>

--- a/bemade_sports_clinic/i18n/fr_CA.po
+++ b/bemade_sports_clinic/i18n/fr_CA.po
@@ -7009,3 +7009,19 @@ msgstr "Télécharger"
 #: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_patient_card
 msgid "Removal pending"
 msgstr "Retrait en attente"
+
+#. module: bemade_sports_clinic
+#: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_detail
+msgid "Did you use personal material for this event? Report it so the client can be re-invoiced."
+msgstr "Avez-vous utilisé du matériel personnel pour cet événement? Signalez-le pour refacturation au client."
+
+#. module: bemade_sports_clinic
+#: model_terms:ir.ui.view,arch_db:bemade_sports_clinic.portal_event_detail
+msgid "Report material used"
+msgstr "Signaler du matériel utilisé"
+
+#. module: bemade_sports_clinic
+#. odoo-python
+#: code:addons/bemade_sports_clinic/controllers/events_portal.py:0
+msgid "Personal material used — %(name)s (%(date)s)"
+msgstr "Matériel personnel utilisé — %(name)s (%(date)s)"

--- a/bemade_sports_clinic/models/res_config_settings.py
+++ b/bemade_sports_clinic/models/res_config_settings.py
@@ -19,6 +19,13 @@ class ResConfigSettings(models.TransientModel):
         'product.product', string='Clinic Product (Vendor PO)',
         config_parameter='bemade_sports_clinic.product_event_clinic_vendor_id')
 
+    # Recipient for portal "report material used" notice emails
+    material_report_email = fields.Char(
+        string='Material Report Recipient',
+        config_parameter='bemade_sports_clinic.material_report_email',
+        help="Email address pre-filled in the portal Add Timesheet notice inviting "
+             "therapists to report personal material used, for client re-invoicing.")
+
     # Customer-side (organization invoice) products
     product_event_coverage_customer_id = fields.Many2one(
         'product.product', string='Coverage Product (Customer Invoice)',

--- a/bemade_sports_clinic/models/sports_event.py
+++ b/bemade_sports_clinic/models/sports_event.py
@@ -1,4 +1,5 @@
 import logging
+import urllib.parse
 
 from markupsafe import Markup, escape
 
@@ -964,6 +965,30 @@ class SportsEvent(models.Model):
                         "Failed to notify assigned staff of cancelled event %s",
                         event.id,
                     )
+
+    def _get_material_report_mailto(self):
+        """Build a `mailto:` URL for the portal "report material used" notice.
+
+        The recipient is the configured clinic address
+        (``bemade_sports_clinic.material_report_email``, defaulting to
+        admin@lefitcrew.com). The subject is translatable — it renders in the
+        caller env's language (the portal therapist's, e.g. fr_CA) — and
+        references THIS event by name + localized start date. The subject is
+        URL-encoded here (event names carry spaces/accents/&) so the template
+        only ever emits a ready-made href.
+        """
+        self.ensure_one()
+        email = self.env['ir.config_parameter'].sudo().get_param(
+            'bemade_sports_clinic.material_report_email') or 'admin@lefitcrew.com'
+        subject = self.env._(
+            "Personal material used — %(name)s (%(date)s)",
+            name=self.name or '',
+            date=format_datetime(self.env, self.date_start) if self.date_start else '',
+        )
+        return 'mailto:%s?%s' % (
+            urllib.parse.quote(email),
+            urllib.parse.urlencode({'subject': subject}),
+        )
 
     def _notify_assigned_staff_deleted(self, partners, event_label,
                                        date_start=None, team_names=None):

--- a/bemade_sports_clinic/tests/__init__.py
+++ b/bemade_sports_clinic/tests/__init__.py
@@ -70,3 +70,4 @@ from . import test_patient_merge_conflicts
 from . import test_patient_merge_suggestions
 from . import test_patient_merge_security
 from . import test_patient_merge_prod_regression
+from . import test_material_report_mailto

--- a/bemade_sports_clinic/tests/test_material_report_mailto.py
+++ b/bemade_sports_clinic/tests/test_material_report_mailto.py
@@ -1,0 +1,81 @@
+import urllib.parse
+from datetime import datetime
+
+from odoo import Command
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged('post_install', '-at_install')
+class TestMaterialReportMailto(TransactionCase):
+    """Server-side coverage for sports.event._get_material_report_mailto().
+
+    The portal modal + the actual mailto click/href + French RENDERING are
+    browser behaviour and are NOT covered here (UAT at /dev-review). What is
+    pinned: the config param is read, the recipient is switchable via Settings,
+    the subject references the event, and it is properly URL-encoded.
+    All fixtures are SYNTHETIC (bemade-addons is public).
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Activate fr_CA so the French msgstr for the subject is loaded from the
+        # module's .po (this also imports our new i18n entry).
+        cls.env['res.lang']._activate_lang('fr_CA')
+        cls.org = cls.env['res.partner'].create({'name': 'MR Org', 'is_company': True})
+        cls.team = cls.env['sports.team'].create({'name': 'MR Team', 'parent_id': cls.org.id})
+        cls.ICP = cls.env['ir.config_parameter'].sudo()
+
+    def _event(self, **vals):
+        vals.setdefault('name', 'MR Event')
+        vals.setdefault('team_ids', [Command.set([self.team.id])])
+        vals.setdefault('date_start', datetime(2026, 3, 4, 14, 0))
+        vals.setdefault('date_end', datetime(2026, 3, 4, 16, 0))
+        vals.setdefault('state', 'confirmed')
+        return self.env['sports.event'].create(vals)
+
+    def test_default_recipient_and_scheme(self):
+        """With the seeded default, the mailto targets admin@lefitcrew.com."""
+        self.ICP.set_param('bemade_sports_clinic.material_report_email', 'admin@lefitcrew.com')
+        ev = self._event()
+        mailto = ev._get_material_report_mailto()
+        self.assertTrue(mailto.startswith('mailto:'))
+        # '@' is percent-encoded (%40) by urllib.parse.quote.
+        self.assertIn('admin%40lefitcrew.com', mailto)
+        self.assertIn('?subject=', mailto)
+
+    def test_recipient_follows_config_param(self):
+        """Changing the Setting changes the mailto recipient (config wired)."""
+        self.ICP.set_param('bemade_sports_clinic.material_report_email', 'billing@example.com')
+        ev = self._event()
+        mailto = ev._get_material_report_mailto()
+        self.assertIn('mailto:billing%40example.com', mailto)
+        self.assertNotIn('admin%40lefitcrew.com', mailto)
+
+    def test_fallback_when_param_missing(self):
+        """Belt-and-suspenders: empty/unset param falls back to the default."""
+        self.ICP.set_param('bemade_sports_clinic.material_report_email', '')
+        ev = self._event()
+        mailto = ev._get_material_report_mailto()
+        self.assertIn('admin%40lefitcrew.com', mailto)
+
+    def test_subject_references_event_and_is_encoded(self):
+        """Subject names THIS event; accents/spaces/& are URL-encoded, not raw."""
+        self.ICP.set_param('bemade_sports_clinic.material_report_email', 'admin@lefitcrew.com')
+        ev = self._event(name='Tournoi Été & Café')
+        mailto = ev._get_material_report_mailto()
+        # No raw space, accent, or ampersand leaks into the URL.
+        self.assertNotIn(' ', mailto)
+        self.assertNotIn('Été', mailto)
+        self.assertNotIn('&', mailto.split('?', 1)[1].replace('&subject', ''))  # no stray unencoded &
+        # Decoding the subject recovers the event name.
+        subject = urllib.parse.parse_qs(mailto.split('?', 1)[1])['subject'][0]
+        self.assertIn('Tournoi Été & Café', subject)
+
+    def test_subject_renders_french_for_fr_ca(self):
+        """In an fr_CA context the subject uses the French msgstr."""
+        self.ICP.set_param('bemade_sports_clinic.material_report_email', 'admin@lefitcrew.com')
+        ev = self._event(name='Match test')
+        mailto = ev.with_context(lang='fr_CA')._get_material_report_mailto()
+        subject = urllib.parse.parse_qs(mailto.split('?', 1)[1])['subject'][0]
+        self.assertIn('Matériel personnel utilisé', subject)

--- a/bemade_sports_clinic/views/portal_event_detail_template.xml
+++ b/bemade_sports_clinic/views/portal_event_detail_template.xml
@@ -47,6 +47,10 @@
                                             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                                         </div>
                                         <div class="modal-body">
+                                            <div class="alert alert-info" role="alert">
+                                                <p class="mb-1">Did you use personal material for this event? Report it so the client can be re-invoiced.</p>
+                                                <a t-att-href="material_report_mailto" class="alert-link">Report material used</a>
+                                            </div>
                                             <div class="mb-3">
                                                 <label class="form-label">Travel Start</label>
                                                 <input type="datetime-local" class="form-control" name="travel_start" t-att-value="ts_travel_start_local"/>

--- a/bemade_sports_clinic/views/res_config_settings_views.xml
+++ b/bemade_sports_clinic/views/res_config_settings_views.xml
@@ -24,6 +24,12 @@
                 <field name="product_event_clinic_vendor_id"/>
               </div>
             </setting>
+            <setting string="Material Report Recipient" help="Email address pre-filled in the portal Add Timesheet notice inviting therapists to report personal material used, for client re-invoicing.">
+              <div class="content-group">
+                <field name="material_report_email"/>
+              </div>
+            </setting>
+
             <setting string="Coverage Product (Customer Invoice)" help="Default product used for event coverage on Customer Invoices">
               <div class="content-group">
                 <field name="product_event_coverage_customer_id"/>


### PR DESCRIPTION
Portal event-detail **Add My Timesheet** modal gains an informational notice with a pre-filled `mailto:` so a field therapist can one-click report personal material used, addressed to a configurable clinic address (`bemade_sports_clinic.material_report_email`, default `admin@lefitcrew.com`) with a subject referencing THIS event (name + localized date). No timesheet model change.

- Setting `res.config.settings.material_report_email` (+ Settings view, seeded default via `ir.config_parameter`, noupdate — not a security record, no migration).
- `sports.event._get_material_report_mailto()` — translatable subject, URL-encoded recipient+subject.
- Controller passes `material_report_mailto` only when `can_add_timesheet`.
- Template notice + link in the modal body; `fr_CA` translations.

Manifest bumped 19.0.1.8.0 → **19.0.1.9.0** (1.8.0 already taken by #1263).

**Validation:** 5 server-side tests (recipient/config-param/fallback/encoding/fr_CA subject) green; view-load smoke clean. Local `/dev-review` browser UAT on a prod copy: modal notice (French) + mailto (To + event subject) + timesheet submit + Settings-recipient-flows-through all **Pass**.

Task: fitcrew Odoo #1262.