### PR TITLE
feat(sports_clinic): add training recommendation field (TP-authored, coach read-only)

### DIFF
--- a/bemade_sports_clinic/__manifest__.py
+++ b/bemade_sports_clinic/__manifest__.py
@@ -18,7 +18,7 @@
 #
 {
     'name': 'Sports Clinic Management',
-    'version': "19.0.1.11.0",
+    'version': "19.0.1.12.0",
     'summary': 'Comprehensive sports medicine clinic management with portal access and activity tracking.',
     'description': """
 Sports Clinic Management System

--- a/bemade_sports_clinic/controllers/player_management_portal.py
+++ b/bemade_sports_clinic/controllers/player_management_portal.py
@@ -192,6 +192,12 @@ class PlayerManagementPortal(CustomerPortal, AccessControlMixin):
                 vals['match_status'] = post.get('match_status')
             if post.get('practice_status'):
                 vals['practice_status'] = post.get('practice_status')
+            # Training recommendation is TP-authored (coach-read only). Accept
+            # it only inside this is_treatment_prof gate so a coach POST cannot
+            # set it.
+            if 'training_recommendation' in post:
+                _tr = (post.get('training_recommendation') or '').strip()
+                vals['training_recommendation'] = _tr if _tr else False
 
         # Use public create method with permission checks
         try:
@@ -300,6 +306,7 @@ class PlayerManagementPortal(CustomerPortal, AccessControlMixin):
             patient_info['position'] = patient.position
             patient_info['match_status'] = patient.match_status
             patient_info['practice_status'] = patient.practice_status
+            patient_info['training_recommendation'] = patient.training_recommendation
             patient_info['last_consultation_date'] = patient.last_consultation_date
 
             # Injury tracking fields
@@ -477,6 +484,13 @@ class PlayerManagementPortal(CustomerPortal, AccessControlMixin):
             if 'last_consultation_date' in post:
                 _lcd = (post.get('last_consultation_date') or '').strip()
                 vals['last_consultation_date'] = _lcd if _lcd else False
+
+            # Training recommendation is TP-authored (coach-read only). Accept
+            # it only inside this is_treatment_prof gate so a coach POST cannot
+            # set it.
+            if 'training_recommendation' in post:
+                _tr = (post.get('training_recommendation') or '').strip()
+                vals['training_recommendation'] = _tr if _tr else False
 
         # Update the patient - no sudo needed as field-level security is in place
         if vals:

--- a/bemade_sports_clinic/models/patient.py
+++ b/bemade_sports_clinic/models/patient.py
@@ -123,6 +123,12 @@ class Patient(models.Model):
         required=True,
         default="yes",
     )
+    # Therapist's free-text guidance on what the player can do in training.
+    # Elaborates practice_status. Authored by treatment professionals; coaches
+    # read it (no field-level groups= so it stays coach-readable). Coach-read /
+    # TP-write is enforced at the portal (template t-if + controller gate), the
+    # same way date_of_birth is handled.
+    training_recommendation = fields.Text(string="Training Recommendation")
     injury_ids = fields.One2many(
         comodel_name="sports.patient.injury",
         inverse_name="patient_id",

--- a/bemade_sports_clinic/views/player_management_portal_templates.xml
+++ b/bemade_sports_clinic/views/player_management_portal_templates.xml
@@ -128,6 +128,35 @@
             </div>
         </t>
 
+        <!-- Training Recommendation: TP authors it, coach sees it read-only.
+             Mirrors the date_of_birth coach-read / TP-write split (template
+             t-if + controller gate). No field-level groups= so it stays
+             coach-readable. -->
+        <div class="card mb-3">
+            <div class="card-header">
+                <h6 class="mb-0">Training Recommendation</h6>
+            </div>
+            <div class="card-body">
+                <t t-if="is_treatment_prof">
+                    <div class="form-group">
+                        <label for="training_recommendation">Training Recommendation</label>
+                        <textarea name="training_recommendation" id="training_recommendation" class="form-control" rows="3" placeholder="Enter training recommendation here"><t t-esc="(form_data and form_data.get('training_recommendation')) or (patient and patient.training_recommendation) or ''"/></textarea>
+                    </div>
+                </t>
+                <t t-else="">
+                    <div class="form-group">
+                        <label>Training Recommendation</label>
+                        <t t-if="patient and patient.training_recommendation">
+                            <p class="form-control-plaintext mb-0" style="white-space: pre-wrap;" t-esc="patient.training_recommendation"/>
+                        </t>
+                        <t t-else="">
+                            <p class="form-control-plaintext text-muted mb-0">No training recommendation</p>
+                        </t>
+                    </div>
+                </t>
+            </div>
+        </div>
+
         <!-- Address Card -->
         <div class="card mb-3">
             <div class="card-header">

--- a/bemade_sports_clinic/views/sports_clinic_portal_views.xml
+++ b/bemade_sports_clinic/views/sports_clinic_portal_views.xml
@@ -1617,6 +1617,12 @@
                                                      </div>
                                                  </td>
                                              </tr>
+                                             <!-- Training recommendation: TP-authored, coach-visible read-only
+                                                  (no is_treatment_prof gate). -->
+                                             <tr t-if="(player.training_recommendation or '').strip()">
+                                                <td><strong>Training Recommendation:</strong></td>
+                                                <td style="white-space: pre-wrap;" t-esc="player.training_recommendation"/>
+                                             </tr>
                                         </table>
                                     </div>
                                     <div class="col-md-6">

--- a/bemade_sports_clinic/views/sports_patient_views.xml
+++ b/bemade_sports_clinic/views/sports_patient_views.xml
@@ -148,6 +148,7 @@
                                 <field name="position"/>
                                 <field name="match_status"/>
                                 <field name="practice_status"/>
+                                <field name="training_recommendation"/>
                                 <field name="predicted_return_date"/>
                                 <field name="return_date"/>
                                 <field name="team_info_notes"/>


### PR DESCRIPTION
Task #1339 — adds a multi-line `training_recommendation` Text to `sports.patient`: the therapist's guidance on what a player can do in training (elaborates practice_status). TP/clinic staff author it; coaches see it read-only. Coach-read/TP-write enforced the DOB way — template t-if + controller gate (write accepted only inside is_treatment_prof, in both create + edit); no field-level groups= (stays coach-readable). Digest change-tracking wiring deferred to #1272.

Manifest 19.0.1.11.0 → 19.0.1.12.0. No security/noupdate records → no migration. Local UAT (scrub_demo): TP authoring backend+portal ✓, coach read-only ✓, coach write-block enforced ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)