### PR TITLE
[bemade_sports_clinic] #1272: team dashboard — role-scoped activity rollups (19.0.1.10.0)

### DIFF
--- a/bemade_sports_clinic/__manifest__.py
+++ b/bemade_sports_clinic/__manifest__.py
@@ -18,7 +18,7 @@
 #
 {
     'name': 'Sports Clinic Management',
-    'version': "19.0.1.9.0",
+    'version': "19.0.1.10.0",
     'summary': 'Comprehensive sports medicine clinic management with portal access and activity tracking.',
     'description': """
 Sports Clinic Management System

--- a/bemade_sports_clinic/controllers/team_management_portal.py
+++ b/bemade_sports_clinic/controllers/team_management_portal.py
@@ -262,12 +262,40 @@ class TeamManagementPortal(CustomerPortal, AccessControlMixin):
                 default_activity_type = request.env.ref(
                     'mail.mail_activity_data_todo', raise_if_not_found=False)
 
+            # Dashboard tab (task 1272): role-scoped, recency-domained, score-
+            # ordered subset of the roster. A portal TP (or admin/internal) sees
+            # the TP rollups; a coach sees the coach rollups — a coach never sees
+            # internal-note or hidden-injury activity (Law 25), because the coach
+            # fields are only ever bumped by coach-visible changes.
+            dashboard_role = 'tp' if (is_treatment_prof or is_admin) else 'coach'
+            Patient = request.env['sports.patient']
+            cutoff = Patient._dashboard_window_cutoff()
+            stamp_field = 'dashboard_last_activity_%s' % dashboard_role
+            score_field = 'dashboard_score_%s' % dashboard_role
+            dashboard_players = players.filtered(
+                lambda p: p[stamp_field] and p[stamp_field] >= cutoff
+            ).sorted(key=lambda p: p[score_field], reverse=True)
+            # Team-level upcoming events (next 7 days).
+            now = fields.Datetime.now()
+            horizon = now + relativedelta(days=7)
+            upcoming_events = request.env['sports.event'].search([
+                ('team_ids', 'in', [team.id]),
+                ('date_start', '>=', now),
+                ('date_start', '<=', horizon),
+                ('state', '!=', 'cancelled'),
+            ], order='date_start asc')
+
             values = {
                 # Use my_teams so existing breadcrumbs logic renders
                 # "Teams / <Team Name>" for team detail pages.
                 'page_name': 'my_teams',
                 'team': team,
                 'players': players,
+                # Dashboard tab context (task 1272)
+                'dashboard_role': dashboard_role,
+                'dashboard_players': dashboard_players,
+                'dashboard_window_hours': Patient._dashboard_window_hours(),
+                'upcoming_events': upcoming_events,
                 # Canonical URL used by pager and templates
                 'default_url': f'/my/team?team_id={team.id}',
                 'user_has_group': request.env.user.has_group,  # Pass the has_group method to template

--- a/bemade_sports_clinic/models/injury_note_history.py
+++ b/bemade_sports_clinic/models/injury_note_history.py
@@ -1,4 +1,4 @@
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class InjuryNoteHistory(models.Model):
@@ -47,3 +47,24 @@ class InjuryNoteHistory(models.Model):
         required=True,
         readonly=True,
     )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super().create(vals_list)
+        # Task 1272: a note change is the canonical source for note activity on
+        # the team dashboards — bump here once, at the audit source, so the
+        # injury create/write hooks never double-count notes. Law 25: internal
+        # notes (and any note on a hidden-from-coaches injury) bump ONLY the TP
+        # rollup; external notes on a visible injury bump both roles.
+        if not self.env.context.get("dashboard_bump"):
+            for rec in records:
+                injury = rec.injury_id
+                patient = injury.patient_id if injury else False
+                if not patient:
+                    continue
+                if rec.scope == "internal" or injury.hidden_from_coaches:
+                    roles = {"tp"}
+                else:
+                    roles = {"coach", "tp"}
+                patient._bump_dashboard_activity(roles)
+        return records

--- a/bemade_sports_clinic/models/patient.py
+++ b/bemade_sports_clinic/models/patient.py
@@ -28,6 +28,15 @@ internal_tracking_fields = {
     "date_of_birth",
 }
 
+# --- Team-dashboard rollup (task 1272) --------------------------------------
+# Ranking weight per clinical stage; more concerning stages score higher so the
+# most urgent players surface first on the dashboards.
+DASHBOARD_STAGE_WEIGHT = {"no_play": 3, "practice_ok": 2, "healthy": 1}
+# Default recency window (hours) for "recently active" players; overridable via
+# the ir.config_parameter below (none is shipped, so the default applies).
+DASHBOARD_WINDOW_HOURS_DEFAULT = 24
+DASHBOARD_WINDOW_PARAM = "bemade_sports_clinic.dashboard_activity_window_hours"
+
 
 class Patient(models.Model):
     _name = "sports.patient"
@@ -181,6 +190,42 @@ class Patient(models.Model):
         "(re)joins a team. Maintained automatically — not shown on forms.",
     )
 
+    # ----------------------------------------------------------------------
+    # Team-dashboard rollup fields (task 1272)
+    # ----------------------------------------------------------------------
+    # Role-scoped rollups powering the team dashboard (backend page + portal
+    # tab) and, later, the #1154 digest slices (C/D). They are NOT computed:
+    # they are maintained ON CHANGE by the propagation hooks on this model, its
+    # injuries and note history (no cron). Law 25 discipline: internal-only
+    # activity (internal_notes; hidden_from_coaches injuries) bumps ONLY the
+    # *_tp fields — a coach must never see it, not even as a count. The domain
+    # filters on the *_last_activity_* stamp (recency); sort/display use the
+    # *_score_* + count fields.
+    dashboard_last_activity_coach = fields.Datetime(
+        string="Last Coach-visible Activity", index=True, copy=False, readonly=True
+    )
+    dashboard_last_activity_tp = fields.Datetime(
+        string="Last TP-visible Activity", index=True, copy=False, readonly=True
+    )
+    dashboard_score_coach = fields.Integer(
+        string="Coach Dashboard Score", default=0, copy=False, readonly=True
+    )
+    dashboard_score_tp = fields.Integer(
+        string="TP Dashboard Score", default=0, copy=False, readonly=True
+    )
+    dashboard_new_injury_count_coach = fields.Integer(
+        string="Recent New Injuries (Coach)", default=0, copy=False, readonly=True
+    )
+    dashboard_new_injury_count_tp = fields.Integer(
+        string="Recent New Injuries (TP)", default=0, copy=False, readonly=True
+    )
+    dashboard_note_update_count_coach = fields.Integer(
+        string="Recent Note Updates (Coach)", default=0, copy=False, readonly=True
+    )
+    dashboard_note_update_count_tp = fields.Integer(
+        string="Recent Note Updates (TP)", default=0, copy=False, readonly=True
+    )
+
     def default_get(self, fields_list):
         res = super().default_get(fields_list)
         if (
@@ -208,7 +253,100 @@ class Patient(models.Model):
             self.sudo()._sync_date_left_last_team()
         if "first_name" in values or "last_name" in values:
             self._recompute_name()
+        # Team-dashboard propagation (task 1272). Skip our own rollup writes
+        # (dashboard_bump) to avoid recursion.
+        if not self.env.context.get("dashboard_bump"):
+            self._propagate_patient_dashboard(values)
         return res
+
+    # ----------------------------------------------------------------------
+    # Team-dashboard rollup maintenance (task 1272)
+    # ----------------------------------------------------------------------
+    @api.model
+    def _dashboard_window_hours(self):
+        """Recency window (hours) for the team dashboards. Configurable via the
+        ``DASHBOARD_WINDOW_PARAM`` ir.config_parameter; defaults to 24h."""
+        raw = self.env["ir.config_parameter"].sudo().get_param(
+            DASHBOARD_WINDOW_PARAM, DASHBOARD_WINDOW_HOURS_DEFAULT
+        )
+        try:
+            hours = int(raw)
+        except (TypeError, ValueError):
+            hours = DASHBOARD_WINDOW_HOURS_DEFAULT
+        return hours if hours > 0 else DASHBOARD_WINDOW_HOURS_DEFAULT
+
+    @api.model
+    def _dashboard_window_cutoff(self):
+        return fields.Datetime.now() - timedelta(hours=self._dashboard_window_hours())
+
+    def _dashboard_role_rollup(self, role, cutoff):
+        """Return ``(score, new_injury_count, note_update_count)`` for ``role``
+        over the recency window, computed from real data.
+
+        Law 25 discipline: the ``coach`` view excludes injuries hidden from
+        coaches and internal-scope note history entirely — a coach never sees
+        internal clinical activity, not even as a count.
+        """
+        self.ensure_one()
+        injuries = self.injury_ids
+        if role == "coach":
+            injuries = injuries.filtered(lambda i: not i.hidden_from_coaches)
+        new_injuries = injuries.filtered(
+            lambda i: i.create_date and i.create_date >= cutoff
+        )
+        note_domain = [
+            ("patient_id", "=", self.id),
+            ("note_datetime", ">=", cutoff),
+        ]
+        if role == "coach":
+            note_domain += [
+                ("scope", "=", "external"),
+                ("injury_id.hidden_from_coaches", "=", False),
+            ]
+        note_count = (
+            self.env["sports.injury.note.history"].sudo().search_count(note_domain)
+        )
+        stage_weight = DASHBOARD_STAGE_WEIGHT.get(self.stage, 0)
+        score = stage_weight * 1000 + len(new_injuries) * 100 + note_count * 10
+        return score, len(new_injuries), note_count
+
+    def _bump_dashboard_activity(self, roles):
+        """Stamp the given role(s) with ``now`` and refresh their score/counts.
+
+        ``roles`` is a subset of ``('coach', 'tp')``; the CALLER decides which
+        roles a change is visible to (Law 25 discipline). Runs sudo: propagation
+        can be triggered by a portal coach editing an injury, who has no write
+        access to these system-maintained fields on ``sports.patient``.
+        """
+        roles = tuple(r for r in ("coach", "tp") if r in roles)
+        if not roles or not self:
+            return
+        now = fields.Datetime.now()
+        cutoff = self._dashboard_window_cutoff()
+        for patient in self:
+            vals = {}
+            for role in roles:
+                score, new_inj, note_cnt = patient._dashboard_role_rollup(role, cutoff)
+                vals["dashboard_last_activity_%s" % role] = now
+                vals["dashboard_score_%s" % role] = score
+                vals["dashboard_new_injury_count_%s" % role] = new_inj
+                vals["dashboard_note_update_count_%s" % role] = note_cnt
+            patient.sudo().with_context(
+                dashboard_bump=True,
+                tracking_disable=True,
+                mail_notrack=True,
+                skip_recompute_followers=True,
+            ).write(vals)
+
+    def _propagate_patient_dashboard(self, values):
+        """Bump dashboard rollups for player-level field changes. External
+        status (match/practice/return dates) is coach-visible -> both roles;
+        internal notes (team_info_notes) are TP-only."""
+        changed = set(values)
+        if external_tracking_fields & changed:
+            self._bump_dashboard_activity({"coach", "tp"})
+        elif internal_tracking_fields & changed:
+            self._bump_dashboard_activity({"tp"})
 
     def _sync_date_left_last_team(self):
         """Maintain the Law 25 retention clock on every path that can change a

--- a/bemade_sports_clinic/models/patient_injury.py
+++ b/bemade_sports_clinic/models/patient_injury.py
@@ -26,6 +26,27 @@ note_history_scope_by_field = {
     "external_notes": "external",
 }
 
+# --- Team-dashboard propagation (task 1272) ---------------------------------
+# Injury field changes that are clinically/externally visible -> bump BOTH the
+# coach and TP rollups (unless the injury is hidden from coaches). Note fields
+# (internal_notes/external_notes) are deliberately NOT here: they are handled
+# once, at the source, by the sports.injury.note.history create hook, so they
+# are never double-counted.
+dashboard_external_injury_fields = {
+    "diagnosis",
+    "stage",
+    "severity",
+    "predicted_resolution_date",
+    "resolution_date",
+    "body_location",
+    "injury_type",
+}
+# Internal/administrative changes -> TP rollup only.
+dashboard_internal_injury_fields = {
+    "parental_consent",
+    "treatment_professional_ids",
+}
+
 
 class PatientInjury(models.Model):
     _name = "sports.patient.injury"
@@ -388,8 +409,40 @@ class PatientInjury(models.Model):
         if not suppress_followers and 'internal_notes' in vals:
             for rec in self:
                 rec._manage_treatment_professional_subscriptions()
-                
+
+        # Task 1272: propagate non-note injury changes to the owning player's
+        # dashboard rollups. Note changes are handled by the note-history hook.
+        if not self.env.context.get('dashboard_bump'):
+            for rec in self:
+                rec._propagate_injury_dashboard(vals)
+
         return res
+
+    def _propagate_injury_dashboard(self, vals):
+        """Bump the owning player's dashboard rollups for this injury change
+        (task 1272). Law 25: a hidden injury only ever touches the TP rollup;
+        toggling visibility bumps the coach rollup only when the injury BECOMES
+        visible again."""
+        self.ensure_one()
+        patient = self.patient_id
+        if not patient:
+            return
+        changed = set(vals)
+        roles = set()
+        if 'hidden_from_coaches' in changed:
+            # Becoming visible again is coach-relevant; becoming hidden is not.
+            roles |= {'tp'} if self.hidden_from_coaches else {'coach', 'tp'}
+        if self.hidden_from_coaches:
+            if changed & (dashboard_external_injury_fields
+                          | dashboard_internal_injury_fields):
+                roles |= {'tp'}
+        else:
+            if changed & dashboard_external_injury_fields:
+                roles |= {'coach', 'tp'}
+            if changed & dashboard_internal_injury_fields:
+                roles |= {'tp'}
+        if roles:
+            patient._bump_dashboard_activity(roles)
         
     def _cleanup_stale_treatment_professionals(self):
         """For each injury in self, drop from treatment_professional_ids
@@ -527,12 +580,22 @@ class PatientInjury(models.Model):
             )
 
     def unlink(self):
+        # Capture (patient, roles) before deletion so the dashboard rollups can
+        # be refreshed afterwards from the remaining injuries (task 1272).
+        to_bump = []
         for rec in self:
             msg_body = _("An injury was deleted.")
             if rec.diagnosis:
                 msg_body += _(" Diagnosis: %s." % rec.diagnosis)
             rec.patient_id.message_post(body=msg_body, message_type="comment")
-        return super().unlink()
+            if rec.patient_id:
+                roles = ('tp',) if rec.hidden_from_coaches else ('coach', 'tp')
+                to_bump.append((rec.patient_id, set(roles)))
+        res = super().unlink()
+        if not self.env.context.get('dashboard_bump'):
+            for patient, roles in to_bump:
+                patient._bump_dashboard_activity(roles)
+        return res
 
     def action_view_injury_form(self):
         self.ensure_one()
@@ -707,17 +770,20 @@ class PatientInjury(models.Model):
             # is_treatment_professional, is_admin, is_internal_user, suppress_notifications defined above
 
             # Set initial stage without chatter/autosubscribe for portal/coach creators
+            # dashboard_bump: these mid-create writes must not each trigger a
+            # dashboard rollup — the single explicit bump below covers the whole
+            # new-injury event once (task 1272).
             if is_treatment_professional or is_admin:
-                record.with_context(mail_notrack=True, mail_create_nolog=True, mail_create_nosubscribe=True).write({'stage': 'active'})
+                record.with_context(mail_notrack=True, mail_create_nolog=True, mail_create_nosubscribe=True, dashboard_bump=True).write({'stage': 'active'})
             else:
-                record.with_context(mail_notrack=True, mail_create_nolog=True, mail_create_nosubscribe=True).write({'stage': 'unverified'})
+                record.with_context(mail_notrack=True, mail_create_nolog=True, mail_create_nosubscribe=True, dashboard_bump=True).write({'stage': 'unverified'})
 
             # Automatically assign therapist when creating an injury
             current_user = self.env.user
-            
+
             # If the injury creator is a treatment professional, assign them
             if current_user.has_group('bemade_sports_clinic.group_sports_clinic_treatment_professional'):
-                record.with_context(mail_notrack=True, mail_create_nolog=True, mail_create_nosubscribe=True).treatment_professional_ids = [(4, current_user.id)]
+                record.with_context(mail_notrack=True, mail_create_nolog=True, mail_create_nosubscribe=True, dashboard_bump=True).treatment_professional_ids = [(4, current_user.id)]
             # Otherwise, if there's a team_id, find and assign team therapists
             elif record.team_id:
                 # sudo: portal users (coach, portal-TP) can read sports.team.staff
@@ -735,12 +801,20 @@ class PatientInjury(models.Model):
                     )
 
                     if therapist_users:
-                        record.with_context(mail_notrack=True, mail_create_nolog=True, mail_create_nosubscribe=True).treatment_professional_ids = [(6, 0, therapist_users.ids)]
+                        record.with_context(mail_notrack=True, mail_create_nolog=True, mail_create_nosubscribe=True, dashboard_bump=True).treatment_professional_ids = [(6, 0, therapist_users.ids)]
 
             if not suppress_notifications:
                 # Only internal/therapist flows adjust followers; portal/coach would 403 on mail.followers
                 record._manage_treatment_professional_subscriptions()
                 # Some flows rely on recomputing followers on patient; keep for staff
                 record.patient_id.recompute_followers()
-            
+
+        # Task 1272: a new injury is recent activity for the owning player.
+        # Hidden injuries surface to TP only (Law 25).
+        if not self.env.context.get('dashboard_bump'):
+            for record in res:
+                if record.patient_id:
+                    roles = {'tp'} if record.hidden_from_coaches else {'coach', 'tp'}
+                    record.patient_id._bump_dashboard_activity(roles)
+
         return res

--- a/bemade_sports_clinic/models/sports_team.py
+++ b/bemade_sports_clinic/models/sports_team.py
@@ -1,5 +1,6 @@
 from odoo import models, fields, api, _, Command
 from odoo.exceptions import ValidationError
+from datetime import timedelta
 import logging
 
 
@@ -30,6 +31,32 @@ class SportsTeam(models.Model):
     player_count = fields.Integer(compute="_compute_player_counts")
     injured_count = fields.Integer(compute="_compute_player_counts")
     healthy_count = fields.Integer(compute="_compute_player_counts")
+    # Three-way team-health breakdown (task 1272) for the red/yellow/green
+    # dashboard header. The existing injured_count/healthy_count are only
+    # two-way (injured vs not) — insufficient to separate no_play from
+    # practice_ok. Reuse the existing sports.patient.stage scheme.
+    stage_no_play_count = fields.Integer(
+        string="No Play", compute="_compute_stage_counts"
+    )
+    stage_practice_ok_count = fields.Integer(
+        string="Practice OK", compute="_compute_stage_counts"
+    )
+    stage_healthy_count = fields.Integer(
+        string="Healthy", compute="_compute_stage_counts"
+    )
+    # Backend team-dashboard page (task 1272): players with recent TP-visible
+    # activity, ranked by TP dashboard score. Non-stored — recomputed per read
+    # so the recency window applies live.
+    dashboard_active_patient_ids = fields.Many2many(
+        comodel_name="sports.patient",
+        string="Recently Active Players",
+        compute="_compute_dashboard_active_patients",
+    )
+    dashboard_upcoming_event_ids = fields.Many2many(
+        comodel_name="sports.event",
+        string="Upcoming Events",
+        compute="_compute_dashboard_upcoming_events",
+    )
     activity_count = fields.Integer(compute="_compute_activity_count")
     parent_id = fields.Many2one(
         comodel_name="res.partner",
@@ -122,6 +149,44 @@ class SportsTeam(models.Model):
             rec.player_count = len(rec.patient_ids)
             rec.injured_count = len(rec.patient_ids.filtered(lambda p: p.is_injured))
             rec.healthy_count = rec.player_count - rec.injured_count
+
+    @api.depends("patient_ids.stage")
+    def _compute_stage_counts(self):
+        for rec in self:
+            players = rec.patient_ids
+            rec.stage_no_play_count = len(
+                players.filtered(lambda p: p.stage == "no_play")
+            )
+            rec.stage_practice_ok_count = len(
+                players.filtered(lambda p: p.stage == "practice_ok")
+            )
+            rec.stage_healthy_count = len(
+                players.filtered(lambda p: p.stage == "healthy")
+            )
+
+    @api.depends(
+        "patient_ids.dashboard_last_activity_tp", "patient_ids.dashboard_score_tp"
+    )
+    def _compute_dashboard_active_patients(self):
+        cutoff = self.env["sports.patient"]._dashboard_window_cutoff()
+        for rec in self:
+            active = rec.patient_ids.filtered(
+                lambda p: p.dashboard_last_activity_tp
+                and p.dashboard_last_activity_tp >= cutoff
+            ).sorted(key=lambda p: p.dashboard_score_tp, reverse=True)
+            rec.dashboard_active_patient_ids = active
+
+    @api.depends("event_ids.date_start", "event_ids.state")
+    def _compute_dashboard_upcoming_events(self):
+        now = fields.Datetime.now()
+        horizon = now + timedelta(days=7)
+        for rec in self:
+            events = rec.event_ids.filtered(
+                lambda e: e.date_start
+                and now <= e.date_start <= horizon
+                and e.state != "cancelled"
+            ).sorted(key=lambda e: e.date_start)
+            rec.dashboard_upcoming_event_ids = events
 
     @api.depends("staff_ids.role")
     def _compute_head_coach(self):

--- a/bemade_sports_clinic/tests/__init__.py
+++ b/bemade_sports_clinic/tests/__init__.py
@@ -71,3 +71,4 @@ from . import test_patient_merge_suggestions
 from . import test_patient_merge_security
 from . import test_patient_merge_prod_regression
 from . import test_material_report_mailto
+from . import test_cov_team_dashboard

--- a/bemade_sports_clinic/tests/test_cov_team_dashboard.py
+++ b/bemade_sports_clinic/tests/test_cov_team_dashboard.py
@@ -1,0 +1,213 @@
+"""Team-dashboard rollup coverage (task 1272).
+
+Acceptance criteria exercised here (server-side logic only; the portal tab and
+backend page UI are verified separately by /dev-review click-through):
+
+  AC2  Recency domain + score ranking: recently-active players surface, ordered
+       by the role score; players whose activity aged past the window drop out.
+  AC3  Role isolation (Law 25): an internal-note change or a hidden-from-coaches
+       injury updates ONLY the TP rollups — a coach never sees it, not even as a
+       count.
+  AC4  Three-way team-health stage counts (no_play / practice_ok / healthy).
+  AC6  On-change propagation with no cron: creating an injury, changing
+       play-status, or editing a note bumps the correct role stamp(s)+score(s)
+       immediately.
+"""
+from datetime import timedelta
+
+from odoo import Command, fields
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged('post_install', '-at_install')
+class TestTeamDashboard(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Acting as admin (base.group_system): injuries created here land 'active'
+        # and, per the module, admin counts as a treatment professional.
+        cls.tp_group = cls.env.ref(
+            'bemade_sports_clinic.group_sports_clinic_treatment_professional')
+        cls.env.user.sudo().group_ids = [Command.link(cls.tp_group.id)]
+
+        cls.org = cls.env['res.partner'].create(
+            {'name': 'Dash Org', 'is_company': True})
+        cls.team = cls.env['sports.team'].create(
+            {'name': 'Dash Team', 'parent_id': cls.org.id})
+
+    # ------------------------------------------------------------------ helpers
+    def _patient(self, first='Test', last='Player', team=True, **vals):
+        vals.setdefault('first_name', first)
+        vals.setdefault('last_name', last)
+        if team:
+            vals['team_ids'] = [Command.link(self.team.id)]
+        return self.env['sports.patient'].create(vals)
+
+    def _injury(self, patient, **vals):
+        vals['patient_id'] = patient.id
+        return self.env['sports.patient.injury'].create(vals)
+
+    def _cutoff(self):
+        return self.env['sports.patient']._dashboard_window_cutoff()
+
+    def _force_coach_stamp(self, patient, when, note_count=0):
+        """Directly set the coach rollup (bypassing propagation) to a known
+        baseline, so a later assertion can prove it was/was not touched."""
+        patient.sudo().with_context(dashboard_bump=True).write({
+            'dashboard_last_activity_coach': when,
+            'dashboard_note_update_count_coach': note_count,
+        })
+
+    # ------------------------------------------------------------------- AC6
+    def test_new_injury_bumps_both_roles(self):
+        patient = self._patient()
+        self.assertFalse(patient.dashboard_last_activity_coach)
+        self.assertFalse(patient.dashboard_last_activity_tp)
+
+        self._injury(patient, diagnosis='Sprain')
+        patient.invalidate_recordset()
+
+        cutoff = self._cutoff()
+        self.assertTrue(patient.dashboard_last_activity_coach >= cutoff)
+        self.assertTrue(patient.dashboard_last_activity_tp >= cutoff)
+        self.assertEqual(patient.dashboard_new_injury_count_coach, 1)
+        self.assertEqual(patient.dashboard_new_injury_count_tp, 1)
+        self.assertTrue(patient.dashboard_score_tp > 0)
+
+    def test_play_status_change_bumps_both_roles(self):
+        patient = self._patient()
+        self._force_coach_stamp(patient, fields.Datetime.now() - timedelta(hours=48))
+
+        patient.write({'match_status': 'no', 'practice_status': 'no'})
+        patient.invalidate_recordset()
+
+        cutoff = self._cutoff()
+        self.assertEqual(patient.stage, 'no_play')
+        self.assertTrue(patient.dashboard_last_activity_coach >= cutoff)
+        self.assertTrue(patient.dashboard_last_activity_tp >= cutoff)
+        # no_play weight (3) dominates the score.
+        self.assertEqual(patient.dashboard_score_coach, 3000)
+        self.assertEqual(patient.dashboard_score_tp, 3000)
+
+    def test_external_note_bumps_both_roles(self):
+        patient = self._patient()
+        injury = self._injury(patient, diagnosis='Bruise')
+        past = fields.Datetime.now() - timedelta(hours=48)
+        self._force_coach_stamp(patient, past)
+
+        injury.write({'external_notes': 'Visible to the coach.'})
+        patient.invalidate_recordset()
+
+        cutoff = self._cutoff()
+        # External notes are coach-visible -> coach stamp refreshed off baseline.
+        self.assertTrue(patient.dashboard_last_activity_coach >= cutoff)
+        self.assertTrue(patient.dashboard_last_activity_tp >= cutoff)
+        self.assertEqual(patient.dashboard_note_update_count_coach, 1)
+        self.assertEqual(patient.dashboard_note_update_count_tp, 1)
+
+    # ------------------------------------------------------------------- AC3
+    def test_internal_note_does_not_bump_coach(self):
+        """The load-bearing Law 25 test: an internal-note change updates ONLY
+        the TP rollups; the coach rollups are left exactly as they were."""
+        patient = self._patient()
+        injury = self._injury(patient, diagnosis='ACL')
+        # Freeze a known coach baseline AFTER the (coach-visible) new injury.
+        past = fields.Datetime.now() - timedelta(hours=48)
+        self._force_coach_stamp(patient, past, note_count=0)
+
+        injury.write({'internal_notes': 'Confidential clinical detail.'})
+        patient.invalidate_recordset()
+
+        # Coach rollup untouched — not even the count.
+        self.assertEqual(patient.dashboard_last_activity_coach, past)
+        self.assertEqual(patient.dashboard_note_update_count_coach, 0)
+        # TP rollup did register the internal note.
+        self.assertTrue(patient.dashboard_last_activity_tp >= self._cutoff())
+        self.assertEqual(patient.dashboard_note_update_count_tp, 1)
+
+    def test_hidden_injury_bumps_tp_only(self):
+        patient = self._patient()
+        self._injury(patient, diagnosis='Hidden', hidden_from_coaches=True)
+        patient.invalidate_recordset()
+
+        # Coach never learns a hidden injury exists.
+        self.assertFalse(patient.dashboard_last_activity_coach)
+        self.assertEqual(patient.dashboard_new_injury_count_coach, 0)
+        # TP sees it.
+        self.assertTrue(patient.dashboard_last_activity_tp >= self._cutoff())
+        self.assertEqual(patient.dashboard_new_injury_count_tp, 1)
+
+    def test_internal_note_on_hidden_injury_stays_tp_only(self):
+        patient = self._patient()
+        injury = self._injury(patient, diagnosis='Hidden', hidden_from_coaches=True)
+        past = fields.Datetime.now() - timedelta(hours=48)
+        self._force_coach_stamp(patient, past, note_count=0)
+
+        # Even an *external* note on a hidden injury must not reach the coach.
+        injury.write({'external_notes': 'Still hidden from the coach.'})
+        patient.invalidate_recordset()
+
+        self.assertEqual(patient.dashboard_last_activity_coach, past)
+        self.assertEqual(patient.dashboard_note_update_count_coach, 0)
+        self.assertEqual(patient.dashboard_note_update_count_tp, 1)
+
+    # ------------------------------------------------------------------- AC4
+    def test_three_way_stage_counts(self):
+        healthy = self._patient('H', 'One')
+        practice = self._patient(
+            'P', 'Two', match_status='no', practice_status='yes')
+        no_play = self._patient(
+            'N', 'Three', match_status='no', practice_status='no')
+        self.team.invalidate_recordset()
+
+        self.assertEqual(healthy.stage, 'healthy')
+        self.assertEqual(practice.stage, 'practice_ok')
+        self.assertEqual(no_play.stage, 'no_play')
+        self.assertEqual(self.team.stage_healthy_count, 1)
+        self.assertEqual(self.team.stage_practice_ok_count, 1)
+        self.assertEqual(self.team.stage_no_play_count, 1)
+
+    # ------------------------------------------------------------------- AC2
+    def test_recency_domain_drops_stale_players(self):
+        patient = self._patient()
+        self._injury(patient, diagnosis='Recent')
+        self.team.invalidate_recordset()
+        self.assertIn(patient, self.team.dashboard_active_patient_ids)
+
+        # Age the TP activity past the window -> the player drops off.
+        patient.sudo().with_context(dashboard_bump=True).write({
+            'dashboard_last_activity_tp': fields.Datetime.now() - timedelta(hours=48),
+        })
+        self.team.invalidate_recordset()
+        self.assertNotIn(patient, self.team.dashboard_active_patient_ids)
+
+    def test_active_players_ranked_by_score_desc(self):
+        # A no_play player (stage weight 3) must outrank a healthy player whose
+        # only activity is a note update.
+        urgent = self._patient(
+            'Urgent', 'Case', match_status='no', practice_status='no')
+        self._injury(urgent, diagnosis='Severe')
+        minor = self._patient('Minor', 'Case')
+        inj = self._injury(minor, diagnosis='Minor')
+        inj.write({'external_notes': 'note'})
+        self.team.invalidate_recordset()
+
+        ranked = self.team.dashboard_active_patient_ids
+        self.assertIn(urgent, ranked)
+        self.assertIn(minor, ranked)
+        self.assertLess(
+            list(ranked).index(urgent), list(ranked).index(minor),
+            "The no_play player must rank ahead of the healthy one.")
+        self.assertGreater(urgent.dashboard_score_tp, minor.dashboard_score_tp)
+
+    def test_window_hours_config_parameter(self):
+        Patient = self.env['sports.patient']
+        self.assertEqual(Patient._dashboard_window_hours(), 24)
+        self.env['ir.config_parameter'].sudo().set_param(
+            'bemade_sports_clinic.dashboard_activity_window_hours', '72')
+        self.assertEqual(Patient._dashboard_window_hours(), 72)
+        # Invalid values fall back to the 24h default.
+        self.env['ir.config_parameter'].sudo().set_param(
+            'bemade_sports_clinic.dashboard_activity_window_hours', 'abc')
+        self.assertEqual(Patient._dashboard_window_hours(), 24)

--- a/bemade_sports_clinic/views/sports_clinic_portal_views.xml
+++ b/bemade_sports_clinic/views/sports_clinic_portal_views.xml
@@ -1063,7 +1063,7 @@
                             <span class="badge fs-6 text-bg-danger">
                                 <i class="fa fa-ban me-1"/><t t-esc="team.stage_no_play_count"/> No Play
                             </span>
-                            <span class="badge fs-6 text-bg-warning text-dark">
+                            <span class="badge fs-6 text-bg-warning" style="color:#000;">
                                 <i class="fa fa-exclamation-triangle me-1"/><t t-esc="team.stage_practice_ok_count"/> Practice OK
                             </span>
                             <span class="badge fs-6 text-bg-success">
@@ -1078,15 +1078,20 @@
                             <div class="container-fluid mb-4">
                                 <div class="row g-3 justify-content-center">
                                     <t t-foreach="dashboard_players" t-as="player">
-                                        <div class="col-12 col-lg-8">
+                                        <div class="col-12 col-lg-8 mb-2">
                                             <t t-set="is_team_view" t-value="True"/>
                                             <t t-set="show_player_activities" t-value="False"/>
                                             <t t-set="accessible" t-value="True"/>
-                                            <t t-call="bemade_sports_clinic.portal_patient_card"/>
+                                            <!-- Wrap so the shared card's h-100 scopes to this
+                                                 wrapper, not the col (else it eats the annotation
+                                                 below and overlaps the next card). -->
+                                            <div>
+                                                <t t-call="bemade_sports_clinic.portal_patient_card"/>
+                                            </div>
                                             <!-- Recent-activity annotation, role-scoped. -->
                                             <t t-set="ni" t-value="player['dashboard_new_injury_count_%s' % dashboard_role]"/>
                                             <t t-set="nu" t-value="player['dashboard_note_update_count_%s' % dashboard_role]"/>
-                                            <div t-if="ni or nu" class="small text-muted mt-1 ms-1">
+                                            <div t-if="ni or nu" class="small text-muted mt-2 ms-1">
                                                 <span t-if="ni" class="me-3">
                                                     <i class="fa fa-chain-broken me-1"/><t t-esc="ni"/> new injury(ies)
                                                 </span>

--- a/bemade_sports_clinic/views/sports_clinic_portal_views.xml
+++ b/bemade_sports_clinic/views/sports_clinic_portal_views.xml
@@ -1028,12 +1028,20 @@
                      gates the mail.activity fetches — roles without the ACL,
                      e.g. staff role 'other', would 403 otherwise). -->
 
-                <!-- Tabbed view: Players (roster) and Activities (team-level only, task 1223) -->
+                <!-- Tabbed view: Dashboard (task 1272, first), Players (roster)
+                     and Activities (team-level only, task 1223) -->
                 <ul class="nav nav-tabs mb-3" role="tablist">
                     <li class="nav-item" role="presentation">
-                        <button class="nav-link active" id="players-tab" data-bs-toggle="tab"
+                        <button class="nav-link active" id="dashboard-tab" data-bs-toggle="tab"
+                                data-bs-target="#dashboard" type="button" role="tab"
+                                aria-controls="dashboard" aria-selected="true">
+                            <i class="fa fa-heartbeat me-1"/> Dashboard
+                        </button>
+                    </li>
+                    <li class="nav-item" role="presentation">
+                        <button class="nav-link" id="players-tab" data-bs-toggle="tab"
                                 data-bs-target="#players" type="button" role="tab"
-                                aria-controls="players" aria-selected="true">
+                                aria-controls="players" aria-selected="false">
                             <i class="fa fa-users me-1"/> Players
                         </button>
                     </li>
@@ -1047,7 +1055,78 @@
                 </ul>
 
                 <div class="tab-content">
-                    <div class="tab-pane fade show active" id="players" role="tabpanel" aria-labelledby="players-tab">
+                    <!-- Dashboard tab (task 1272): team-health header, recent
+                         player changes (role-scoped, ranked), upcoming events. -->
+                    <div class="tab-pane fade show active" id="dashboard" role="tabpanel" aria-labelledby="dashboard-tab">
+                        <!-- Team-health summary: red/yellow/green by stage. -->
+                        <div class="d-flex flex-wrap gap-2 mb-3">
+                            <span class="badge fs-6 text-bg-danger">
+                                <i class="fa fa-ban me-1"/><t t-esc="team.stage_no_play_count"/> No Play
+                            </span>
+                            <span class="badge fs-6 text-bg-warning text-dark">
+                                <i class="fa fa-exclamation-triangle me-1"/><t t-esc="team.stage_practice_ok_count"/> Practice OK
+                            </span>
+                            <span class="badge fs-6 text-bg-success">
+                                <i class="fa fa-check me-1"/><t t-esc="team.stage_healthy_count"/> Healthy
+                            </span>
+                        </div>
+                        <h5 class="mb-2">
+                            Recent player changes
+                            <small class="text-muted">(last <t t-esc="dashboard_window_hours"/>h)</small>
+                        </h5>
+                        <t t-if="dashboard_players">
+                            <div class="container-fluid mb-4">
+                                <div class="row g-3 justify-content-center">
+                                    <t t-foreach="dashboard_players" t-as="player">
+                                        <div class="col-12 col-lg-8">
+                                            <t t-set="is_team_view" t-value="True"/>
+                                            <t t-set="show_player_activities" t-value="False"/>
+                                            <t t-set="accessible" t-value="True"/>
+                                            <t t-call="bemade_sports_clinic.portal_patient_card"/>
+                                            <!-- Recent-activity annotation, role-scoped. -->
+                                            <t t-set="ni" t-value="player['dashboard_new_injury_count_%s' % dashboard_role]"/>
+                                            <t t-set="nu" t-value="player['dashboard_note_update_count_%s' % dashboard_role]"/>
+                                            <div t-if="ni or nu" class="small text-muted mt-1 ms-1">
+                                                <span t-if="ni" class="me-3">
+                                                    <i class="fa fa-chain-broken me-1"/><t t-esc="ni"/> new injury(ies)
+                                                </span>
+                                                <span t-if="nu" class="me-3">
+                                                    <i class="fa fa-sticky-note me-1"/><t t-esc="nu"/> note update(s)
+                                                </span>
+                                            </div>
+                                        </div>
+                                    </t>
+                                </div>
+                            </div>
+                        </t>
+                        <t t-else="">
+                            <p class="text-muted">No recent player changes in the last <t t-esc="dashboard_window_hours"/> hours.</p>
+                        </t>
+                        <h5 class="mb-2">
+                            Upcoming events <small class="text-muted">(next 7 days)</small>
+                        </h5>
+                        <t t-if="upcoming_events">
+                            <ul class="list-group mb-3">
+                                <t t-foreach="upcoming_events" t-as="ev">
+                                    <li class="list-group-item d-flex justify-content-between align-items-center flex-wrap">
+                                        <span>
+                                            <i class="fa fa-calendar me-2"/>
+                                            <t t-esc="ev.name"/>
+                                            <span t-if="ev.event_type" class="badge text-bg-light ms-2" t-esc="ev.event_type"/>
+                                        </span>
+                                        <span class="text-muted small">
+                                            <t t-esc="ev.date_start" t-options="{'widget': 'datetime'}"/>
+                                        </span>
+                                    </li>
+                                </t>
+                            </ul>
+                        </t>
+                        <t t-else="">
+                            <p class="text-muted">No upcoming events in the next 7 days.</p>
+                        </t>
+                    </div>
+
+                    <div class="tab-pane fade" id="players" role="tabpanel" aria-labelledby="players-tab">
                         <!-- Pending Removals Alert — only for viewers who can action
                              a removal on this team (task 1260), not any portal TP. -->
                         <t t-if="any(p.pending_removal for p in players) and can_remove_on_team">

--- a/bemade_sports_clinic/views/sports_team_views.xml
+++ b/bemade_sports_clinic/views/sports_team_views.xml
@@ -88,6 +88,44 @@
                 </list>
             </field>
         </record>
+        <!-- Task 1272: embedded list of recently-active players for the team
+             Dashboard page. Ordered by the TP dashboard score (most concerning
+             first), color-coded by the existing stage scheme. -->
+        <record id="sports_patient_view_list_dashboard" model="ir.ui.view">
+            <field name="name">sports.patient.view.list.dashboard</field>
+            <field name="model">sports.patient</field>
+            <field name="arch" type="xml">
+                <list string="Recently Active Players" create="false"
+                      default_order="dashboard_score_tp desc"
+                      decoration-danger="stage == 'no_play'"
+                      decoration-warning="stage == 'practice_ok'">
+                    <field name="last_name"/>
+                    <field name="first_name"/>
+                    <field name="stage"/>
+                    <field name="dashboard_new_injury_count_tp" string="New Injuries"/>
+                    <field name="dashboard_note_update_count_tp" string="Note Updates"/>
+                    <field name="dashboard_last_activity_tp" string="Last Activity"/>
+                    <field name="dashboard_score_tp" string="Score" optional="hide"/>
+                    <button name="action_view_patient_form" type="object"
+                            title="Details" string="Open" icon="fa-arrow-right"/>
+                </list>
+            </field>
+        </record>
+        <!-- Task 1272: embedded list of the team's upcoming (7-day) events. -->
+        <record id="sports_event_view_list_team_dashboard" model="ir.ui.view">
+            <field name="name">sports.event.view.list.team.dashboard</field>
+            <field name="model">sports.event</field>
+            <field name="arch" type="xml">
+                <list string="Upcoming Events" create="false"
+                      decoration-muted="state == 'cancelled'">
+                    <field name="name"/>
+                    <field name="event_type"/>
+                    <field name="date_start"/>
+                    <field name="date_end" optional="hide"/>
+                    <field name="state"/>
+                </list>
+            </field>
+        </record>
         <record id="sports_team_view_form" model="ir.ui.view">
             <field name="name">sports.team.view.form</field>
             <field name="model">sports.team</field>
@@ -133,6 +171,32 @@
                             </group>
                         </group>
                         <notebook>
+                            <page name="dashboard" string="Dashboard">
+                                <!-- Team-health header: red/yellow/green counts
+                                     by stage (task 1272). -->
+                                <div class="d-flex flex-wrap gap-2 mb-3" name="team_health">
+                                    <span class="badge fs-6 text-bg-danger">
+                                        <i class="fa fa-ban me-1"/>
+                                        <field name="stage_no_play_count" readonly="1"/> No Play
+                                    </span>
+                                    <span class="badge fs-6 text-bg-warning text-dark">
+                                        <i class="fa fa-exclamation-triangle me-1"/>
+                                        <field name="stage_practice_ok_count" readonly="1"/> Practice OK
+                                    </span>
+                                    <span class="badge fs-6 text-bg-success">
+                                        <i class="fa fa-check me-1"/>
+                                        <field name="stage_healthy_count" readonly="1"/> Healthy
+                                    </span>
+                                </div>
+                                <separator string="Recent Player Changes"/>
+                                <field name="dashboard_active_patient_ids" nolabel="1"
+                                       readonly="1"
+                                       context="{'list_view_ref': 'bemade_sports_clinic.sports_patient_view_list_dashboard'}"/>
+                                <separator string="Upcoming Events (next 7 days)"/>
+                                <field name="dashboard_upcoming_event_ids" nolabel="1"
+                                       readonly="1"
+                                       context="{'list_view_ref': 'bemade_sports_clinic.sports_event_view_list_team_dashboard'}"/>
+                            </page>
                             <page name="players" string="Players">
                                 <field name="patient_ids" nolabel="1"
                                        context="{'list_view_ref': 'bemade_sports_clinic.sports_patient_view_list_embedded'}"/>

--- a/bemade_sports_clinic/views/sports_team_views.xml
+++ b/bemade_sports_clinic/views/sports_team_views.xml
@@ -179,7 +179,7 @@
                                         <i class="fa fa-ban me-1"/>
                                         <field name="stage_no_play_count" readonly="1"/> No Play
                                     </span>
-                                    <span class="badge fs-6 text-bg-warning text-dark">
+                                    <span class="badge fs-6 text-bg-warning" style="color:#000;">
                                         <i class="fa fa-exclamation-triangle me-1"/>
                                         <field name="stage_practice_ok_count" readonly="1"/> Practice OK
                                     </span>


### PR DESCRIPTION
First slice of the #1154 digest epic. Per-team dashboard in portal (`/my/team` first tab) + backend (`sports.team` form first page), driven by role-scoped, on-change-maintained rollup fields on `sports.patient` (no cron). Team-health red/yellow/green header; 7-day upcoming events.

- Law 25 role isolation: internal notes / `hidden_from_coaches` injuries bump only the TP fields — a coach never sees internal activity (3 dedicated tests + UAT-verified on scrubbed data).
- Full suite 805/805 + 10 new dashboard tests green.
- UI polish (this PR): legible Practice-OK badge (dark-mode `text-dark` flip), note-update annotation no longer overlaps.

Manifest 19.0.1.9.0 → 19.0.1.10.0. UAT (prod-copy, three roles) passed.
Task: fitcrew Odoo #1272.