### PR TITLE
feat(sports_clinic): add player position field on player record

### DIFF
--- a/bemade_sports_clinic/__manifest__.py
+++ b/bemade_sports_clinic/__manifest__.py
@@ -18,7 +18,7 @@
 #
 {
     'name': 'Sports Clinic Management',
-    'version': "19.0.1.10.0",
+    'version': "19.0.1.11.0",
     'summary': 'Comprehensive sports medicine clinic management with portal access and activity tracking.',
     'description': """
 Sports Clinic Management System

--- a/bemade_sports_clinic/controllers/player_management_portal.py
+++ b/bemade_sports_clinic/controllers/player_management_portal.py
@@ -173,6 +173,10 @@ class PlayerManagementPortal(CustomerPortal, AccessControlMixin):
                 vals['country_id'] = int(post.get('country_id'))
             except Exception:
                 pass
+        # Player position - any portal user with access (incl. coaches) can set
+        if 'position' in post:
+            _pos = (post.get('position') or '').strip()
+            vals['position'] = _pos if _pos else False
 
         # Additional fields for treatment professionals
         if is_treatment_prof:
@@ -293,6 +297,7 @@ class PlayerManagementPortal(CustomerPortal, AccessControlMixin):
             patient_info['team_info_notes'] = patient.team_info_notes
             
             # Status fields
+            patient_info['position'] = patient.position
             patient_info['match_status'] = patient.match_status
             patient_info['practice_status'] = patient.practice_status
             patient_info['last_consultation_date'] = patient.last_consultation_date
@@ -420,7 +425,12 @@ class PlayerManagementPortal(CustomerPortal, AccessControlMixin):
                 vals['country_id'] = country_id
             except (ValueError, TypeError):
                 pass  # Invalid country_id, skip
-            
+
+        # Player position - any portal user with access (incl. coaches) can update
+        if 'position' in post:
+            _pos = (post.get('position') or '').strip()
+            vals['position'] = _pos if _pos else False
+
         # Additional fields that only treatment professionals can update
         if is_treatment_prof:
             # Team assignments via multi-select

--- a/bemade_sports_clinic/models/patient.py
+++ b/bemade_sports_clinic/models/patient.py
@@ -106,6 +106,7 @@ class Patient(models.Model):
         column2="team_id",
         string="Teams",
     )
+    position = fields.Char(string="Position")
     match_status = fields.Selection(
         # Selection rather than bool for easy expansion later
         selection=[

--- a/bemade_sports_clinic/views/player_management_portal_templates.xml
+++ b/bemade_sports_clinic/views/player_management_portal_templates.xml
@@ -42,6 +42,16 @@
                     </div>
                 </div>
 
+                <div class="row mb-3">
+                    <div class="col-md-6">
+                        <div class="form-group">
+                            <label>Position</label>
+                            <input type="text" name="position" class="form-control"
+                                   t-att-value="(form_data and form_data.get('position')) or (patient and patient.position) or ''"/>
+                        </div>
+                    </div>
+                </div>
+
                 <!-- Date of Birth is visible/editable to treatment professionals only to respect field ACLs -->
                 <t t-if="is_treatment_prof">
                     <div class="row mb-3">

--- a/bemade_sports_clinic/views/sports_patient_views.xml
+++ b/bemade_sports_clinic/views/sports_patient_views.xml
@@ -145,6 +145,7 @@
                                 <separator string="Team Information"/>
                                 <field name="team_ids"
                                        widget="many2many_tags"/>
+                                <field name="position"/>
                                 <field name="match_status"/>
                                 <field name="practice_status"/>
                                 <field name="predicted_return_date"/>


### PR DESCRIPTION
Task #1273 — adds a free-text `position` Char to `sports.patient`, editable on both surfaces staff and coaches use: the backend player form (Team Information) and the portal `/my/player/edit` (shared `portal_player_form_body` partial, also on the coach Add-Player create form). Not PHI → no group restriction. No dashboard display / no per-team toggle in this build — deferred to #1272.

Manifest 19.0.1.10.0 → 19.0.1.11.0 (minor, new field). No security/noupdate records touched → no migration. Local UAT (scrub_demo): backend persist ✓, portal round-trip both directions ✓, regression + create form ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)